### PR TITLE
release: v0.20.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## v0.20.0 - 2024-01-09
+
+### Build-in Talk update
+
+- Built-in Talk in binaries is updated to v18.0.1
+
+### Fixes
+
+- Fix language detection for some languages [#458](https://github.com/nextcloud/talk-desktop/pull/458)
+
 ## v0.19.0 - 2023-12-12
 
 ### Build-in Talk update

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "talk-desktop",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "talk-desktop",
-      "version": "0.19.0",
+      "version": "0.20.0",
       "license": "AGPL-3.0",
       "dependencies": {
         "@nextcloud/axios": "^2.4.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "name": "talk-desktop",
   "productName": "Nextcloud Talk",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "description": "Official Desktop client for Nextcloud Talk",
   "bugs": "https://github.com/nextcloud/talk-desktop/issues",
   "license": "AGPL-3.0",


### PR DESCRIPTION
## v0.20.0 - 2024-01-09

### Build-in Talk update

- Built-in Talk in binaries is updated to v18.0.1

### Fixes

- Fix language detection for some languages [#458](https://github.com/nextcloud/talk-desktop/pull/458)