### PR TITLE
Fix wrong display-name property from provisioning getUser response

### DIFF
--- a/src/patchers/nextcloud-auth.js
+++ b/src/patchers/nextcloud-auth.js
@@ -32,7 +32,9 @@ export {
 export function getCurrentUser() {
 	return {
 		uid: appData.userMetadata.id,
-		displayName: appData.userMetadata.displayname,
-		isAdmin: appData.userMetadata.groups.includes('admin'), // TODO: Is it true way to detect admin?
+		// Current user metadata had different property name for display name than userMetadata
+		// @see https://github.com/nextcloud/server/pull/36665
+		displayName: appData.userMetadata.displayname ?? appData.userMetadata['display-name'],
+		isAdmin: appData.userMetadata.groups.includes('admin'),
 	}
 }


### PR DESCRIPTION
### ☑️ Resolves

* Issue #70

In provisioning API `getUser` and `getCurrentUser` methods returns display name with a different property name.
In this PR `@nextcloud/auth/getCurrentUser` tries both properties considering the current name as "legacy".

Related: https://github.com/nextcloud/server/pull/36665

### 🚧 Tasks

- [x] Use legacy `'display-name'` property as a fallback for display name
