### PR TITLE
fix(patchers): add highlight own group mentions support

### DIFF
--- a/src/patchers/nextcloud-initial-state.js
+++ b/src/patchers/nextcloud-initial-state.js
@@ -46,6 +46,7 @@ function getInitialStateFromCapabilities(capabilities, userMetadata) {
 			attachment_folder: capabilities?.spreed?.config?.attachments?.folder,
 			attachment_folder_free_space: userMetadata?.quota?.free ?? 0, // TODO: Is User's Quota free equal to attachment_folder_free_space
 			enable_matterbridge: false, // TODO: Missed in Capabilities. Is it a problem?
+			user_group_ids: userMetadata.groups,
 		},
 		theming: {
 			background: capabilities?.theming?.background,


### PR DESCRIPTION
### ☑️ Resolves

* Issue: support of https://github.com/nextcloud/spreed/pull/9436

### 🖼️ Screenshots

![image](https://user-images.githubusercontent.com/25978914/236036508-26402689-23bc-4184-8daf-c934119013eb.png)

### 🚧 Tasks

- [x] Add `user_group_ids` initial state from `userMetadata`'s groups
