### PR TITLE
Replace `esm.js` extension to `es.mjs` in nextcloud/auth patch import

### DIFF
--- a/src/patchers/nextcloud-auth.js
+++ b/src/patchers/nextcloud-auth.js
@@ -24,7 +24,7 @@ import { appData } from '../app/AppData.js'
 export {
 	getRequestToken,
 	onRequestTokenUpdate,
-} from '@talk/node_modules/@nextcloud/auth/dist/index.esm.js'
+} from '@talk/node_modules/@nextcloud/auth/dist/index.es.mjs'
 
 /**
  *


### PR DESCRIPTION
### ☑️ Resolves

* Issue caused by introducing exported output of `nextcloud/auth v2.1.0` https://github.com/nextcloud/nextcloud-auth/pull/516
* which was bumped on spreed master branch https://github.com/nextcloud/spreed/pull/9633
* which lead us to `file is not found`