### PR TITLE
Release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,47 @@
+# Changelog
+
+## v0.3.0 - 2023-04-06
+
+### Features
+
+- Native context menu for text editing and spell checking
+- New release notifications
+- More translations
+
+### Fixes
+
+- Fix black screen on signaling session error
+- Fix unclosable "About window" on macOS
+- Fix macOS icon
+
+### Build-in Talk update
+
+Built-in Talk in binaries is updated to 16.0.2. Talk changelog: https://github.com/nextcloud/spreed/releases/tag/v16.0.2
+
+## v0.2.2 - 2023-03-24
+
+### Fixes
+
+- Fix wrong display name in calls and temp messages
+- Fix loosing authentication on notify_push caused brute force protection
+- Fix zoom without SHIFT and by mouse wheel
+
+### Build-in Talk update
+
+Built-in Talk in binaries is updated to 16.0.1. Talk changelog: https://github.com/nextcloud/spreed/releases/tag/v16.0.1
+
+## v0.2.1 - 2023-03-21
+
+### Fixes
+ 
+- Fix dev and prod instances lock each other
+- Fix repository links
+
+## v0.2.0 - 2023-03-21
+
+🎉 First release of Nextcloud Talk Preview
+
+- Connect to Nextcloud 26 with Nextcloud Talk 16
+- Chat and make video-calls
+- Send files
+- Receive native notifications

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "talk-desktop",
-	"version": "0.2.2",
+	"version": "0.3.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "talk-desktop",
-			"version": "0.2.2",
+			"version": "0.3.0",
 			"license": "AGPL-3.0",
 			"dependencies": {
 				"@nextcloud/browser-storage": "^0.2.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"private": true,
 	"name": "talk-desktop",
 	"productName": "Nextcloud Talk",
-	"version": "0.2.2",
+	"version": "0.3.0",
 	"description": "Official Desktop client for Nextcloud Talk",
 	"bugs": "https://github.com/nextcloud/talk-desktop/issues",
 	"license": "AGPL-3.0",


### PR DESCRIPTION
## v0.3.0 - 2023-04-06

### Features

- Native context menu for text editing and spell checking
- New release notifications
- More translations

### Fixes

- Fix black screen on signaling session error
- Fix unclosable "About window" on macOS
- Fix MacOS icon

### Build-in Talk update

Built-in Talk in binaries is updated to 16.0.2. Talk changelog: https://github.com/nextcloud/spreed/releases/tag/v16.0.2