### PR TITLE
release: v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## v0.7.0 - 2023-06-27
+
+### Build-in Talk update
+
+Built-in Talk in binaries is updated to 17.0.1. Talk changelog: https://github.com/nextcloud/spreed/blob/master/CHANGELOG.md
+
+### Features
+
+- Allow to log in with a copy-pasted URL from browser [#204](https://github.com/nextcloud/talk-desktop/pull/204)
+
+### Fixes
+
+- Fix capabilities update only with re-login [#198](https://github.com/nextcloud/talk-desktop/issues/198)
+- Fix login for users with a space in userid [#199](https://github.com/nextcloud/talk-desktop/issues/199)
+- Urldecode the app password [#203](https://github.com/nextcloud/talk-desktop/pull/203)
+
 ## v0.6.0 - 2023-05-22
 
 ### Build-in Talk update

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "talk-desktop",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "talk-desktop",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "license": "AGPL-3.0",
       "dependencies": {
         "@nextcloud/axios": "^2.3.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "name": "talk-desktop",
   "productName": "Nextcloud Talk",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Official Desktop client for Nextcloud Talk",
   "bugs": "https://github.com/nextcloud/talk-desktop/issues",
   "license": "AGPL-3.0",


### PR DESCRIPTION
## v0.7.0 - 2023-06-27

### Build-in Talk update

Built-in Talk in binaries is updated to 17.0.1. Talk changelog: https://github.com/nextcloud/spreed/blob/master/CHANGELOG.md

### Features

- Allow to log in with a copy-pasted URL from browser [#204](https://github.com/nextcloud/talk-desktop/pull/204)

### Fixes

- Fix capabilities update only with re-login [#198](https://github.com/nextcloud/talk-desktop/issues/198)
- Fix login for users with a space in userid [#199](https://github.com/nextcloud/talk-desktop/issues/199)
- Urldecode the app password [#203](https://github.com/nextcloud/talk-desktop/pull/203)