### PR TITLE
fix(talk): correctly import Vuex store from Talk

### DIFF
--- a/src/talk/renderer/init.js
+++ b/src/talk/renderer/init.js
@@ -118,7 +118,7 @@ function createTalkHashPiniaAdapter(talkInstance) {
 function createTalkHashVuexAdapter(talkInstance) {
 	let store
 	try {
-		store = require('@talk/src/store/index.js')
+		store = require('@talk/src/store/index.js').default
 	} catch {
 		return null
 	}


### PR DESCRIPTION
### ☑️ Resolves

* Regression from https://github.com/nextcloud/talk-desktop/pull/542
* Thought, it works fine while importing module with `_esModule: true`...

![image](https://github.com/nextcloud/talk-desktop/assets/25978914/9e5b4c3d-6f7e-462f-8577-71f1a5f16247)
