### PR TITLE
fix(auth): fix login for users with space in userid

### DIFF
--- a/src/authentication/login.service.js
+++ b/src/authentication/login.service.js
@@ -42,7 +42,7 @@ function parseLoginRedirectUrl(url) {
 	}
 	return {
 		server: parsed[1],
-		user: decodeURIComponent(parsed[2]),
+		user: decodeURIComponent(parsed[2].replaceAll('+', ' ')),
 		password: parsed[3],
 	}
 }


### PR DESCRIPTION
### ☑️ Resolves

* Issue #199

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![image](https://github.com/nextcloud/talk-desktop/assets/25978914/49f9de43-dcef-4c84-9c13-e75e5380dc34) | ![image](https://github.com/nextcloud/talk-desktop/assets/25978914/4f5b8f15-5c2b-41ef-bf1b-a04d8385a5b8)

### 🚧 Tasks

- [x] Replace `+` with space ` ` in received `userid` from login flow

P.S. Should it be mentioned in the loginFlow docs?
