### PR TITLE
fix(authentication): Use content size on login web-view to avoid scroll on Windows

### DIFF
--- a/src/authentication/login.window.js
+++ b/src/authentication/login.window.js
@@ -45,6 +45,7 @@ function openLoginWebView(parentWindow, serverUrl) {
 			height: HEIGHT,
 			minWidth: WIDTH,
 			minHeight: HEIGHT,
+			useContentSize: true,
 			resizable: true,
 			center: true,
 			fullscreenable: false,


### PR DESCRIPTION
### ☑️ Resolves

* Should not be a regression, but for me it was like a regression of https://github.com/nextcloud/talk-desktop/pull/237

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![image](https://github.com/nextcloud/talk-desktop/assets/25978914/0e24bfcf-30d5-491f-9b4b-d059f1167d23) | ![image](https://github.com/nextcloud/talk-desktop/assets/25978914/ed5b303e-08c1-4e62-8f9b-760ca30b2418)

### 🚧 Tasks

- [x] Use content size for window, so the window size will not include large window shadows on Windows
