### PR TITLE
fix(talk): support original path for root page

### DIFF
--- a/src/talk/renderer/talk.main.js
+++ b/src/talk/renderer/talk.main.js
@@ -26,6 +26,11 @@ import 'regenerator-runtime' // TODO: Why isn't it added on bundling
 import { init, initTalkHashIntegration } from './init.js'
 import { setupWebPage } from '../../shared/setupWebPage.js'
 
+// Initially open the welcome page, if not specified
+if (!window.location.hash) {
+	window.location.hash = '#/apps/spreed'
+}
+
 await setupWebPage()
 
 const { router } = await init()


### PR DESCRIPTION
### ☑️ Resolves

* Allows to remove special path alias for welcome page for Talk Desktop: https://github.com/nextcloud/spreed/pull/11877
* This doesn't require support (backport of mentioned PR) for old Talk versions

### 🖼️ Screenshots

No visual changes

