### PR TITLE
fix(patchers): fix doubling webroot in generateFilePath

### DIFF
--- a/src/patchers/nextcloud-router.js
+++ b/src/patchers/nextcloud-router.js
@@ -76,7 +76,7 @@ export function generateFilePath(app, type, file) {
 		return require(`../../sounds/${filename}.ogg`)
 	}
 
-	return getRootUrl() + _generateFilePath(app, type, file)
+	return _generateFilePath(app, type, file)
 }
 
 // Copy of original function, but using patched generateFilePath


### PR DESCRIPTION
### ☑️ Resolves

There was a redundant `webroot` in `generateFilePath` patcher. `generateFilePath` already uses `webroot` which breaks some links.

It breaks loading one file: `/core/img/filetypes/file.svg`