### PR TITLE
release: v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## v0.8.0 - 2023-07-25
+
+### Build-in Talk update
+
+Built-in Talk in binaries is updated to 17.0.2. Talk changelog: https://github.com/nextcloud/spreed/blob/master/CHANGELOG.md
+
+### Features
+
+- Add System Tray icon [#79](https://github.com/nextcloud/talk-desktop/pull/79)
+- Add quit button on the Welcome screen [#271](https://github.com/nextcloud/talk-desktop/pull/271)
+
+### Fixes
+
+- Fix incorrect dark theme detection [#254](https://github.com/nextcloud/talk-desktop/pull/254)
+- Fix infinity Welcome loading on revoked credentials [#270](https://github.com/nextcloud/talk-desktop/pull/270)
+
 ## v0.7.0 - 2023-06-27
 
 ### Build-in Talk update

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "talk-desktop",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "talk-desktop",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "license": "AGPL-3.0",
       "dependencies": {
         "@nextcloud/axios": "^2.4.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "name": "talk-desktop",
   "productName": "Nextcloud Talk",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Official Desktop client for Nextcloud Talk",
   "bugs": "https://github.com/nextcloud/talk-desktop/issues",
   "license": "AGPL-3.0",


### PR DESCRIPTION
## v0.8.0 - 2023-07-25

### Build-in Talk update

Built-in Talk in binaries is updated to 17.0.2. Talk changelog: https://github.com/nextcloud/spreed/blob/master/CHANGELOG.md

### Features

- Add System Tray icon [#79](https://github.com/nextcloud/talk-desktop/pull/79)
- Add quit button on the Welcome screen [#271](https://github.com/nextcloud/talk-desktop/pull/271)

### Fixes

- Fix incorrect dark theme detection [#254](https://github.com/nextcloud/talk-desktop/pull/254)
- Fix infinity Welcome loading on revoked credentials [#270](https://github.com/nextcloud/talk-desktop/pull/270)