### PR TITLE
fix(patchers): add support for `.gif` images request for animated emojis

### DIFF
--- a/src/patchers/@nextcloud/router.js
+++ b/src/patchers/@nextcloud/router.js
@@ -65,6 +65,7 @@ export function generateFilePath(app, type, file) {
 			'.jpg': () => require(`@talk/img/${filename}.jpg`),
 			'.jpeg': () => require(`@talk/img/${filename}.jpeg`),
 			'.webp': () => require(`@talk/img/${filename}.webp`),
+			'.gif': () => require(`@talk/img/${filename}.gif`),
 			// Note: spreed uses img for both images and sounds
 			'.ogg': () => require(`@talk/img/${filename}.ogg`),
 		}


### PR DESCRIPTION
### ☑️ Resolves

* Fix: https://github.com/nextcloud/talk-desktop/issues/405
 
### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![image](https://github.com/nextcloud/talk-desktop/assets/25978914/f0da7dfb-59ed-46fa-8b74-48026411e901) | ![image](https://github.com/nextcloud/talk-desktop/assets/25978914/428601bd-b025-43ef-9fc2-f168b1c44ce5)

### 🚧 Tasks

- [x] Add `.gif` support for images requested from the server
