### PR TITLE
Fix loosing authentication on notify_push on any ws error

### DIFF
--- a/src/talk/renderer/notifications/notifications.store.js
+++ b/src/talk/renderer/notifications/notifications.store.js
@@ -340,9 +340,7 @@ export function createNotificationStore() {
 	// Initial call to the notification endpoint
 	_fetch()
 
-	const hasPush = listen('notify_notification', () => {
-		_fetchAfterNotifyPush()
-	}, { user: appData.credentials.user, password: appData.credentials.password })
+	const hasPush = listen('notify_notification', _fetchAfterNotifyPush, { credentials: appData.credentials })
 
 	if (hasPush) {
 		console.debug('Has notify_push enabled, slowing polling to 15 minutes')


### PR DESCRIPTION
### ☑️ Resolves

* Issue #75

### 🚧 Tasks

- [x] Add missed credentials on reconnect after error in notify_push client. It caused infinity unsuccessful reconnections
- [x] Refactor notify_push a bit
