### PR TITLE
release: v0.23.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## v0.23.0 - 2024-03-11
+
+### Build-in Talk update
+
+- Built-in Talk in binaries is updated to v19.0.0-beta.1
+
+### Fixes
+
+- Fix Talk hash integration with Talk 18 and below [#550](https://github.com/nextcloud/talk-desktop/pull/550)
+
 ## v0.22.0 - 2024-03-05
 
 ### Build-in Talk update

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "talk-desktop",
-  "version": "0.22.0",
+  "version": "0.23.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "talk-desktop",
-      "version": "0.22.0",
+      "version": "0.23.0",
       "license": "AGPL-3.0",
       "dependencies": {
         "@nextcloud/axios": "^2.4.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "name": "talk-desktop",
   "productName": "Nextcloud Talk",
-  "version": "0.22.0",
+  "version": "0.23.0",
   "description": "Official Desktop client for Nextcloud Talk",
   "bugs": "https://github.com/nextcloud/talk-desktop/issues",
   "license": "AGPL-3.0",


### PR DESCRIPTION
## v0.23.0 - 2024-03-11

### Build-in Talk update

- Built-in Talk in binaries is updated to v19.0.0-beta.1

### Fixes

- Fix Talk hash integration with Talk 18 and below [#550](https://github.com/nextcloud/talk-desktop/pull/550)