### PR TITLE
Fix unclosable About window on Mac - make About window closable by Escape and a new close button

### DIFF
--- a/src/help/help.window.js
+++ b/src/help/help.window.js
@@ -29,7 +29,7 @@ const { BrowserWindow } = require('electron')
  */
 function createHelpWindow(parentWindow) {
 	const WIDTH = 720
-	const HEIGHT = 500
+	const HEIGHT = 525
 	const TITLE = `About - ${BASE_TITLE}`
 	const window = new BrowserWindow({
 		title: TITLE,

--- a/src/help/renderer/HelpApp.vue
+++ b/src/help/renderer/HelpApp.vue
@@ -42,15 +42,30 @@
 			rows="11"
 			readonly
 			@focus="$event.target.setSelectionRange(0, -1)" />
-		<p>This is a Preview version. Drawbacks and issues are in the repository.</p>
+		<p>
+			<NcButton type="secondary" wide @click="close">
+				<template #icon>
+					<MdiWindowClose />
+				</template>
+				Close
+			</NcButton>
+		</p>
 	</div>
 </template>
 
 <script>
+import MdiWindowClose from 'vue-material-design-icons/WindowClose.vue'
+import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
+
 import { appData } from '../../app/AppData.js'
 
 export default {
 	name: 'HelpApp',
+
+	components: {
+		MdiWindowClose,
+		NcButton,
+	},
 
 	inheritAttrs: false,
 
@@ -75,6 +90,26 @@ export default {
 				`OS: ${window.OS.version}`,
 				'----------------------------System report----------------------------',
 			].join('\n')
+		},
+	},
+
+	mounted() {
+		window.addEventListener('keyup', this.handleEscape)
+	},
+
+	beforeDestroy() {
+		window.removeEventListener('keyup', this.handleEscape)
+	},
+
+	methods: {
+		handleEscape(event) {
+			if (event.key === 'Escape') {
+				this.close()
+			}
+		},
+
+		close() {
+			window.close()
 		},
 	},
 }


### PR DESCRIPTION
### ☑️ Resolves

* Issue #102

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![image](https://user-images.githubusercontent.com/25978914/228293656-9b7ef056-aeb0-4eb8-bf12-23bd6f2bf2a6.png) | ![image](https://user-images.githubusercontent.com/25978914/228292800-9ece1ac4-584c-4571-9ce4-12035c5fc2bf.png)

### 🚧 Tasks

By default and by design native modal windows on MacOS doesn't have controls and not closable.

- [x] Add close button to the about window
- [x] Close About window by Escape
