### PR TITLE
chore(dev): change default Webpack logger port from 9000 for 9005

### DIFF
--- a/forge.config.js
+++ b/forge.config.js
@@ -91,6 +91,8 @@ module.exports = {
 			config: {
 				mainConfig: './webpack.main.config.js',
 				devContentSecurityPolicy: `default-src 'self' 'unsafe-inline' data: blob: ${process.env.NEXTCLOUD_DEV_SERVER_HOSTS}; script-src 'self' 'unsafe-eval' 'unsafe-inline' data: blob:`,
+				port: 3000, // The default for this plugin
+				loggerPort: 9005, // The default is 9000, but it conflicts with Talk API
 				renderer: {
 					config: './webpack.renderer.config.js',
 					entryPoints: [


### PR DESCRIPTION
9000 conflicts with Talk API

Used only to provide log from Webpack during development.

9005 checked on https://en.wikipedia.org/wiki/List_of_TCP_and_UDP_port_numbers