### PR TITLE
build: fix checking for esbuild-loader in Talk

### DIFF
--- a/webpack.renderer.config.js
+++ b/webpack.renderer.config.js
@@ -136,7 +136,21 @@ let webpackRendererConfig = mergeWithRules({
 	],
 })
 
-if (require.resolve('esbuild-loader', { paths: [TALK_PATH] })) {
+// Check if there is esbuild-loader in the Talk repo, not in the Talk Desktop
+let hasEsbuildLoader = false
+try {
+	const esbuildLoaderPath = require.resolve('esbuild-loader', { paths: [TALK_PATH] })
+	// If there is esbuild-loader, it might be in its parents, not in Talk itself
+	// e.g. in server or in talk-desktop
+	// Check if it is inside Talk
+	if (esbuildLoaderPath.startsWith(TALK_PATH)) {
+		hasEsbuildLoader = true
+	}
+} catch {
+	// There is no esbuild-loader in Talk or its parents
+}
+
+if (hasEsbuildLoader) {
 	console.log('Using esbuild-loader')
 	// With Electron we can use the most modern features
 	// But with web client - we cannot


### PR DESCRIPTION
### ☑️ Resolves

Build doesn't work with `stable27`. Check with by `require.resolve('esbuild-loader', { paths: [TALK_PATH] })` is not enough. If there is no `esbuild-loader` in Talk, it just finds it in the Talk Desktop. 

### 🚧 Tasks

- [x] Check if found `esbuild-loader` is in Talk repo
