### PR TITLE
fix(tray): use tray only in talk window and re-setup when window changes

### DIFF
--- a/src/talk/talk.window.js
+++ b/src/talk/talk.window.js
@@ -1,7 +1,7 @@
 /*
- * @copyright Copyright (c) 2022 Grigorii Shartsev <grigorii.shartsev@nextcloud.com>
+ * @copyright Copyright (c) 2022 Grigorii Shartsev <me@shgk.me>
  *
- * @author Grigorii Shartsev <grigorii.shartsev@nextcloud.com>
+ * @author Grigorii Shartsev <me@shgk.me>
  *
  * @license GNU AGPL version 3 or any later version
  *
@@ -27,6 +27,7 @@ const {
 const { applyContextMenu } = require('../app/applyContextMenu.js')
 const { applyDownloadNotification } = require('../app/applyDownloadNotification.js')
 const { applyWheelZoom } = require('../app/applyWheelZoom.js')
+const { setupTray } = require('../app/app.tray.js')
 
 /**
  * @return {import('electron').BrowserWindow}
@@ -70,6 +71,7 @@ function createTalkWindow() {
 	applyContextMenu(window)
 	applyDownloadNotification(window)
 	applyWheelZoom(window)
+	setupTray(window)
 
 	window.loadURL(TALK_WINDOW_WEBPACK_ENTRY)
 


### PR DESCRIPTION
### ☑️ Resolves

Tray sometimes misses the window it is associated with and works inconsistently on different windows:

- Welcome and Login windows have tray icon, but the app doesn't stay in tray when a window is closed
- On logout the main talk window is closed but still exists in the memory as a leaked window process (because the tray keeps the window from being closed)
- After logout opening a login window from the tray crashes the app:
 ![image](https://github.com/nextcloud/talk-desktop/assets/25978914/033b7cb9-a946-4732-a11c-9bc817ecf101)

This PR changes the behavior of the Tray. Now the system tray icon is only used in main Talk app window, but is not used in Welcome loading screen and Login window.

### 🚧 Tasks

- [x] Move the `tray` initialization from `app` initialization in `main.js` to `createTalkWindow`
- [x] Destroy the `tray` instance when window is closed
- [x] Keep the tray module to manage `isQuitting` state by itself, not my `main.js`
- [x] Close `talkWindow` with `window.destroy()` on logout to remove it (`close` is prevented by tray)
- [x] Refactor a `setupTray`, use a `browserWindow` as a param instead of click handler, because it always supposed to have the same click handler while setup needs the window to be associated with
