### PR TITLE
Fix: catch http errors on development and styles loading

### DIFF
--- a/src/app/appData.service.js
+++ b/src/app/appData.service.js
@@ -73,8 +73,7 @@ export async function refetchAppDataIfDirty(appData) {
 				console.debug('AppData re-fetched')
 				return true
 			} catch (error) {
-				// In development mode unauthenticated response will be ERR_NETWORK due to CORS error
-				if (error.response?.status === 401 || process.env.NODE_ENV === 'development') {
+				if (error.response?.status === 401) {
 					appData.reset().persist()
 					console.debug('AppData credentials are invalid... Resetting')
 					return true

--- a/src/app/webRequestInterceptor.js
+++ b/src/app/webRequestInterceptor.js
@@ -110,10 +110,29 @@ function enableWebRequestInterceptor(serverUrl, {
 	 */
 	function addCorsHeaders(details) {
 		if (details.method === 'OPTIONS') {
-			// OPTIONS method for CORS on OCS and API is not allowed at all... Let's make a hack...
-			// 405 Method Not Allowed -> 200 OK
-			details.statusLine = details.statusLine.replace('405', '200')
+			if (details.statusCode >= 400) {
+				// OPTIONS request may not be successful for many reasons, but it is not related to actual error.
+				// For example:
+				// - 405 Method Not Allowed -> 200 OK
+				//   OPTIONS method for CORS on OCS and API is not allowed at all.
+				//   Emulate allowed CORS.
+				// - 401 Unauthorized -> 200 OK
+				//   There is an authentication issue.
+				//   But if OPTIONS request fails, an actual request will fail with general Network error.
+				//   ClientRequest sender will not be able to detect the reason.
+				// - 500 Server error -> 200 OK
+				//   Same as 401 on some requests
+				//
+				// Replacing status is safe here, because it is only used for OPTIONS request.
+				// The following actual request will return the actual status anyway
+				details.statusCode = 200
+				// eslint-disable-next-line no-unused-vars
+				const [httpVersion, statusCode, optionalReason] = details.statusLine.split(' ')
+				details.statusLine = [httpVersion, '200', optionalReason].join(' ')
+			}
 		}
+
+		// Emulate CORS
 		details.responseHeaders['Access-Control-Allow-Origin'] = ALLOWED_ORIGIN
 		details.responseHeaders['Access-Control-Allow-Methods'] = ALLOWED_METHODS
 		details.responseHeaders['Access-Control-Allow-Credentials'] = ALLOWED_CREDENTIALS_TRUE

--- a/src/app/webRequestInterceptor.js
+++ b/src/app/webRequestInterceptor.js
@@ -91,6 +91,7 @@ function enableWebRequestInterceptor(serverUrl, {
 		'If-None-Match',
 		// DAV
 		'Depth',
+		'requesttoken',
 	].join(', ')]
 	const EXPOSED_HEADERS = [[
 		// Common headers

--- a/src/talk/renderer/init.js
+++ b/src/talk/renderer/init.js
@@ -22,6 +22,7 @@
 import { register } from '@nextcloud/l10n'
 import { loadServerCss } from '../../shared/resource.utils.js'
 import { appData } from '../../app/AppData.js'
+import { getCapabilities } from '../../shared/ocs.service.js'
 
 /**
  * Initialize Talk application: styles, localization etc.
@@ -35,7 +36,24 @@ export async function init() {
 		loadServerCss('/index.php/apps/theming/theme/light.css'),
 		loadServerCss('/index.php/apps/theming/theme/dark.css'),
 		loadServerCss('/core/css/server.css'),
-	])
+	]).catch(async () => {
+		// It is not possible to determine why styles loading failed in a web-browser
+		// There are 2 the most likely reasons:
+		// 1. Invalid authentication (401 or 500)
+		// 2. Server is unavailable
+
+		// Request any data from the server to check
+		await getCapabilities()
+	}).catch((error) => {
+		// Problem #1 is handled globally
+		// For problem #2 - just quit until the app supports opening offline
+		if (![401, 500].includes(error.response?.status)) {
+			// Mark Talk hash dirty to check server availability on the next app start
+			appData.setTalkHashDirty(true).persist()
+			alert(t('talk_desktop', 'Cannot connect to the server. Please check your internet connection and try again later.'))
+			window.TALK_DESKTOP.quit()
+		}
+	})
 
 	// Load styles overrides
 	await import('./assets/overrides.css')


### PR DESCRIPTION
### ☑️ Resolves

Two related issues:

1. Sometimes start shows just the default background without any visible errors or menu when credentials are not valid anymore or the server is not available on start.

2. Sometimes on development it is not possible to handle if a request was not successful because of an authentication error or other problem.

### 🚧 Tasks

- [x] Add `requesttoken` to the allowed DAV request headers list
- [x] Consider all failed OPTIONS requests as successful in CORS
  - When `OPTIONS` request fails it is always just a general `Network error` for the client. The client cannot determine if it was actually a network error, authentication error or anything else
  - `OPTIONS` request now always returns 200
  - If there was an error, then actual request will fail later with an implicit error
- [x] Handle errors on styles loading
  - It's made a bit hacky. It is not possible to determine style loading error reason. I'm doing an additional general HTTP request to get the error.
  - Then unauthenticated error is handled globally
  - Other errors are shown as an alert, marks app data as invalid to check on the next start and quit the app

### 🖼️ Screenshots

#### 🏚️ Before

![image](https://github.com/nextcloud/talk-desktop/assets/25978914/99eee95f-965f-4bd0-8497-c6d43d58b26d)

![image](https://github.com/nextcloud/talk-desktop/assets/25978914/78c40111-671e-4519-8070-760ef408bdfb)

#### 🏡 After

- In case of an authentication error: logout as in other cases on invalid authentication
- In case of network/server availability error quit after a message:
  ![image](https://github.com/nextcloud/talk-desktop/assets/25978914/3af17ffc-9ea2-492f-91ae-d17672a843f2)

### Alternative solutions and follow-ups

1. Cache styles after login to not re-fetch then each init
2. Show a beautiful error instead of alert