### PR TITLE
chore(deps): pin exact undici@6.6.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "floating-vue": "^1.0.0-beta.19",
         "howler": "^2.2.4",
         "semver": "^7.6.0",
-        "undici": "^6.6.2",
+        "undici": "6.6.2",
         "unzip-crx-3": "^0.2.0",
         "vue": "^2.7.16",
         "vue-material-design-icons": "^5.3.0"

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "floating-vue": "^1.0.0-beta.19",
     "howler": "^2.2.4",
     "semver": "^7.6.0",
-    "undici": "^6.6.2",
+    "undici": "6.6.2",
     "unzip-crx-3": "^0.2.0",
     "vue": "^2.7.16",
     "vue-material-design-icons": "^5.3.0"


### PR DESCRIPTION
- Bring back #557
- `undici` must be exact `6.6.2`, not `compatible with 6.6.2`