### PR TITLE
fix(talk): typo in TalkHash Pinia store init

### DIFF
--- a/src/talk/renderer/talk.main.js
+++ b/src/talk/renderer/talk.main.js
@@ -40,6 +40,6 @@ createDesktopApp(router)
 
 await import('@talk/src/main.js')
 
-initTalkHashIntegration(OCA.Talk.instance.$pinia)
+initTalkHashIntegration(OCA.Talk.instance)
 
 await import('./notifications/notifications.store.js')


### PR DESCRIPTION
Pinia stores should be used in component's setup context or with pinia instance like `useStore(pinia)`.

There was a typo, I passed `instance.$pinia` instead of `instance` to the function, so there `instance.$pinia.$pinia === undefined` was used as Pinia.

It is not required, Pinia has "active global Pinia" and it usually works, but it is not guaranteed, especially if there are many Pinia instances on the page.