### PR TITLE
build: Use universal build for mac os

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
 		"start": "electron-forge start",
 		"package": "electron-forge package",
 		"package:linux": "electron-forge package --platform=linux",
-		"package:mac": "electron-forge package --platform=darwin",
+		"package:mac": "electron-forge package --platform=darwin --arch=universal",
 		"package:windows": "electron-forge package --platform=win32",
 		"package:all": "electron-forge package --platform=all",
 		"make": "electron-forge make --skip-package",


### PR DESCRIPTION
Make sure to build a universal app bundle on Mac OS so that it has a native binary available when running on apple silicon chips.

Tested with an M1 and works fine though I cannot test intel compatibility of the resulting bundle.