### PR TITLE
Bump min supported server version and check minimal supported built-in version

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@
 
 ## 🏗️ Prerequisites
 
-- [Nextcloud Server](https://github.com/nextcloud/server) version 26 or higher.
-- [Nextcloud Talk](https://github.com/nextcloud/spreed) version 16 or higher.
+- [Nextcloud Server](https://github.com/nextcloud/server) version 27 or higher.
+- [Nextcloud Talk](https://github.com/nextcloud/spreed) version 17 or higher.
 
 ## 👾 Drawbacks
 
@@ -42,7 +42,7 @@ Nextcloud Talk Desktop requires [Nextcloud Talk source code](https://github.com/
 
 #### No `nextcloud/spreed` is cloned?
 
-Clone `nextcloud/spreed` on `desktop-stable26` branch and install dependencies:
+Clone `nextcloud/spreed` and install dependencies:
 
 ```bash
 # Clone in the repository root

--- a/src/constants.js
+++ b/src/constants.js
@@ -31,8 +31,9 @@ const BASE_TITLE = packageJson.productName
  */
 const USER_AGENT = `Mozilla/5.0 (${getOsTitle()}) Nextcloud-Talk v${packageJson.version}`
 const DEV_SERVER_ORIGIN = 'http://localhost:3000'
-const MIN_REQUIRED_NEXTCLOUD_VERSION = 26
-const MIN_REQUIRED_TALK_VERSION = 16
+const MIN_REQUIRED_NEXTCLOUD_VERSION = 27
+const MIN_REQUIRED_TALK_VERSION = 17
+const MIN_REQUIRED_BUILT_IN_TALK_VERSION = '17.0.0'
 
 module.exports = {
 	BASE_TITLE,
@@ -40,4 +41,5 @@ module.exports = {
 	DEV_SERVER_ORIGIN,
 	MIN_REQUIRED_NEXTCLOUD_VERSION,
 	MIN_REQUIRED_TALK_VERSION,
+	MIN_REQUIRED_BUILT_IN_TALK_VERSION,
 }

--- a/webpack.renderer.config.js
+++ b/webpack.renderer.config.js
@@ -22,15 +22,10 @@
 require('dotenv').config()
 
 const path = require('node:path')
-const fs = require('node:fs')
 const webpack = require('webpack')
 const { mergeWithRules } = require('webpack-merge')
 
 const TALK_PATH = path.resolve(__dirname, process.env.TALK_PATH ?? 'spreed')
-if (!fs.existsSync(process.env.TALK_PATH)) {
-	throw new Error(`TALK_PATH path is not correct: ${path.resolve(TALK_PATH)}`)
-}
-console.log(`Using Nextcloud Talk on path: ${path.resolve(TALK_PATH)}`)
 
 /**
  * appName and appVersion constants are set by process.env.npm_package_* in @nextcloud/webpack-vue-config.


### PR DESCRIPTION
### 🖼️ Screenshots

> Incorrect path

![image](https://github.com/nextcloud/talk-desktop/assets/25978914/42f38a67-5013-4b6b-93cc-2e84c482e1ba)

> Path to the wrong package (e.g. server or apps)

![image](https://github.com/nextcloud/talk-desktop/assets/25978914/1c17393f-5483-472a-a4a5-8aad58d808b0)

![image](https://github.com/nextcloud/talk-desktop/assets/25978914/0f817559-bc09-4f9a-a8eb-c7f7d8c2a4e0)

> Unsupported built-in Talk version

![image](https://github.com/nextcloud/talk-desktop/assets/25978914/ef360e3a-5a99-4b96-955d-76c19212a7b9)

> Everything is fine

![image](https://github.com/nextcloud/talk-desktop/assets/25978914/40fda095-98c7-4323-9003-1318e5911780)

### 🚧 Tasks

- [x] Bump minimal supported server to Nextcloud 27 (Talk 17) 
- [x] Add check for minimal supported built-in version (Talk 17)
