### PR TITLE
release: v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.6.0 - 2023-05-22
+
+### Build-in Talk update
+
+Built-in Talk in binaries is updated to 17.0.0-rc.1. Talk changelog: https://github.com/nextcloud/spreed/blob/master/CHANGELOG.md
+
 ## v0.5.0 - 2023-05-15
 
 ### Build-in Talk update

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "talk-desktop",
-	"version": "0.5.0",
+	"version": "0.6.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "talk-desktop",
-			"version": "0.5.0",
+			"version": "0.6.0",
 			"license": "AGPL-3.0",
 			"dependencies": {
 				"@nextcloud/axios": "^2.3.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"private": true,
 	"name": "talk-desktop",
 	"productName": "Nextcloud Talk",
-	"version": "0.5.0",
+	"version": "0.6.0",
 	"description": "Official Desktop client for Nextcloud Talk",
 	"bugs": "https://github.com/nextcloud/talk-desktop/issues",
 	"license": "AGPL-3.0",


### PR DESCRIPTION
## v0.6.0 - 2023-05-22

### Build-in Talk update

Built-in Talk in binaries is updated to 17.0.0-rc.1. Talk changelog: https://github.com/nextcloud/spreed/blob/master/CHANGELOG.md