### PR TITLE
fix: all windows l10n

### DIFF
--- a/src/authentication/login.window.js
+++ b/src/authentication/login.window.js
@@ -20,7 +20,7 @@
  */
 
 const os = require('node:os')
-const { BrowserWindow } = require('electron')
+const { BrowserWindow, app } = require('electron')
 const { BASE_TITLE } = require('../constants.js')
 const { parseLoginRedirectUrl } = require('./login.service.js')
 const { getOsTitle } = require('../shared/os.utils.js')
@@ -63,7 +63,10 @@ function openLoginWebView(parentWindow, serverUrl) {
 			// This header value is used as an application name on the Login page
 			// Use BASE_TITLE instead of the USER_AGENT as User-Agent header
 			userAgent: `${os.hostname()} (Talk Desktop Client - ${getOsTitle()})`,
-			extraHeaders: 'OCS-APIRequest: true',
+			extraHeaders: [
+				'OCS-APIRequest: true',
+				`Accept-Language: ${app.getPreferredSystemLanguages().join(',')}`,
+			].join('\n'),
 		})
 
 		window.webContents.on('did-start-loading', () => {

--- a/src/authentication/renderer/AuthenticationApp.vue
+++ b/src/authentication/renderer/AuthenticationApp.vue
@@ -28,9 +28,9 @@
 			<form @submit.prevent="login">
 				<fieldset :disabled="state === 'loading'">
 					<h2 class="login-box__header">
-						Log in to Nextcloud
+						{{ t('talk_desktop', 'Log in to Nextcloud') }}
 					</h2>
-					<NcTextField label="Nextcloud server address"
+					<NcTextField :label="t('talk_desktop', 'Nextcloud server address')"
 						label-visible
 						:value.sync="rawServerUrl"
 						placeholder="https://try.nextcloud.com"
@@ -46,7 +46,7 @@
 						<template #icon>
 							<MdiArrowRight :size="20" />
 						</template>
-						Log in
+						{{ t('talk_desktop', 'Log in') }}
 					</NcButton>
 					<NcButton v-else-if="state ==='loading'"
 						class="submit-button"
@@ -56,7 +56,7 @@
 						<template #icon>
 							<NcLoadingIcon appearance="light" />
 						</template>
-						Logging in...
+						{{ t('talk_desktop', 'Logging in...') }}
 					</NcButton>
 				</fieldset>
 			</form>
@@ -116,7 +116,7 @@ export default {
 	methods: {
 		setSuccess() {
 			this.state = 'success'
-			this.stateText = 'Logged in successfully'
+			this.stateText = t('talk_desktop', 'Logged in successfully')
 		},
 
 		setLoading() {
@@ -138,7 +138,7 @@ export default {
 				// eslint-disable-next-line no-new
 				new URL(this.serverUrl)
 			} catch {
-				return this.setError('Invalid server address')
+				return this.setError(t('talk_desktop', 'Invalid server address'))
 			}
 
 			// Prepare to request the server
@@ -152,22 +152,28 @@ export default {
 			try {
 				capabilitiesResponse = await getCapabilities()
 			} catch {
-				return this.setError('Nextcloud server not found')
+				return this.setError(t('talk_desktop', 'Nextcloud server not found'))
 			}
 
 			// Check if Talk is installed and enabled
 			const talkCapabilities = capabilitiesResponse.capabilities.spreed
 			if (!talkCapabilities) {
-				return this.setError('Nextcloud Talk is not installed in the server')
+				return this.setError(t('talk_desktop', 'Nextcloud Talk is not installed in the server'))
 			}
 
 			// Check versions compatibilities
+			const createVersionError = (componentName, minRequiredVersion, foundVersion) => t('talk_desktop', '{componentName} {minRequiredVersion} or higher is required but {foundVersion} is installed', {
+				componentName,
+				minRequiredVersion,
+				foundVersion,
+			})
 			if (capabilitiesResponse.version.major < MIN_REQUIRED_NEXTCLOUD_VERSION) {
-				return this.setError(`Nextcloud ${MIN_REQUIRED_NEXTCLOUD_VERSION} or higher is required but ${capabilitiesResponse.version.string} is installed`)
+				return this.setError(createVersionError('Nextcloud', MIN_REQUIRED_NEXTCLOUD_VERSION, capabilitiesResponse.version.string))
 			}
 			if (parseInt(talkCapabilities.version.split('.')[0]) < MIN_REQUIRED_TALK_VERSION) {
 				// TODO: use semver package and check not only major version?
-				return this.setError(`Nextcloud Talk ${MIN_REQUIRED_TALK_VERSION} or higher is required but ${talkCapabilities.version} is installed`)
+				return this.setError(createVersionError('Nextcloud Talk', MIN_REQUIRED_TALK_VERSION, talkCapabilities.version,
+				))
 			}
 
 			// Login with web view
@@ -180,7 +186,7 @@ export default {
 				credentials = maybeCredentials
 			} catch (error) {
 				console.error(error)
-				return this.setError('Unexpected error')
+				return this.setError(t('talk_desktop', 'Unexpected error'))
 			}
 
 			// Add credentials to the request
@@ -194,7 +200,7 @@ export default {
 			} catch (error) {
 				// A network connection was lost after successful requests or something unexpected went wrong
 				console.error(error)
-				return this.setError('Login was successful but something went wrong...')
+				return this.setError(t('talk_desktop', 'Login was successful but something went wrong...'))
 			}
 
 			// Yay!

--- a/src/authentication/renderer/authentication.main.js
+++ b/src/authentication/renderer/authentication.main.js
@@ -24,6 +24,12 @@ import '../../shared/assets/default/default.css'
 import '../../shared/assets/default/server.css'
 
 import Vue from 'vue'
+import { translate as t } from '@nextcloud/l10n'
 import AuthenticationApp from './AuthenticationApp.vue'
+import { setupWebPage } from '../../shared/setupWebPage.js'
+
+await setupWebPage()
+
+Vue.prototype.t = t
 
 new Vue(AuthenticationApp).$mount('#app')

--- a/src/help/renderer/HelpApp.vue
+++ b/src/help/renderer/HelpApp.vue
@@ -21,23 +21,24 @@
 
 <template>
 	<div class="about">
-		<h2>About</h2>
+		<h2>{{ t('talk_desktop', 'About') }}</h2>
 		<p>{{ $options.packageInfo.productName }} - {{ $options.packageInfo.description }}</p>
 		<ul class="about__list">
 			<li>
-				Privacy and Legal Policy: <a class="link" href="https://nextcloud.com/privacy/" target="_blank">https://nextcloud.com/privacy/</a>
+				{{ t('talk_desktop', 'Privacy and Legal Policy') }}: <a class="link" href="https://nextcloud.com/privacy/" target="_blank">https://nextcloud.com/privacy/</a>
 			</li>
 			<li>
-				License: <a class="link" href="https://www.gnu.org/licenses/agpl-3.0.txt" target="_blank">{{ $options.packageInfo.license }}</a>
+				{{ t('talk_desktop', 'License') }}: <a class="link" href="https://www.gnu.org/licenses/agpl-3.0.txt" target="_blank">{{ $options.packageInfo.license }}</a>
 			</li>
 			<li>
-				Issues: <a :href="$options.packageInfo.bugs" class="link" target="_blank">{{ $options.packageInfo.bugs }}</a>
+				{{ t('talk_desktop', 'Issues') }}: <a :href="$options.packageInfo.bugs" class="link" target="_blank">{{ $options.packageInfo.bugs }}</a>
 			</li>
 			<li>
-				Source Code: <a :href="$options.packageInfo.repository" class="link" target="_blank">{{ $options.packageInfo.repository }}</a>
+				{{ t('talk_desktop', 'Source Code') }}: <a :href="$options.packageInfo.repository" class="link" target="_blank">{{ $options.packageInfo.repository }}</a>
 			</li>
 		</ul>
-		<NcTextArea :value="report"
+		<NcTextArea :aria-label="t('talk_desktop', 'System report')"
+			:value="report"
 			rows="11"
 			readonly
 			class="about__report"
@@ -47,7 +48,7 @@
 				<template #icon>
 					<MdiWindowClose />
 				</template>
-				Close
+				{{ t('talk_desktop', 'Close') }}
 			</NcButton>
 		</p>
 	</div>

--- a/src/help/renderer/help.app.js
+++ b/src/help/renderer/help.app.js
@@ -22,12 +22,12 @@ import '../../shared/assets/default/default.css'
 import '../../shared/assets/default/server.css'
 
 import Vue from 'vue'
+import { translate as t } from '@nextcloud/l10n'
 import HelpApp from './HelpApp.vue'
-import { appData } from '../../app/AppData.js'
+import { setupWebPage } from '../../shared/setupWebPage.js'
 
-appData.restore()
+await setupWebPage()
 
-window.TALK_DESKTOP.getOs().then(os => {
-	window.OS = os
-	new Vue(HelpApp).$mount('#app')
-})
+Vue.prototype.t = t
+
+new Vue(HelpApp).$mount('#app')

--- a/src/main.js
+++ b/src/main.js
@@ -63,6 +63,10 @@ if (process.env.NODE_ENV === 'production') {
 
 ipcMain.on('app:quit', () => app.quit())
 ipcMain.handle('app:getOs', () => getOs())
+ipcMain.handle('app:getSystemL10n', () => ({
+	locale: app.getLocale(),
+	language: app.getPreferredSystemLanguages()[0],
+}))
 ipcMain.handle('app:enableWebRequestInterceptor', (event, ...args) => enableWebRequestInterceptor(...args))
 ipcMain.handle('app:disableWebRequestInterceptor', (event, ...args) => disableWebRequestInterceptor(...args))
 ipcMain.handle('app:setBadgeCount', async (event, count) => app.setBadgeCount(count))

--- a/src/preload.js
+++ b/src/preload.js
@@ -59,6 +59,12 @@ const TALK_DESKTOP = {
 	 */
 	getOs: () => ipcRenderer.invoke('app:getOs'),
 	/**
+	 * Get system locale and preferred language
+	 *
+	 * @return {Promise<{ locale: string, language: string }>}
+	 */
+	getSystemL10n: () => ipcRenderer.invoke('app:getSystemL10n'),
+	/**
 	 * Enable web request intercepting
 	 *
 	 * @type {typeof import('./app/webRequestInterceptor').enableWebRequestInterceptor}

--- a/src/shared/setupWebPage.js
+++ b/src/shared/setupWebPage.js
@@ -1,0 +1,70 @@
+/*
+ * @copyright Copyright (c) 2023 Grigorii Shartsev <me@shgk.me>
+ *
+ * @author Grigorii Shartsev <me@shgk.me>
+ *
+ * @license AGPL-3.0-or-later
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { applyBodyThemeAttrs } from './theme.utils.js'
+import { appData } from '../app/AppData.js'
+import { register } from '@nextcloud/l10n'
+
+/**
+ * Apply locale to the document attributes, used by @nextcloud/l10n,
+ * and register translation bundles for Talk and Talk Desktop.
+ *
+ * @return {Promise<void>}
+ */
+async function applyL10n() {
+	const { language, locale } = appData.userMetadata ?? await window.TALK_DESKTOP.getSystemL10n()
+
+	document.documentElement.lang = language
+	document.documentElement.dataset.locale = locale
+
+	console.log(`Using locale "${locale}" for language "${language}"`)
+
+	if (language !== 'en') {
+		try {
+			const { default: translationBundle } = await import(`@talk/l10n/${language}.json`)
+			register('spreed', translationBundle.translations)
+		} catch (e) {
+			console.log(`Language pack "${language}" for spreed not found...`)
+		}
+
+		try {
+			const { default: translationBundle } = await import(`../../l10n/${language}.json`)
+			register('talk_desktop', translationBundle.translations)
+		} catch (e) {
+			console.log(`Language pack "${language}" for talk_desktop not found...`)
+		}
+	}
+}
+
+/**
+ * Make all required initial setup for the web page:
+ * - restore app data
+ * - get OS info
+ * - apply theme to HTML data-attrs
+ * - apply locale to HTML lang and data-locale attrs
+ * - register translation bundles for Talk and Talk Desktop
+ */
+export async function setupWebPage() {
+	appData.restore()
+	window.OS = await window.TALK_DESKTOP.getOs()
+	applyBodyThemeAttrs()
+	await applyL10n()
+}

--- a/src/talk/renderer/init.js
+++ b/src/talk/renderer/init.js
@@ -19,7 +19,6 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { register } from '@nextcloud/l10n'
 import { loadServerCss } from '../../shared/resource.utils.js'
 import { appData } from '../../app/AppData.js'
 import { getCapabilities } from '../../shared/ocs.service.js'
@@ -57,27 +56,6 @@ export async function init() {
 
 	// Load styles overrides
 	await import('./assets/overrides.css')
-
-	// Set locale
-	document.documentElement.lang = appData.userMetadata.language
-	document.documentElement.dataset.locale = appData.userMetadata.locale
-
-	// l10n
-	if (appData.userMetadata.language !== 'en') {
-		try {
-			const { default: translationsBundle } = await import(`@talk/l10n/${appData.userMetadata.language}.json`)
-			register('spreed', translationsBundle.translations)
-		} catch (e) {
-			console.log(`Language pack "${appData.userMetadata.language}" for spreed not found...`)
-		}
-
-		try {
-			const { default: translationsBundle } = await import(`../../../l10n/${appData.userMetadata.language}.json`)
-			register('talk_desktop', translationsBundle.translations)
-		} catch (e) {
-			console.log(`Language pack "${appData.userMetadata.language}" for talk_desktop not found...`)
-		}
-	}
 
 	// Get Talk's router and store
 	const { default: router } = await import('@talk/src/router/router.js')

--- a/src/talk/renderer/talk.main.js
+++ b/src/talk/renderer/talk.main.js
@@ -24,20 +24,15 @@ import './assets/styles.css'
 
 import 'regenerator-runtime' // TODO: Why isn't it added on bundling
 import { init } from './init.js'
-import { appData } from '../../app/AppData.js'
-import { applyBodyThemeAttrs } from '../../shared/theme.utils.js'
+import { setupWebPage } from '../../shared/setupWebPage.js'
 
-appData.restore()
+await setupWebPage()
 
-applyBodyThemeAttrs();
+const { router } = await init()
 
-(async () => {
-	const { router } = await init()
+const { createDesktopApp } = await import('./desktop.app.js')
+createDesktopApp(router)
 
-	const { createDesktopApp } = await import('./desktop.app.js')
-	createDesktopApp(router)
+await import('@talk/src/main.js')
 
-	await import('@talk/src/main.js')
-
-	await import('./notifications/notifications.store.js')
-})()
+await import('./notifications/notifications.store.js')

--- a/src/upgrade/renderer/upgrade.app.js
+++ b/src/upgrade/renderer/upgrade.app.js
@@ -21,11 +21,11 @@ import '../../shared/assets/default/server.css'
 
 import Vue from 'vue'
 import UpgradeApp from './UpgradeApp.vue'
-import { appData } from '../../app/AppData.js'
 import { translate } from '@nextcloud/l10n'
+import { setupWebPage } from '../../shared/setupWebPage.js'
+
+await setupWebPage()
 
 Vue.prototype.t = translate
-
-appData.restore()
 
 new Vue(UpgradeApp).$mount('#app')


### PR DESCRIPTION
### ☑️ Resolves

* Fix #3 
* Fix #363

### 🖼️ Screenshots

![image](https://github.com/nextcloud/talk-desktop/assets/25978914/d14cfc1f-c46f-4231-a75b-e4d3b1ee41b8)

P.S. Translated by GitHub Copilot

### 🚧 Tasks

- [x] Add `app:getSystemL10n` to get the preferred language and system locale
- [x] Add universal `setupWebPage` util to be used to set up every window, including l10n registration
- [x] Use system preferred language on Accounts window
- [x] Add missing t-strings
