### PR TITLE
Fix missed notifications event bus emitting and notification request caching

### DIFF
--- a/src/app/webRequestInterceptor.js
+++ b/src/app/webRequestInterceptor.js
@@ -80,11 +80,14 @@ function enableWebRequestInterceptor(serverUrl, {
 		'Authorization',
 		'OCS-APIRequest',
 		'Content-Type',
+		'If-None-Match',
 		// DAV
 		// TODO: should we add any other WebDAV headers?
 		'Depth',
 	].join(', ')]
 	const EXPOSED_HEADERS = [[
+		// Common headers
+		'ETag',
 		// Nextcloud Talk custom Response Headers
 		'x-nextcloud-talk-modified-before',
 		'x-nextcloud-talk-hash',


### PR DESCRIPTION
### ☑️ Resolves

* Fix #83

### 🚧 Tasks

- [x] Add missed `ETag` and `If-None-Match` headers in request patching. Without them notifications endpoint always returns old notifications as new and leaded to useless frequent queries
- [x] Add missed `notifications:notification:received` and `notifications:action:execute` events in `nextcloud/event-bus`
- [x] With `notifications:action:execute` reuse Talk Web's notification action

