### PR TITLE
release: v0.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## v0.18.0 - 2023-12-07
+
+### Build-in Talk update
+
+- Built-in Talk in binaries is updated to v18.0.0-rc.3
+
+### Fixes
+
+- l10n: replace triple dots with ellipsis [#450](https://github.com/nextcloud/talk-desktop/pull/450)
+
 ## v0.17.0 - 2023-11-30
 
 ### Build-in Talk update

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "talk-desktop",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "talk-desktop",
-      "version": "0.17.0",
+      "version": "0.18.0",
       "license": "AGPL-3.0",
       "dependencies": {
         "@nextcloud/axios": "^2.4.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "name": "talk-desktop",
   "productName": "Nextcloud Talk",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "description": "Official Desktop client for Nextcloud Talk",
   "bugs": "https://github.com/nextcloud/talk-desktop/issues",
   "license": "AGPL-3.0",


### PR DESCRIPTION
## v0.18.0 - 2023-12-07

### Build-in Talk update

- Built-in Talk in binaries is updated to v18.0.0-rc.3

### Fixes

- l10n: replace triple dots with ellipsis [#450](https://github.com/nextcloud/talk-desktop/pull/450)