### PR TITLE
release: v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## v0.4.0 - 2023-05-09
+
+### Fixes
+
+- Fix doubling webroot cause failing loading the default file icon [#173](https://github.com/nextcloud/talk-desktop/pull/173)
+- Allow MKCOL requests for creating virtual bg folder [#174](https://github.com/nextcloud/talk-desktop/pull/174)
+- Fix initial state patching to add highlight own group mentions support [#171](https://github.com/nextcloud/talk-desktop/pull/171)
+
+### Build-in Talk update
+
+Built-in Talk in binaries is updated to new major 17.0.0-beta.1. Talk changelog: https://github.com/nextcloud/spreed/releases/tag/v17.0.0-beta.1
+
 ## v0.3.2 - 2023-04-20
 
 ### Fixes

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@
 
 ## 🏗️ Prerequisites
 
-- [Nextcloud Server](https://github.com/nextcloud/server) version 26 only.
-- [Nextcloud Talk](https://github.com/nextcloud/spreed) version 16 only.
+- [Nextcloud Server](https://github.com/nextcloud/server) version 26 or higher.
+- [Nextcloud Talk](https://github.com/nextcloud/spreed) version 16 or higher.
 
 ## 👾 Drawbacks
 
@@ -46,7 +46,7 @@ Clone `nextcloud/spreed` on `desktop-stable26` branch and install dependencies:
 
 ```bash
 # Clone in the repository root
-git clone -b stable26 https://github.com/nextcloud/spreed
+git clone https://github.com/nextcloud/spreed
 
 # Install dependencies
 cd ./spreed/
@@ -58,11 +58,10 @@ cd ../
 
 #### `nextcloud/spreed` is already cloned?
 
-1. Switch to `stable26` branch.
-2. Set `TALK_PATH` ENV variable or edit `.env` file:
-   ```dotenv
-   TALK_PATH=/path/to/nextcloud-dev/apps/spreed/
-   ```
+Set `TALK_PATH` ENV variable or edit `.env` file:
+ ```dotenv
+TALK_PATH=/path/to/nextcloud-dev/apps/spreed/
+ ```
 
 ### Development
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "talk-desktop",
-	"version": "0.3.2",
+	"version": "0.4.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "talk-desktop",
-			"version": "0.3.2",
+			"version": "0.4.0",
 			"license": "AGPL-3.0",
 			"dependencies": {
 				"@nextcloud/axios": "^2.3.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"private": true,
 	"name": "talk-desktop",
 	"productName": "Nextcloud Talk",
-	"version": "0.3.2",
+	"version": "0.4.0",
 	"description": "Official Desktop client for Nextcloud Talk",
 	"bugs": "https://github.com/nextcloud/talk-desktop/issues",
 	"license": "AGPL-3.0",


### PR DESCRIPTION
## v0.4.0 - 2023-05-09

### Fixes

- Fix doubling webroot cause failing loading the default file icon [#173](https://github.com/nextcloud/talk-desktop/pull/173)
- Allow MKCOL requests for creating virtual bg folder [#174](https://github.com/nextcloud/talk-desktop/pull/174)
- Fix initial state patching to add highlight own group mentions support [#171](https://github.com/nextcloud/talk-desktop/pull/171)

### Build-in Talk update

Built-in Talk in binaries is updated to new major 17.0.0-beta.1. Talk changelog: https://github.com/nextcloud/spreed/releases/tag/v17.0.0-beta.1