### PR TITLE
fix: restore app from system tray on reopen

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -92,7 +92,8 @@ app.whenReady().then(async () => {
 		if (mainWindow.isMinimized()) {
 			mainWindow.restore()
 		}
-		mainWindow.focus()
+		// Show window if it's hidden in the system tray and focus it
+		mainWindow.show()
 	}
 
 	/**


### PR DESCRIPTION
### ☑️ Resolves

* Fix https://github.com/nextcloud/talk-desktop/issues/278

Currently when Talk Desktop executable is run:
- If it wasn't running - it starts
- If it is running - the window is focused
- If it is running but minimized - it is restored and the window is focused
- If it is running but minimized to the system tray and there is no window - nothing happened (it is the bug)

### 🚧 Tasks

- [x] On app focus (including second instance request) - show the window. It also focuses the window and doesn't change anything for a shown window.
