### PR TITLE
Release v0.26.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.26.1 - 2024-03-26
+
+### Fixes
+
+- Downgrade undici dependency again [#583](https://github.com/nextcloud/talk-desktop/pull/583)
+
 ## v0.26.0 - 2024-03-26
 
 ### Build-in Talk update

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "talk-desktop",
-  "version": "0.26.0",
+  "version": "0.26.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "talk-desktop",
-      "version": "0.26.0",
+      "version": "0.26.1",
       "license": "AGPL-3.0",
       "dependencies": {
         "@nextcloud/axios": "^2.4.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "name": "talk-desktop",
   "productName": "Nextcloud Talk",
-  "version": "0.26.0",
+  "version": "0.26.1",
   "description": "Official Desktop client for Nextcloud Talk",
   "bugs": "https://github.com/nextcloud/talk-desktop/issues",
   "license": "AGPL-3.0",


### PR DESCRIPTION
## v0.26.1 - 2024-03-26

### Fixes
- Downgrade undici dependency again [#583](https://github.com/nextcloud/talk-desktop/pull/583)

## v0.26.0 - 2024-03-26

### Build-in Talk update
- Built-in Talk in binaries is updated to v19.0.0-beta.5