### PR TITLE
Release/v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## v0.3.1 - 2023-04-16
+
+### Fixes
+
+- Fix issue with opening a chat [#141](https://github.com/nextcloud/talk-desktop/pull/141)
+- Fix GitHub rate limit error on development [#125](https://github.com/nextcloud/talk-desktop/pull/125) 
+
+### Development notes
+
+- Now Nextcloud Talk can be built with [Nextcloud Talk `stable26` branch](https://github.com/nextcloud/spreed/tree/stable26)
+
 ## v0.3.0 - 2023-04-06
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -2,7 +2,11 @@
 
 > Nextcloud Talk Desktop client based on Nextcloud Talk web application bundling ✨
 
-## Prerequisites
+## 📥 Download Binaries
+
+### https://github.com/nextcloud-releases/talk-desktop/releases
+
+## 🏗️ Prerequisites
 
 - [Nextcloud Server](https://github.com/nextcloud/server) version 26 only.
 - [Nextcloud Talk](https://github.com/nextcloud/spreed) version 16 only.
@@ -42,7 +46,7 @@ Clone `nextcloud/spreed` on `desktop-stable26` branch and install dependencies:
 
 ```bash
 # Clone in the repository root
-git clone -b desktop-stable26 https://github.com/nextcloud/spreed
+git clone -b stable26 https://github.com/nextcloud/spreed
 
 # Install dependencies
 cd ./spreed/
@@ -54,7 +58,7 @@ cd ../
 
 #### `nextcloud/spreed` is already cloned?
 
-1. Switch to `desktop-stable26` branch.
+1. Switch to `stable26` branch.
 2. Set `TALK_PATH` ENV variable or edit `.env` file:
    ```dotenv
    TALK_PATH=/path/to/nextcloud-dev/apps/spreed/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "talk-desktop",
-	"version": "0.3.0",
+	"version": "0.3.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "talk-desktop",
-			"version": "0.3.0",
+			"version": "0.3.1",
 			"license": "AGPL-3.0",
 			"dependencies": {
 				"@nextcloud/browser-storage": "^0.2.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"private": true,
 	"name": "talk-desktop",
 	"productName": "Nextcloud Talk",
-	"version": "0.3.0",
+	"version": "0.3.1",
 	"description": "Official Desktop client for Nextcloud Talk",
 	"bugs": "https://github.com/nextcloud/talk-desktop/issues",
 	"license": "AGPL-3.0",


### PR DESCRIPTION
## v0.3.1 - 2023-04-16

### Fixes

- Fix issue with opening a chat [#141](https://github.com/nextcloud/talk-desktop/pull/141)
- Fix GitHub rate limit error on development [#125](https://github.com/nextcloud/talk-desktop/pull/125) 

### Development notes

- Now Nextcloud Talk can be built with [Nextcloud Talk `stable26` branch](https://github.com/nextcloud/spreed/tree/stable26)