### PR TITLE
Fix incorrect dark theme detection caused by missing css load waiting

### DIFF
--- a/src/shared/resource.utils.js
+++ b/src/shared/resource.utils.js
@@ -25,21 +25,25 @@ import { appData } from '../app/AppData.js'
  * Load styles from URL via new <link> element
  *
  * @param {string} url - Styles URL
- * @return {HTMLLinkElement} Created styles link element
+ * @return {Promise<HTMLLinkElement>} Created styles link element
  */
-export function loadCss(url) {
-	const link = document.createElement('link')
-	link.rel = 'stylesheet'
-	link.href = url
-	document.querySelector('head').appendChild(link)
-	return link
+export async function loadCss(url) {
+	return new Promise((resolve, reject) => {
+		const link = document.createElement('link')
+		link.rel = 'stylesheet'
+		link.href = url
+		document.querySelector('head').appendChild(link)
+		link.onload = () => resolve(link)
+		link.onerror = (error) => reject(error)
+	})
+
 }
 
 /**
  * Load styles from URL via loadCss from server host
  *
  * @param {string} url - Styles URL
- * @return {HTMLLinkElement} Created styles link element
+ * @return {Promise<HTMLLinkElement>} Created styles link element
  */
 export function loadServerCss(url) {
 	return loadCss(`${appData.serverUrl}${url}`)


### PR DESCRIPTION
### ☑️ Resolves

Sometimes with a dark theme, some components act like a light theme.

The problem appears when Talk app initializes and starts faster than CSS with the user's theme is loaded.
(Currently, Talk detect dark theme by CSS)

`loadCss` util is supposed to be async and return a promise, but actually, it doesn't.

_This could be not the only problem with dark theme detection thus it also appears out of initial loading._

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![image](https://github.com/nextcloud/talk-desktop/assets/25978914/1cad6f36-3197-40eb-8dd4-6102db90d501) | ![image](https://github.com/nextcloud/talk-desktop/assets/25978914/f5f7202b-0eb8-4467-83d8-255910171848)

### 🚧 Tasks

- [x] Create and return promise in `loadCss` util
