### PR TITLE
Add CommandOrControl + Plus hotkey for zoomIn without SHIFT

### DIFF
--- a/src/app/app.menu.js
+++ b/src/app/app.menu.js
@@ -93,6 +93,13 @@ function setupMenu() {
 			{ type: 'separator' },
 			{ role: 'resetZoom' },
 			{ role: 'zoomIn' },
+			// By default zoomIn works by "CommandOrControl + +" ("CommandOrControl + SHIFT + =")
+			// Hidden menu item adds zoomIn without SHIFT
+			{
+				role: 'zoomIn',
+				accelerator: 'CommandOrControl+=',
+				visible: false,
+			},
 			{ role: 'zoomOut' },
 			{ type: 'separator' },
 			{ role: 'togglefullscreen' },

--- a/src/app/applyWheelZoom.js
+++ b/src/app/applyWheelZoom.js
@@ -1,0 +1,38 @@
+/*
+ * @copyright Copyright (c) 2023 Grigorii Shartsev <grigorii.shartsev@nextcloud.com>
+ *
+ * @author Grigorii Shartsev <grigorii.shartsev@nextcloud.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Enable zooming window by mouse wheel
+ *
+ * @param {import('electron').BrowserWindow} browserWindow - Browser window
+ */
+export function applyWheelZoom(browserWindow) {
+	browserWindow.webContents.on('zoom-changed', (event, zoomDirection) => {
+		const zoom = browserWindow.webContents.getZoomLevel()
+		// 0.5 level delta seems to be equivalent of "CTRL+" (zoomIn) and CTRL- (zoomOut) commands
+		const zoomDelta = 0.5 * (zoomDirection === 'in' ? 1 : -1)
+		const newZoom = zoom + zoomDelta
+		// Undocumented default limits for zoom level is [-8, 9] or [~23.25%, 515.97%]
+		if (newZoom >= -8 && newZoom <= 9) {
+			browserWindow.webContents.setZoomLevel(zoom + zoomDelta)
+		}
+	})
+}

--- a/src/talk/talk.window.js
+++ b/src/talk/talk.window.js
@@ -24,6 +24,7 @@ const {
 	windowOpenExternalLinkHandler,
 	willNavigateExternalLinkHandler,
 } = require('../app/externalLinkHandlers.js')
+const { applyWheelZoom } = require('../app/applyWheelZoom.js')
 
 /**
  * @return {import('electron').BrowserWindow}
@@ -63,6 +64,8 @@ function createTalkWindow() {
 	window.once('ready-to-show', () => {
 		window.show()
 	})
+
+	applyWheelZoom(window)
 
 	window.loadURL(TALK_WINDOW_WEBPACK_ENTRY)
 


### PR DESCRIPTION
### ☑️ Resolves

* Issue #74

### 🚧 Tasks

By default an Electron application has "CommandOrControl + Plus" hotkey for zooming in. It is not very  intuitive, that without SHIFT pressing "CommandOrControl + Plus" actually works as "CommandOrControl + =". 

- [x] Add additional invisible zoomIn menu item with "CommandOrControl + =" hotkey

Adding invisible menu item to add hotkey alias may look wierd. But it seems to be a common practice to solve this problem in Electron applicatoin in a simple and reliable way.

Also, it was possible to change the hotkey in the existed menu item, but it would change displayed hotkey. This solution keeps displaying original hotkey in menu while both hotkeys works exactly the same.

![image](https://user-images.githubusercontent.com/25978914/227061566-e5911cd8-7a0b-4056-b955-459c2973d862.png)

