### PR TITLE
fix(authentication): system lang separator

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -72,8 +72,8 @@ if (process.env.NODE_ENV === 'production') {
 ipcMain.on('app:quit', () => app.quit())
 ipcMain.handle('app:getOs', () => getOs())
 ipcMain.handle('app:getSystemL10n', () => ({
-	locale: app.getLocale(),
-	language: app.getPreferredSystemLanguages()[0],
+	locale: app.getLocale().replace('-', '_'),
+	language: app.getPreferredSystemLanguages()[0].replace('-', '_'),
 }))
 ipcMain.handle('app:enableWebRequestInterceptor', (event, ...args) => enableWebRequestInterceptor(...args))
 ipcMain.handle('app:disableWebRequestInterceptor', (event, ...args) => disableWebRequestInterceptor(...args))


### PR DESCRIPTION
`@nextcloud/l10n` expect `_` separator while OS may return `-`.

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
`de-DE` | `de_DE`
![image](https://github.com/nextcloud/talk-desktop/assets/25978914/b9ac5cbb-5e37-455b-80e1-85f2b7d5e3b5) | ![image](https://github.com/nextcloud/talk-desktop/assets/25978914/afc65009-c566-479d-96c2-f9f9dd7623ef)