### PR TITLE
revert: "chore(deps): Bump undici from 6.6.2 to 6.7.1"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "floating-vue": "^1.0.0-beta.19",
         "howler": "^2.2.4",
         "semver": "^7.6.0",
-        "undici": "6.7.1",
+        "undici": "6.6.2",
         "unzip-crx-3": "^0.2.0",
         "vue": "^2.7.16",
         "vue-material-design-icons": "^5.3.0"
@@ -3524,6 +3524,14 @@
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@fastify/busboy": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.0.0.tgz",
+      "integrity": "sha512-JUFJad5lv7jxj926GPgymrWQxxjPYuJNiNjNMzqT+HiuP6Vl3dk5xzG+8sTX96np0ZAluvaMzPsjhHZ5rNuNQQ==",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@floating-ui/core": {
@@ -19147,9 +19155,12 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.7.1",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.7.1.tgz",
-      "integrity": "sha512-+Wtb9bAQw6HYWzCnxrPTMVEV3Q1QjYanI0E4q02ehReMuquQdLTEFEYbfs7hcImVYKcQkWSwT6buEmSVIiDDtQ==",
+      "version": "6.6.2",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.6.2.tgz",
+      "integrity": "sha512-vSqvUE5skSxQJ5sztTZ/CdeJb1Wq0Hf44hlYMciqHghvz+K88U0l7D6u1VsndoFgskDcnU+nG3gYmMzJVzd9Qg==",
+      "dependencies": {
+        "@fastify/busboy": "^2.0.0"
+      },
       "engines": {
         "node": ">=18.0"
       }
@@ -23055,6 +23066,11 @@
       "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.0.tgz",
       "integrity": "sha512-Ys+3g2TaW7gADOJzPt83SJtCDhMjndcDMFVQ/Tj9iA1BfJzFKD9mAUXT3OenpuPHbI6P/myECxRJrofUsDx/5g==",
       "dev": true
+    },
+    "@fastify/busboy": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.0.0.tgz",
+      "integrity": "sha512-JUFJad5lv7jxj926GPgymrWQxxjPYuJNiNjNMzqT+HiuP6Vl3dk5xzG+8sTX96np0ZAluvaMzPsjhHZ5rNuNQQ=="
     },
     "@floating-ui/core": {
       "version": "0.3.1"
@@ -34149,9 +34165,12 @@
       }
     },
     "undici": {
-      "version": "6.7.1",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.7.1.tgz",
-      "integrity": "sha512-+Wtb9bAQw6HYWzCnxrPTMVEV3Q1QjYanI0E4q02ehReMuquQdLTEFEYbfs7hcImVYKcQkWSwT6buEmSVIiDDtQ=="
+      "version": "6.6.2",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.6.2.tgz",
+      "integrity": "sha512-vSqvUE5skSxQJ5sztTZ/CdeJb1Wq0Hf44hlYMciqHghvz+K88U0l7D6u1VsndoFgskDcnU+nG3gYmMzJVzd9Qg==",
+      "requires": {
+        "@fastify/busboy": "^2.0.0"
+      }
     },
     "undici-types": {
       "version": "5.26.5",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "floating-vue": "^1.0.0-beta.19",
     "howler": "^2.2.4",
     "semver": "^7.6.0",
-    "undici": "6.7.1",
+    "undici": "6.6.2",
     "unzip-crx-3": "^0.2.0",
     "vue": "^2.7.16",
     "vue-material-design-icons": "^5.3.0"


### PR DESCRIPTION
- https://github.com/nextcloud/talk-desktop/pull/562 was not supposed to happen
- See: https://github.com/nextcloud/talk-desktop/pull/552#issuecomment-1988667826