### PR TITLE
fix(welcome): init globals

### DIFF
--- a/src/welcome/welcome.js
+++ b/src/welcome/welcome.js
@@ -23,6 +23,7 @@ import '../shared/assets/default/icons.css'
 
 import { appData } from '../app/AppData.js'
 import { refetchAppDataIfDirty } from '../app/appData.service.js'
+import { initGlobals } from '../shared/globals/globals.js'
 
 const quitButton = document.querySelector('.quit')
 quitButton.addEventListener('click', () => window.TALK_DESKTOP.quit())
@@ -35,6 +36,8 @@ window.TALK_DESKTOP.getOs().then(os => {
 })
 
 appData.restore()
+
+initGlobals()
 
 if (appData.credentials) {
 	await window.TALK_DESKTOP.enableWebRequestInterceptor(appData.serverUrl, { enableCors: true, enableCookies: true, credentials: appData.credentials })


### PR DESCRIPTION
### ☑️ Resolves

* Regression from https://github.com/nextcloud/talk-desktop/pull/537
* `Welcome` window has a special minimal setup. But `initGlobals()` must be there as well, otherwise Web requests for Capabilities don't work, and the app gets stuck on capabilities update on invalid hash.
