### PR TITLE
feat: add `--background` argv support for opening app minimized to the system tray

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -34,6 +34,14 @@ const { createWelcomeWindow } = require('./welcome/welcome.window.js')
 const { installVueDevtools } = require('./install-vue-devtools.js')
 
 /**
+ * Parse command line arguments
+ */
+const ARGUMENTS = {
+	// Open Talk window in the background, minimized to the system tray
+	openInBackground: process.argv.includes('--background'),
+}
+
+/**
  * Separate production and development instances, including application and user data
  */
 if (process.env.NODE_ENV === 'development') {
@@ -173,7 +181,11 @@ app.whenReady().then(async () => {
 		}
 
 		mainWindow.once('ready-to-show', () => {
-			mainWindow.show()
+			// Do not show the main window if it is the Talk Window opened in the background
+			const isTalkWindow = createMainWindow === createTalkWindow
+			if (!isTalkWindow || !ARGUMENTS.openInBackground) {
+				mainWindow.show()
+			}
 			welcomeWindow.close()
 		})
 	})

--- a/src/talk/talk.window.js
+++ b/src/talk/talk.window.js
@@ -60,10 +60,6 @@ function createTalkWindow() {
 		height: 600,
 	})
 
-	window.once('ready-to-show', () => {
-		window.show()
-	})
-
 	applyContextMenu(window)
 	applyDownloadNotification(window)
 	applyWheelZoom(window)


### PR DESCRIPTION
### ☑️ Resolves

* Fix #427
* Will be useful for #29

### 🖼️ Screenshots

Welcome window is not hide. Hiding the welcome window is more problematic because the app is not in the system tray and connection could not be successful.

So for some time it is visible anyway.

![bg](https://github.com/nextcloud/talk-desktop/assets/25978914/455d8a1a-7e72-468b-9391-2a57ca278500)

### 🚧 Tasks

- [x] Add argv `--background` support: on open if the main Talk window is to be open and there was argv `--background` - do not show the window. It can be opened from the system tray.
- [x] Opening on the login window is not changed