### PR TITLE
release: v0.22.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## v0.22.0 - 2024-03-05
+
+### Build-in Talk update
+
+- Built-in Talk in binaries is updated to v18.0.4
+
+### Fixes
+
+- Fix window icon on linux [#308](https://github.com/nextcloud/talk-desktop/pull/308)
+- Fix "Share from Nextcloud" support [#540](https://github.com/nextcloud/talk-desktop/pull/540)
+- Allow avatar menu on desktop [Talk#11675](https://github.com/nextcloud/spreed/pull/11675)
+
+### Other changes
+
+- Added Nextcloud Talk 19 support
+- Update dependencies
+- Update translations
+
 ## v0.21.0 - 2024-02-01
 
 ### Build-in Talk update

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "talk-desktop",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "talk-desktop",
-      "version": "0.21.0",
+      "version": "0.22.0",
       "license": "AGPL-3.0",
       "dependencies": {
         "@nextcloud/axios": "^2.4.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "name": "talk-desktop",
   "productName": "Nextcloud Talk",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "description": "Official Desktop client for Nextcloud Talk",
   "bugs": "https://github.com/nextcloud/talk-desktop/issues",
   "license": "AGPL-3.0",


### PR DESCRIPTION
## v0.22.0 - 2024-03-05

### Build-in Talk update

- Built-in Talk in binaries is updated to v18.0.4

### Fixes

- Fix window icon on linux [#308](https://github.com/nextcloud/talk-desktop/pull/308)
- Fix "Share from Nextcloud" support [#540](https://github.com/nextcloud/talk-desktop/pull/540)
- Allow avatar menu on desktop [Talk#11675](https://github.com/nextcloud/spreed/pull/11675)

### Other changes

- Added Nextcloud Talk 19 support
- Update dependencies
- Update translations