### PR TITLE
build: support TS in Talk

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
         "@nextcloud/eslint-plugin": "^2.1.0",
         "@nextcloud/webpack-vue-config": "^6.0.1",
         "@vercel/webpack-asset-relocator-loader": "^1.7.3",
+        "@vue/tsconfig": "^0.5.1",
         "babel-loader-exclude-node-modules-except": "^1.2.1",
         "babel-plugin-add-module-exports": "^1.0.4",
         "css-loader": "^6.10.0",
@@ -5590,6 +5591,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@vue/tsconfig": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@vue/tsconfig/-/tsconfig-0.5.1.tgz",
+      "integrity": "sha512-VcZK7MvpjuTPx2w6blwnwZAu5/LgBUtejFOi3pPGQFXQN5Ela03FUtd2Qtg4yWGGissVL0dr6Ro1LfOFh+PCuQ==",
+      "dev": true
     },
     "node_modules/@vueuse/components": {
       "version": "10.9.0",
@@ -24605,6 +24612,12 @@
         "@typescript-eslint/parser": "^6.7.0",
         "vue-eslint-parser": "^9.3.1"
       }
+    },
+    "@vue/tsconfig": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@vue/tsconfig/-/tsconfig-0.5.1.tgz",
+      "integrity": "sha512-VcZK7MvpjuTPx2w6blwnwZAu5/LgBUtejFOi3pPGQFXQN5Ela03FUtd2Qtg4yWGGissVL0dr6Ro1LfOFh+PCuQ==",
+      "dev": true
     },
     "@vueuse/components": {
       "version": "10.9.0",

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "@nextcloud/eslint-plugin": "^2.1.0",
     "@nextcloud/webpack-vue-config": "^6.0.1",
     "@vercel/webpack-asset-relocator-loader": "^1.7.3",
+    "@vue/tsconfig": "^0.5.1",
     "babel-loader-exclude-node-modules-except": "^1.2.1",
     "babel-plugin-add-module-exports": "^1.0.4",
     "css-loader": "^6.10.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,14 @@
+{
+	"extends": "@vue/tsconfig/tsconfig.json",
+	"include": ["*.ts"],
+	"exclude": ["node_modules", "vendor"],
+	"compilerOptions": {
+		"allowJs": true,
+		"checkJs": true,
+		"allowImportingTsExtensions": true,
+		"lib": ["ESNext"],
+	},
+	"vueCompilerOptions": {
+		"target": 2.7,
+	}
+}

--- a/webpack.renderer.config.js
+++ b/webpack.renderer.config.js
@@ -104,6 +104,9 @@ let webpackRendererConfig = mergeWithRules({
 	},
 
 	resolve: {
+		// FIXME: temporary solution to allow import TS modules without extension in Talk
+		extensions: ['.js', '.ts'],
+
 		alias: {
 			'@talk': TALK_PATH,
 			...createPatcherAliases('@nextcloud/initial-state'),


### PR DESCRIPTION
### ☑️ Resolves

* Importing TS with ESM import without extensions in Talk source doesn't work in Talk Desktop, module not found.

```
ERROR in ./spreed/src/components/NewMessage/NewMessage.vue?vue&type=script&lang=js& (./node_modules/esbuild-loader/dist/index.cjs??clonedRuleSet-15!./node_modules/vue-loader/lib/index.js??vue-loader-options!./spreed/src/components/NewMessage/NewMessage.vue?vue&type=script&lang=js&) 25:0-101
  Module not found: Error: Can't resolve '../../services/avatarService'
```

### 🚧 Tasks

- [x] Add TS support in Talk Desktop
- [x] Temporary allow importing TS without extensions
  - This is not a good solution, but spending almost a full working day I have found no other solutions from the Talk Desktop side and I don't understand, why it doesn't work.
  - Alternative - follow server style in Talk and always import with extensions. But it would require a new Talk release.
