### PR TITLE
fix: "Share from Nextcloud" support

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@
 
 - Currently not supported:
   - Screen sharing ([#11](https://github.com/nextcloud/talk-desktop/issues/11))
-  - Share from Nextcloud (including files creation) ([#12](https://github.com/nextcloud/talk-desktop/issues/12))
   - Contacts menu on user avatars menus ([#34](https://github.com/nextcloud/talk-desktop/issues/34))
   - Setting User Status ([#26](https://github.com/nextcloud/talk-desktop/issues/26))
   - Search ([#30](https://github.com/nextcloud/talk-desktop/issues/30))

--- a/src/app/webRequestInterceptor.js
+++ b/src/app/webRequestInterceptor.js
@@ -90,10 +90,11 @@ function enableWebRequestInterceptor(serverUrl, {
 		'If-None-Match',
 		// WebDAV
 		'Depth',
-		'requesttoken',
 		// Nextcloud
+		'requesttoken',
 		'OCS-APIRequest',
 		'X-OC-MTIME',
+		'X-Requested-With',
 	].join(', ')]
 	const EXPOSED_HEADERS = [[
 		// Common headers

--- a/src/app/webRequestInterceptor.js
+++ b/src/app/webRequestInterceptor.js
@@ -81,7 +81,7 @@ function enableWebRequestInterceptor(serverUrl, {
 	}
 
 	const ALLOWED_ORIGIN = [process.env.NODE_ENV === 'production' ? 'file://' : `${DEV_SERVER_ORIGIN}`]
-	const ALLOWED_METHODS = ['GET, POST, PUT, PATCH, DELETE, PROPFIND, MKCOL'] // Includes WebDAV
+	const ALLOWED_METHODS = ['GET, POST, PUT, PATCH, DELETE, PROPFIND, MKCOL, SEARCH, REPORT'] // Includes WebDAV
 	const ALLOWED_CREDENTIALS_TRUE = ['true']
 	const ALLOWED_HEADERS = [[
 		// Common

--- a/src/patchers/@nextcloud/axios.js
+++ b/src/patchers/@nextcloud/axios.js
@@ -23,7 +23,6 @@ import axios from '@desktop-modules--@nextcloud/axios'
 
 axios.interceptors.request.use((config) => {
 	config.withCredentials = true
-	delete config.headers.requesttoken
 	config.headers['OCS-APIRequest'] = 'true'
 	return config
 }, (error) => Promise.reject(error))

--- a/src/patchers/@nextcloud/initial-state.js
+++ b/src/patchers/@nextcloud/initial-state.js
@@ -84,8 +84,8 @@ function getInitialStateFromCapabilities(capabilities, userMetadata) {
 // eslint-disable-next-line jsdoc/require-jsdoc
 export function loadState(app, key, fallback) {
 	const capabilities = getInitialStateFromCapabilities(appData.capabilities, appData.userMetadata)
-	const elem = capabilities[app][key]
-	if (elem === null) {
+	const elem = capabilities[app]?.[key]
+	if (elem === null || elem === undefined) {
 		if (fallback !== undefined) {
 			return fallback
 		}


### PR DESCRIPTION
### ☑️ Resolves

* FilePicker ("Share from Nextcloud") support. It should have been working after migrating to `@nextcloud/dialogs@5` but after some changes in `@nextcloud/dialogs` it hasn't been working again

### 🚧 Tasks

- [x] Handle initial state for non-existing app (otherwise getting optional Files configs crashed FilePicker)
- [x] Don't delete `requesttocken` header (it allows non-`OCS-APIRequests` requests like getting Files app configs)
  - I have no idea why I deleted this header 😶
  - Actually, it also allows requesting the contact menu for `NcAvatar`
- [x] Allow SEARCH and REPORT requests and X-Requested-With header (otherwise in DEV mode they are blocked by CORS)