### PR TITLE
release: v0.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## v0.3.2 - 2023-04-20
+
+### Fixes
+
+- Fix importing images to support video backgrounds in Nextcloud Talk 17
+
+### Build-in Talk update
+
+Built-in Talk in binaries is updated to 16.0.3. Talk changelog: https://github.com/nextcloud/spreed/releases/tag/v16.0.3
+
 ## v0.3.1 - 2023-04-16
 
 ### Fixes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "talk-desktop",
-	"version": "0.3.1",
+	"version": "0.3.2",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "talk-desktop",
-			"version": "0.3.1",
+			"version": "0.3.2",
 			"license": "AGPL-3.0",
 			"dependencies": {
 				"@nextcloud/browser-storage": "^0.2.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"private": true,
 	"name": "talk-desktop",
 	"productName": "Nextcloud Talk",
-	"version": "0.3.1",
+	"version": "0.3.2",
 	"description": "Official Desktop client for Nextcloud Talk",
 	"bugs": "https://github.com/nextcloud/talk-desktop/issues",
 	"license": "AGPL-3.0",


### PR DESCRIPTION
## v0.3.2 - 2023-04-20

### Fixes

- Fix importing images to support video backgrounds in Nextcloud Talk 17

### Build-in Talk update

Built-in Talk in binaries is updated to 16.0.3. Talk changelog: https://github.com/nextcloud/spreed/releases/tag/v16.0.3
