### PR TITLE
Fix GitHub Rate Limit error: do not make unnecessary the latest new version requests

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -51,7 +51,9 @@ if (!app.requestSingleInstanceLock()) {
 /**
  * Schedule check for a new version available to download from GitHub
  */
-setupReleaseNotificationScheduler(2 * 60)
+if (process.env.NODE_ENV === 'production') {
+	setupReleaseNotificationScheduler(2 * 60)
+}
 
 // Handle creating/removing shortcuts on Windows when installing/uninstalling.
 // if (require('electron-squirrel-startup')) {


### PR DESCRIPTION
### ☑️ Resolves

* Issue #124

### 🖼️ Screenshots

No visual changes

### 🚧 Tasks

- [x] Do not check a new version on development
- [x] Do not request GitHub if a new version was already found
