### PR TITLE
feat(auth): Allow to login with a copy pasted URL from browser

### DIFF
--- a/src/authentication/renderer/AuthenticationApp.vue
+++ b/src/authentication/renderer/AuthenticationApp.vue
@@ -106,8 +106,9 @@ export default {
 	computed: {
 		serverUrl() {
 			const addHTTPS = (url) => url.startsWith('http') ? url : `https://${url}`
+			const removeIndexPhp = (url) => url.includes('/index.php') ? url.slice(0, url.indexOf('/index.php')) : url
 			const removeTrailingSlash = (url) => url.endsWith('/') ? url.slice(0, -1) : url
-			return removeTrailingSlash(addHTTPS(this.rawServerUrl)).trim()
+			return removeTrailingSlash(removeIndexPhp(addHTTPS(this.rawServerUrl))).trim()
 		},
 	},
 


### PR DESCRIPTION
### ☑️ Resolves

* Copy paste URL from browser e.g. `https://192.168.178.101/index.php/apps/spreed/` and try to login

Before | After
---|---
![grafik](https://github.com/nextcloud/talk-desktop/assets/213943/2ca3c4dd-dada-48be-b697-7175562e386a) | ![grafik](https://github.com/nextcloud/talk-desktop/assets/213943/a885a3d3-b427-4141-8115-7c825f76330b)

