### PR TITLE
show application if not focused or closed when clicking on tray icon

### DIFF
--- a/src/app/app.tray.js
+++ b/src/app/app.tray.js
@@ -51,7 +51,7 @@ function setupTray(browserWindow) {
 			role: 'quit',
 		},
 	]))
-	tray.on('click', () => browserWindow.show())
+	tray.on('click', () => browserWindow.isFocused() ? browserWindow.close() : browserWindow.show())
 
 	browserWindow.on('close', event => {
 		if (!isAppQuitting) {


### PR DESCRIPTION
When clicking on the tray icon, if window is not focused show it instead of closing it. If window is closed or not focused will be shown.

### ☑️ Resolves

* Issue #…

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
B | A

### 🚧 Tasks

- [ ] ...
