### PR TITLE
feat: screen sharing

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -33,6 +33,10 @@ module.exports = {
 	},
 
 	rules: {
+		// import/default is not compatible with SFC Setup .vue files
+		// It works fine on server because by default in @nextcloud/eslint-config .vue files are not inspected via eslint-plugin-import thus import/extensions doesn't include .vue
+		// See: https://github.com/import-js/eslint-plugin-import/blob/main/README.md#importextensions
+		'import/default': 'off',
 		/**
 		 * ESLint
 		 */

--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@
 ## 👾 Drawbacks
 
 - Currently not supported:
-  - Screen sharing ([#11](https://github.com/nextcloud/talk-desktop/issues/11))
   - Setting User Status ([#26](https://github.com/nextcloud/talk-desktop/issues/26))
   - Search ([#30](https://github.com/nextcloud/talk-desktop/issues/30))
   - Untrusted certificate on Linux ([#23](https://github.com/nextcloud/talk-desktop/issues/23))

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.27.0",
       "license": "AGPL-3.0",
       "dependencies": {
+        "@mdi/svg": "^7.4.47",
         "@nextcloud/axios": "^2.4.0",
         "@nextcloud/browser-storage": "^0.3.0",
         "@nextcloud/capabilities": "^1.1.0",
@@ -4147,6 +4148,11 @@
       "dependencies": {
         "unist-util-is": "^3.0.0"
       }
+    },
+    "node_modules/@mdi/svg": {
+      "version": "7.4.47",
+      "resolved": "https://registry.npmjs.org/@mdi/svg/-/svg-7.4.47.tgz",
+      "integrity": "sha512-WQ2gDll12T9WD34fdRFgQVgO8bag3gavrAgJ0frN4phlwdJARpE6gO1YvLEMJR0KKgoc+/Ea/A0Pp11I00xBvw=="
     },
     "node_modules/@nextcloud/auth": {
       "version": "2.2.1",
@@ -23629,6 +23635,11 @@
           }
         }
       }
+    },
+    "@mdi/svg": {
+      "version": "7.4.47",
+      "resolved": "https://registry.npmjs.org/@mdi/svg/-/svg-7.4.47.tgz",
+      "integrity": "sha512-WQ2gDll12T9WD34fdRFgQVgO8bag3gavrAgJ0frN4phlwdJARpE6gO1YvLEMJR0KKgoc+/Ea/A0Pp11I00xBvw=="
     },
     "@nextcloud/auth": {
       "version": "2.2.1",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "release:package": "zx ./scripts/prepare-release-packages.mjs"
   },
   "dependencies": {
+    "@mdi/svg": "^7.4.47",
     "@nextcloud/axios": "^2.4.0",
     "@nextcloud/browser-storage": "^0.3.0",
     "@nextcloud/capabilities": "^1.1.0",

--- a/src/main.js
+++ b/src/main.js
@@ -20,7 +20,7 @@
  */
 
 const path = require('node:path')
-const { app, dialog, BrowserWindow, ipcMain } = require('electron')
+const { app, dialog, BrowserWindow, ipcMain, desktopCapturer, systemPreferences } = require('electron')
 const { setupMenu } = require('./app/app.menu.js')
 const { setupReleaseNotificationScheduler } = require('./app/githubReleaseNotification.service.js')
 const { enableWebRequestInterceptor, disableWebRequestInterceptor } = require('./app/webRequestInterceptor.js')
@@ -28,7 +28,7 @@ const { createAuthenticationWindow } = require('./authentication/authentication.
 const { openLoginWebView } = require('./authentication/login.window.js')
 const { createHelpWindow } = require('./help/help.window.js')
 const { createUpgradeWindow } = require('./upgrade/upgrade.window.js')
-const { getOs, isLinux } = require('./shared/os.utils.js')
+const { getOs, isLinux, isMac } = require('./shared/os.utils.js')
 const { createTalkWindow } = require('./talk/talk.window.js')
 const { createWelcomeWindow } = require('./welcome/welcome.window.js')
 const { installVueDevtools } = require('./install-vue-devtools.js')
@@ -81,6 +81,20 @@ ipcMain.handle('app:setBadgeCount', async (event, count) => app.setBadgeCount(co
 ipcMain.on('app:relaunch', () => {
 	app.relaunch()
 	app.exit(0)
+})
+ipcMain.handle('app:getDesktopCapturerSources', async () => {
+	// macOS 10.15 Catalina or higher requires consent for screen access
+	if (isMac() && systemPreferences.getMediaAccessStatus('screen') !== 'granted') {
+		// TODO: show user-friendly error in this case
+		return []
+	}
+
+	const sources = await desktopCapturer.getSources({ types: ['window', 'screen'], fetchWindowIcons: true })
+	return sources.map((source) => ({
+		id: source.id,
+		name: source.name,
+		icon: source.appIcon?.toDataURL(),
+	}))
 })
 
 app.whenReady().then(async () => {

--- a/src/preload.js
+++ b/src/preload.js
@@ -84,6 +84,12 @@ const TALK_DESKTOP = {
 	 */
 	setBadgeCount: (count) => ipcRenderer.invoke('app:setBadgeCount', count),
 	/**
+	 * Get available desktop capture sources: screens and windows
+	 *
+	 * @return {Promise<{ id: string, name: string, icon?: string }>}
+	 */
+	getDesktopCapturerSources: () => ipcRenderer.invoke('app:getDesktopCapturerSources'),
+	/**
 	 * Relaunch the application
 	 */
 	relaunch: () => ipcRenderer.send('app:relaunch'),

--- a/src/preload.js
+++ b/src/preload.js
@@ -86,7 +86,7 @@ const TALK_DESKTOP = {
 	/**
 	 * Get available desktop capture sources: screens and windows
 	 *
-	 * @return {Promise<{ id: string, name: string, icon?: string }>}
+	 * @return {Promise<{ id: string, name: string, icon?: string }[]|null>}
 	 */
 	getDesktopCapturerSources: () => ipcRenderer.invoke('app:getDesktopCapturerSources'),
 	/**

--- a/src/shared/os.utils.js
+++ b/src/shared/os.utils.js
@@ -77,10 +77,20 @@ function isWindows() {
 }
 
 /**
+ * Is it Linux with Wayland window communication protocol?
+ * @return {boolean}
+ */
+function isWayland() {
+	// TODO: is it better than checking for XDG_SESSION_TYPE === 'wayland'?
+	return !!process.env.WAYLAND_DISPLAY
+}
+
+/**
  * @typedef OsVersion
  * @property {boolean} isLinux - Is Linux?
  * @property {boolean} isMac - Is Mac?
  * @property {boolean} isWindows - Is Windows?
+ * @property {boolean} isWayland - Is Linux with Wayland window communication protocol?
  * @property {string} version - Full string representation of OS version
  */
 
@@ -94,6 +104,7 @@ function getOs() {
 		isLinux: isLinux(),
 		isMac: isMac(),
 		isWindows: isWindows(),
+		isWayland: isWayland(),
 		version: getOsVersion(),
 	}
 }
@@ -104,5 +115,6 @@ module.exports = {
 	isLinux,
 	isMac,
 	isWindows,
+	isWayland,
 	getOs,
 }

--- a/src/talk/renderer/AppGetDesktopMediaSource.vue
+++ b/src/talk/renderer/AppGetDesktopMediaSource.vue
@@ -1,0 +1,56 @@
+<!--
+  - @copyright Copyright (c) 2024 Grigorii Shartsev <me@shgk.me>
+  -
+  - @author Grigorii Shartsev <me@shgk.me>
+  -
+  - @license AGPL-3.0-or-later
+  -
+  - This program is free software: you can redistribute it and/or modify
+  - it under the terms of the GNU Affero General Public License as
+  - published by the Free Software Foundation, either version 3 of the
+  - License, or (at your option) any later version.
+  -
+  - This program is distributed in the hope that it will be useful,
+  - but WITHOUT ANY WARRANTY; without even the implied warranty of
+  - MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  - GNU Affero General Public License for more details.
+  -
+  - You should have received a copy of the GNU Affero General Public License
+  - along with this program. If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<script setup>
+import { ref } from 'vue'
+
+import DesktopMediaSourceDialog from './components/DesktopMediaSourceDialog.vue'
+
+const showDialog = ref(false)
+
+let promiseWithResolvers = null
+
+const handlePrompt = (sourceId) => {
+	promiseWithResolvers.resolve({ sourceId })
+	promiseWithResolvers = null
+	showDialog.value = false
+}
+
+/**
+ * Prompt user to select a desktop media source to share and return the selected sourceId or an empty string if canceled
+ *
+ * @return {Promise<{ sourceId: string }>} sourceId of the selected mediaSource or an empty string if canceled
+ */
+function promptDesktopMediaSource() {
+	if (promiseWithResolvers) {
+		return promiseWithResolvers.promise
+	}
+	showDialog.value = true
+	promiseWithResolvers = Promise.withResolvers()
+	return promiseWithResolvers.promise
+}
+
+defineExpose({ promptDesktopMediaSource })
+</script>
+
+<template>
+	<DesktopMediaSourceDialog v-if="showDialog" @submit="handlePrompt($event)" @cancel="handlePrompt('')" />
+</template>

--- a/src/talk/renderer/components/DesktopMediaSourceDialog.vue
+++ b/src/talk/renderer/components/DesktopMediaSourceDialog.vue
@@ -24,6 +24,7 @@ import { computed, nextTick, onBeforeUnmount, onMounted, ref } from 'vue'
 
 import MdiCancel from '@mdi/svg/svg/cancel.svg?raw'
 import MdiMonitorShare from '@mdi/svg/svg/monitor-share.svg?raw'
+import MdiApplicationOutline from 'vue-material-design-icons/ApplicationOutline.vue'
 import MdiMonitor from 'vue-material-design-icons/Monitor.vue'
 import MdiMonitorSpeaker from 'vue-material-design-icons/MonitorSpeaker.vue'
 
@@ -34,6 +35,11 @@ import NcLoadingIcon from '@nextcloud/vue/dist/Components/NcLoadingIcon.js'
 import { translate as t } from '@nextcloud/l10n'
 
 const emit = defineEmits(['submit', 'cancel'])
+
+// On Wayland getting each stream for the live preview requests user to select the source via system dialog again
+// Instead - show static images.
+// See: https://github.com/electron/electron/issues/27732
+const previewType = window.OS.isWayland ? 'thumbnail' : 'live'
 
 const selectedSourceId = ref(null)
 const sources = ref(null)
@@ -100,13 +106,23 @@ const requestDesktopCapturerSources = async () => {
 		emit('cancel')
 	}
 
-	const hasMultipleScreens = sources.value.filter((source) => source.id.startsWith('screen:')).length > 1
+	// On Wayland we don't manually provide the source stream. It is covered by Wayland and custom id is not supported
+	if (!window.OS.isWayland) {
+		// There is no sourceId for the entire desktop with all the screens and audio in Electron.
+		// But it is possible to capture it. "entire-desktop:0:0" is a custom sourceId for this specific case.
+		const hasMultipleScreens = sources.value.filter((source) => source.id.startsWith('screen:')).length > 1
+		sources.value.unshift({
+			id: 'entire-desktop:0:0',
+			name: hasMultipleScreens ? t('talk_desktop', 'All screens with audio') : t('talk_desktop', 'Entire screen with audio'),
+		})
+	}
 
-	// There is no sourceId for the entire desktop in Electron - create a custom one
-	sources.value.unshift({
-		id: 'entire-desktop:0:0',
-		name: hasMultipleScreens ? t('talk_desktop', 'All screens with audio') : t('talk_desktop', 'Entire screen with audio'),
-	})
+	// On Wayland there might be no name from the desktopCapturer
+	if (window.OS.isWayland) {
+		for (const source of sources.value) {
+			source.name ||= t('talk_desktop', 'Selected screen or window')
+		}
+	}
 
 	// Preselect the first media source if any
 	selectedSourceId.value = sources.value[0]?.id
@@ -116,16 +132,23 @@ const setVideoSources = async () => Promise.allSettled(sources.value.map(async (
 	videoElements[source.id].srcObject = await getStreamForMediaSource(source.id)
 }))
 
-onMounted(async () => {
-	await requestDesktopCapturerSources()
+const showLivePreviews = async () => {
 	// Wait for video elements to be mounted
 	await nextTick()
 	// Set streams for all ids
 	await setVideoSources()
+}
+
+onMounted(async () => {
+	await requestDesktopCapturerSources()
+
+	if (previewType === 'live') {
+		await showLivePreviews()
+	}
 })
 
 onBeforeUnmount(() => {
-	if (!sources.value) {
+	if (!sources.value || previewType !== 'live') {
 		return
 	}
 	// Release all streams, otherwise they are still captured even if no video element is using them
@@ -150,10 +173,17 @@ onBeforeUnmount(() => {
 					class="capture-source__input"
 					type="radio"
 					:value="source.id">
-				<video :ref="(element) => videoElements[source.id] = element"
+				<video v-if="previewType === 'live'"
+					:ref="(element) => videoElements[source.id] = element"
 					class="capture-source__preview"
 					muted
 					@loadedmetadata="$event.target.play()" />
+				<img v-else-if="previewType === 'thumbnail' && source.thumbnail"
+					alt=""
+					:src="source.thumbnail"
+					class="capture-source__preview">
+				<span v-else class="capture-source__preview" />
+
 				<span class="capture-source__caption">
 					<img v-if="source.icon"
 						alt=""
@@ -161,6 +191,7 @@ onBeforeUnmount(() => {
 						class="capture-source__caption-icon">
 					<MdiMonitorSpeaker v-else-if="source.id.startsWith('entire-desktop:')" :size="16" />
 					<MdiMonitor v-else-if="source.id.startsWith('screen:')" :size="16" />
+					<MdiApplicationOutline v-else-if="source.id.startsWith('window:')" :size="16" />
 					<span class="capture-source__caption-text">{{ source.name }}</span>
 				</span>
 			</label>

--- a/src/talk/renderer/components/DesktopMediaSourceDialog.vue
+++ b/src/talk/renderer/components/DesktopMediaSourceDialog.vue
@@ -20,30 +20,22 @@
   -->
 
 <script setup>
-import { computed, nextTick, onBeforeUnmount, onMounted, ref } from 'vue'
+import { computed, onMounted, ref } from 'vue'
 
 import MdiCancel from '@mdi/svg/svg/cancel.svg?raw'
 import MdiMonitorShare from '@mdi/svg/svg/monitor-share.svg?raw'
-import MdiApplicationOutline from 'vue-material-design-icons/ApplicationOutline.vue'
-import MdiMonitor from 'vue-material-design-icons/Monitor.vue'
-import MdiMonitorSpeaker from 'vue-material-design-icons/MonitorSpeaker.vue'
 
 import NcDialog from '@nextcloud/vue/dist/Components/NcDialog.js'
 import NcEmptyContent from '@nextcloud/vue/dist/Components/NcEmptyContent.js'
 import NcLoadingIcon from '@nextcloud/vue/dist/Components/NcLoadingIcon.js'
 
 import { translate as t } from '@nextcloud/l10n'
+import DesktopMediaSourcePreview from './DesktopMediaSourcePreview.vue'
 
 const emit = defineEmits(['submit', 'cancel'])
 
-// On Wayland getting each stream for the live preview requests user to select the source via system dialog again
-// Instead - show static images.
-// See: https://github.com/electron/electron/issues/27732
-const previewType = window.OS.isWayland ? 'thumbnail' : 'live'
-
 const selectedSourceId = ref(null)
 const sources = ref(null)
-const videoElements = {}
 
 const handleSubmit = () => emit('submit', selectedSourceId.value)
 const handleCancel = () => emit('cancel')
@@ -62,41 +54,6 @@ const dialogButtons = computed(() => [
 		callback: handleSubmit,
 	},
 ])
-
-const getStreamForMediaSource = (mediaSourceId) => {
-	const MAX_PREVIEW_SIZE = 320
-	// Special case for sharing all the screens with desktop audio in Electron
-	// In this case, it must have exactly these constraints
-	// "entire-desktop:0:0" is a custom sourceId for this specific case
-	const constraints = mediaSourceId === 'entire-desktop:0:0'
-		? {
-			audio: {
-				mandatory: {
-					chromeMediaSource: 'desktop',
-				},
-			},
-			video: {
-				mandatory: {
-					chromeMediaSource: 'desktop',
-					maxWidth: MAX_PREVIEW_SIZE,
-					maxHeight: MAX_PREVIEW_SIZE,
-				},
-			},
-		}
-		: {
-			audio: false,
-			video: {
-				mandatory: {
-					chromeMediaSource: 'desktop',
-					chromeMediaSourceId: mediaSourceId,
-					maxWidth: MAX_PREVIEW_SIZE,
-					maxHeight: MAX_PREVIEW_SIZE,
-				},
-			},
-		}
-
-	return navigator.mediaDevices.getUserMedia(constraints)
-}
 
 const requestDesktopCapturerSources = async () => {
 	sources.value = await window.TALK_DESKTOP.getDesktopCapturerSources()
@@ -123,63 +80,21 @@ const requestDesktopCapturerSources = async () => {
 			source.name ||= t('talk_desktop', 'Selected screen or window')
 		}
 	}
-
-	// Preselect the first media source if any
-	selectedSourceId.value = sources.value[0]?.id
-}
-
-const setVideoSources = async () => Promise.allSettled(sources.value.map(async (source) => {
-	videoElements[source.id].srcObject = await getStreamForMediaSource(source.id)
-}))
-
-const releaseVideoSource = (sourceId) => {
-	const stream = videoElements[sourceId].srcObject
-	for (const track of stream.getTracks()) {
-		track.stop()
-	}
-}
-
-const releaseVideoSources = () => {
-	for (const source of sources.value) {
-		releaseVideoSource(source.id)
-	}
-}
-
-const setVideoElement = (element, sourceId) => {
-	if (element) {
-		videoElements[sourceId] = element
-	} else {
-		delete videoElements[sourceId]
-	}
 }
 
 const handleVideoSuspend = (source) => {
-	releaseVideoSource(source.id)
 	sources.value.splice(sources.value.indexOf(source), 1)
 	if (selectedSourceId.value === source.id) {
 		selectedSourceId.value = null
 	}
 }
 
-const showLivePreviews = async () => {
-	// Wait for video elements to be mounted
-	await nextTick()
-	// Set streams for all ids
-	await setVideoSources()
-}
-
 onMounted(async () => {
 	await requestDesktopCapturerSources()
 
-	if (previewType === 'live') {
-		await showLivePreviews()
-	}
-})
-
-onBeforeUnmount(() => {
-	// Release all streams, otherwise they are still captured even if no video element is using them
-	if (sources.value && previewType === 'live') {
-		releaseVideoSources()
+	// Preselect the first media source if any
+	if (!selectedSourceId.value) {
+		selectedSourceId.value = sources.value[0]?.id
 	}
 })
 </script>
@@ -190,35 +105,12 @@ onBeforeUnmount(() => {
 		:buttons="dialogButtons"
 		@update:open="handleCancel">
 		<div v-if="sources" class="capture-source-grid">
-			<label v-for="source in sources" :key="source.id" class="capture-source">
-				<input :id="source.id"
-					v-model="selectedSourceId"
-					class="capture-source__input"
-					type="radio"
-					:value="source.id">
-				<video v-if="previewType === 'live'"
-					:ref="(element) => setVideoElement(element, source.id)"
-					class="capture-source__preview"
-					muted
-					@loadedmetadata="$event.target.play()"
-					@suspend="handleVideoSuspend(source)" />
-				<img v-else-if="previewType === 'thumbnail' && source.thumbnail"
-					alt=""
-					:src="source.thumbnail"
-					class="capture-source__preview">
-				<span v-else class="capture-source__preview" />
-
-				<span class="capture-source__caption">
-					<img v-if="source.icon"
-						alt=""
-						:src="source.icon"
-						class="capture-source__caption-icon">
-					<MdiMonitorSpeaker v-else-if="source.id.startsWith('entire-desktop:')" :size="16" />
-					<MdiMonitor v-else-if="source.id.startsWith('screen:')" :size="16" />
-					<MdiApplicationOutline v-else-if="source.id.startsWith('window:')" :size="16" />
-					<span class="capture-source__caption-text">{{ source.name }}</span>
-				</span>
-			</label>
+			<DesktopMediaSourcePreview v-for="source in sources"
+				:key="source.id"
+				:source="source"
+				:selected="selectedSourceId === source.id"
+				@select="selectedSourceId = source.id"
+				@suspend="handleVideoSuspend(source)" />
 		</div>
 		<NcEmptyContent v-else :name="t('talk_desktop', 'Loading …')">
 			<template #icon>
@@ -234,58 +126,5 @@ onBeforeUnmount(() => {
 	grid-template-columns: repeat(3, minmax(0, 1fr));
 	grid-gap: calc(var(--default-grid-baseline) * 2);
 	width: 100%;
-}
-
-.capture-source {
-	display: flex;
-	flex-direction: column;
-	gap: var(--default-grid-baseline);
-	overflow: hidden;
-
-	&__input {
-		position: absolute;
-		z-index: -1;
-		opacity: 0 !important;
-		width: var(--default-clickable-area);
-		height: var(--default-clickable-area);
-		margin: 4px 14px;
-	}
-
-	&__preview {
-		aspect-ratio: 16 / 9;
-		object-fit: contain;
-		width: calc(100% - 4px - 4px);
-		flex: 1 0;
-		margin: 4px auto;
-		border-radius: var(--border-radius-large);
-	}
-
-	&:focus &__preview,
-	&:hover &__preview {
-		box-shadow: 0 0 0 2px var(--color-primary-element);
-		background-color: var(--color-background-hover);
-	}
-
-	&:has(&__input:checked) &__preview {
-		box-shadow: 0 0 0 4px var(--color-primary-element);
-		background-color: var(--color-background-hover);
-	}
-
-	&__caption {
-		display: flex;
-		gap: var(--default-grid-baseline);
-		align-items: center;
-		padding: var(--default-grid-baseline);
-	}
-
-	&__caption-icon {
-		height: 16px;
-	}
-
-	&__caption-text {
-		text-wrap: nowrap;
-		text-overflow: ellipsis;
-		overflow: hidden;
-	}
 }
 </style>

--- a/src/talk/renderer/components/DesktopMediaSourceDialog.vue
+++ b/src/talk/renderer/components/DesktopMediaSourceDialog.vue
@@ -95,6 +95,11 @@ const getStreamForMediaSource = (mediaSourceId) => {
 const requestDesktopCapturerSources = async () => {
 	sources.value = await window.TALK_DESKTOP.getDesktopCapturerSources()
 
+	// There is no source. Probably the user hasn't granted the permission.
+	if (!sources.value) {
+		emit('cancel')
+	}
+
 	const hasMultipleScreens = sources.value.filter((source) => source.id.startsWith('screen:')).length > 1
 
 	// There is no sourceId for the entire desktop in Electron - create a custom one

--- a/src/talk/renderer/components/DesktopMediaSourceDialog.vue
+++ b/src/talk/renderer/components/DesktopMediaSourceDialog.vue
@@ -1,0 +1,231 @@
+<!--
+  - @copyright Copyright (c) 2024 Grigorii Shartsev <me@shgk.me>
+  -
+  - @author Grigorii Shartsev <me@shgk.me>
+  -
+  - @license AGPL-3.0-or-later
+  -
+  - This program is free software: you can redistribute it and/or modify
+  - it under the terms of the GNU Affero General Public License as
+  - published by the Free Software Foundation, either version 3 of the
+  - License, or (at your option) any later version.
+  -
+  - This program is distributed in the hope that it will be useful,
+  - but WITHOUT ANY WARRANTY; without even the implied warranty of
+  - MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  - GNU Affero General Public License for more details.
+  -
+  - You should have received a copy of the GNU Affero General Public License
+  - along with this program. If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<script setup>
+import { computed, nextTick, onBeforeUnmount, onMounted, ref } from 'vue'
+
+import MdiCancel from '@mdi/svg/svg/cancel.svg?raw'
+import MdiMonitorShare from '@mdi/svg/svg/monitor-share.svg?raw'
+import MdiMonitor from 'vue-material-design-icons/Monitor.vue'
+import MdiMonitorSpeaker from 'vue-material-design-icons/MonitorSpeaker.vue'
+
+import NcDialog from '@nextcloud/vue/dist/Components/NcDialog.js'
+import NcEmptyContent from '@nextcloud/vue/dist/Components/NcEmptyContent.js'
+import NcLoadingIcon from '@nextcloud/vue/dist/Components/NcLoadingIcon.js'
+
+import { translate as t } from '@nextcloud/l10n'
+
+const emit = defineEmits(['submit', 'cancel'])
+
+const selectedSourceId = ref(null)
+const sources = ref(null)
+const videoElements = {}
+
+const handleSubmit = () => emit('submit', selectedSourceId.value)
+const handleCancel = () => emit('cancel')
+
+const dialogButtons = computed(() => [
+	{
+		label: t('talk_desktop', 'Cancel'),
+		icon: MdiCancel,
+		callback: handleCancel,
+	},
+	{
+		label: t('talk_desktop', 'Share screen'),
+		type: 'primary',
+		icon: MdiMonitorShare,
+		disabled: !selectedSourceId.value,
+		callback: handleSubmit,
+	},
+])
+
+const getStreamForMediaSource = (mediaSourceId) => {
+	const MAX_PREVIEW_SIZE = 320
+	// Special case for sharing all the screens with desktop audio in Electron
+	// In this case, it must have exactly these constraints
+	// "entire-desktop:0:0" is a custom sourceId for this specific case
+	const constraints = mediaSourceId === 'entire-desktop:0:0'
+		? {
+			audio: {
+				mandatory: {
+					chromeMediaSource: 'desktop',
+				},
+			},
+			video: {
+				mandatory: {
+					chromeMediaSource: 'desktop',
+					maxWidth: MAX_PREVIEW_SIZE,
+					maxHeight: MAX_PREVIEW_SIZE,
+				},
+			},
+		}
+		: {
+			audio: false,
+			video: {
+				mandatory: {
+					chromeMediaSource: 'desktop',
+					chromeMediaSourceId: mediaSourceId,
+					maxWidth: MAX_PREVIEW_SIZE,
+					maxHeight: MAX_PREVIEW_SIZE,
+				},
+			},
+		}
+
+	return navigator.mediaDevices.getUserMedia(constraints)
+}
+
+const requestDesktopCapturerSources = async () => {
+	sources.value = await window.TALK_DESKTOP.getDesktopCapturerSources()
+
+	const hasMultipleScreens = sources.value.filter((source) => source.id.startsWith('screen:')).length > 1
+
+	// There is no sourceId for the entire desktop in Electron - create a custom one
+	sources.value.unshift({
+		id: 'entire-desktop:0:0',
+		name: hasMultipleScreens ? t('talk_desktop', 'All screens with audio') : t('talk_desktop', 'Entire screen with audio'),
+	})
+
+	// Preselect the first media source if any
+	selectedSourceId.value = sources.value[0]?.id
+}
+
+const setVideoSources = async () => Promise.allSettled(sources.value.map(async (source) => {
+	videoElements[source.id].srcObject = await getStreamForMediaSource(source.id)
+}))
+
+onMounted(async () => {
+	await requestDesktopCapturerSources()
+	// Wait for video elements to be mounted
+	await nextTick()
+	// Set streams for all ids
+	await setVideoSources()
+})
+
+onBeforeUnmount(() => {
+	if (!sources.value) {
+		return
+	}
+	// Release all streams, otherwise they are still captured even if no video element is using them
+	for (const source of sources.value) {
+		const stream = videoElements[source.id].srcObject
+		for (const track of stream.getTracks()) {
+			track.stop()
+		}
+	}
+})
+</script>
+
+<template>
+	<NcDialog :name="t('talk_desktop', 'Choose what to share')"
+		size="normal"
+		:buttons="dialogButtons"
+		@update:open="handleCancel">
+		<div v-if="sources" class="capture-source-grid">
+			<label v-for="source in sources" :key="source.id" class="capture-source">
+				<input :id="source.id"
+					v-model="selectedSourceId"
+					class="capture-source__input"
+					type="radio"
+					:value="source.id">
+				<video :ref="(element) => videoElements[source.id] = element"
+					class="capture-source__preview"
+					muted
+					@loadedmetadata="$event.target.play()" />
+				<span class="capture-source__caption">
+					<img v-if="source.icon"
+						alt=""
+						:src="source.icon"
+						class="capture-source__caption-icon">
+					<MdiMonitorSpeaker v-else-if="source.id.startsWith('entire-desktop:')" :size="16" />
+					<MdiMonitor v-else-if="source.id.startsWith('screen:')" :size="16" />
+					<span class="capture-source__caption-text">{{ source.name }}</span>
+				</span>
+			</label>
+		</div>
+		<NcEmptyContent v-else :name="t('talk_desktop', 'Loading …')">
+			<template #icon>
+				<NcLoadingIcon />
+			</template>
+		</NcEmptyContent>
+	</NcDialog>
+</template>
+
+<style scoped lang="scss">
+.capture-source-grid {
+	display: grid;
+	grid-template-columns: repeat(3, minmax(0, 1fr));
+	grid-gap: calc(var(--default-grid-baseline) * 2);
+	width: 100%;
+}
+
+.capture-source {
+	display: flex;
+	flex-direction: column;
+	gap: var(--default-grid-baseline);
+	overflow: hidden;
+
+	&__input {
+		position: absolute;
+		z-index: -1;
+		opacity: 0 !important;
+		width: var(--default-clickable-area);
+		height: var(--default-clickable-area);
+		margin: 4px 14px;
+	}
+
+	&__preview {
+		aspect-ratio: 16 / 9;
+		object-fit: contain;
+		width: calc(100% - 4px - 4px);
+		flex: 1 0;
+		margin: 4px auto;
+		border-radius: var(--border-radius-large);
+	}
+
+	&:focus &__preview,
+	&:hover &__preview {
+		box-shadow: 0 0 0 2px var(--color-primary-element);
+		background-color: var(--color-background-hover);
+	}
+
+	&:has(&__input:checked) &__preview {
+		box-shadow: 0 0 0 4px var(--color-primary-element);
+		background-color: var(--color-background-hover);
+	}
+
+	&__caption {
+		display: flex;
+		gap: var(--default-grid-baseline);
+		align-items: center;
+		padding: var(--default-grid-baseline);
+	}
+
+	&__caption-icon {
+		height: 16px;
+	}
+
+	&__caption-text {
+		text-wrap: nowrap;
+		text-overflow: ellipsis;
+		overflow: hidden;
+	}
+}
+</style>

--- a/src/talk/renderer/components/DesktopMediaSourcePreview.vue
+++ b/src/talk/renderer/components/DesktopMediaSourcePreview.vue
@@ -1,0 +1,194 @@
+<!--
+  - @copyright Copyright (c) 2024 Grigorii Shartsev <me@shgk.me>
+  -
+  - @author Grigorii Shartsev <me@shgk.me>
+  -
+  - @license AGPL-3.0-or-later
+  -
+  - This program is free software: you can redistribute it and/or modify
+  - it under the terms of the GNU Affero General Public License as
+  - published by the Free Software Foundation, either version 3 of the
+  - License, or (at your option) any later version.
+  -
+  - This program is distributed in the hope that it will be useful,
+  - but WITHOUT ANY WARRANTY; without even the implied warranty of
+  - MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  - GNU Affero General Public License for more details.
+  -
+  - You should have received a copy of the GNU Affero General Public License
+  - along with this program. If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<script setup>
+import { onBeforeUnmount, onMounted, ref } from 'vue'
+
+import MdiMonitor from 'vue-material-design-icons/Monitor.vue'
+import MdiApplicationOutline from 'vue-material-design-icons/ApplicationOutline.vue'
+import MdiMonitorSpeaker from 'vue-material-design-icons/MonitorSpeaker.vue'
+
+// On Wayland getting each stream for the live preview requests user to select the source via system dialog again
+// Instead - show static images.
+// See: https://github.com/electron/electron/issues/27732
+const previewType = window.OS.isWayland ? 'thumbnail' : 'live'
+
+const videoElement = ref(null)
+
+const props = defineProps({
+	source: {
+		type: Object,
+		required: true,
+	},
+	selected: {
+		type: Boolean,
+		required: true,
+	},
+})
+
+const emit = defineEmits(['select', 'suspended'])
+
+const getStreamForMediaSource = (mediaSourceId) => {
+	const MAX_PREVIEW_SIZE = 320
+	// Special case for sharing all the screens with desktop audio in Electron
+	// In this case, it must have exactly these constraints
+	// "entire-desktop:0:0" is a custom sourceId for this specific case
+	const constraints = mediaSourceId === 'entire-desktop:0:0'
+		? {
+			audio: {
+				mandatory: {
+					chromeMediaSource: 'desktop',
+				},
+			},
+			video: {
+				mandatory: {
+					chromeMediaSource: 'desktop',
+					maxWidth: MAX_PREVIEW_SIZE,
+					maxHeight: MAX_PREVIEW_SIZE,
+				},
+			},
+		}
+		: {
+			audio: false,
+			video: {
+				mandatory: {
+					chromeMediaSource: 'desktop',
+					chromeMediaSourceId: mediaSourceId,
+					maxWidth: MAX_PREVIEW_SIZE,
+					maxHeight: MAX_PREVIEW_SIZE,
+				},
+			},
+		}
+
+	return navigator.mediaDevices.getUserMedia(constraints)
+}
+
+const setVideoSource = async () => {
+	videoElement.value.srcObject = await getStreamForMediaSource(props.source.id)
+}
+
+const releaseVideoSource = () => {
+	const stream = videoElement.value.srcObject
+	for (const track of stream.getTracks()) {
+		track.stop()
+	}
+}
+
+onMounted(async () => {
+	if (previewType === 'live') {
+		await setVideoSource()
+	}
+})
+
+onBeforeUnmount(() => {
+	// Release the stream, otherwise it is still captured even if no video element is using it
+	releaseVideoSource()
+})
+</script>
+
+<template>
+	<label :key="source.id" class="capture-source">
+		<input :id="source.id"
+			class="capture-source__input"
+			type="radio"
+			:value="source.id"
+			:checked="selected"
+			@change="emit('select')">
+
+		<video v-if="previewType === 'live'"
+			ref="videoElement"
+			class="capture-source__preview"
+			muted
+			@loadedmetadata="$event.target.play()"
+			@suspend="emit('suspend')" />
+		<img v-else-if="previewType === 'thumbnail' && source.thumbnail"
+			alt=""
+			:src="source.thumbnail"
+			class="capture-source__preview">
+		<span v-else class="capture-source__preview" />
+
+		<span class="capture-source__caption">
+			<img v-if="source.icon"
+				alt=""
+				:src="source.icon"
+				class="capture-source__caption-icon">
+			<MdiMonitorSpeaker v-else-if="source.id.startsWith('entire-desktop:')" :size="16" />
+			<MdiMonitor v-else-if="source.id.startsWith('screen:')" :size="16" />
+			<MdiApplicationOutline v-else-if="source.id.startsWith('window:')" :size="16" />
+			<span class="capture-source__caption-text">{{ source.name }}</span>
+		</span>
+	</label>
+</template>
+
+<style scoped lang="scss">
+.capture-source {
+	display: flex;
+	flex-direction: column;
+	gap: var(--default-grid-baseline);
+	overflow: hidden;
+
+	&__input {
+		position: absolute;
+		z-index: -1;
+		opacity: 0 !important;
+		width: var(--default-clickable-area);
+		height: var(--default-clickable-area);
+		margin: 4px 14px;
+	}
+
+	&__preview {
+		aspect-ratio: 16 / 9;
+		object-fit: contain;
+		width: calc(100% - 4px - 4px);
+		flex: 1 0;
+		margin: 4px auto;
+		border-radius: var(--border-radius-large);
+	}
+
+	&:focus &__preview,
+	&:hover &__preview {
+		box-shadow: 0 0 0 2px var(--color-primary-element);
+		background-color: var(--color-background-hover);
+	}
+
+	&:has(&__input:checked) &__preview {
+		box-shadow: 0 0 0 4px var(--color-primary-element);
+		background-color: var(--color-background-hover);
+	}
+
+	&__caption {
+		display: flex;
+		gap: var(--default-grid-baseline);
+		align-items: center;
+		padding: var(--default-grid-baseline);
+	}
+
+	&__caption-icon {
+		height: 16px;
+	}
+
+	&__caption-text {
+		text-wrap: nowrap;
+		text-overflow: ellipsis;
+		overflow: hidden;
+	}
+}
+</style>

--- a/src/talk/renderer/getDesktopMediaSource.js
+++ b/src/talk/renderer/getDesktopMediaSource.js
@@ -1,0 +1,41 @@
+/*
+ * @copyright Copyright (c) 2024 Grigorii Shartsev <me@shgk.me>
+ *
+ * @author Grigorii Shartsev <me@shgk.me>
+ *
+ * @license AGPL-3.0-or-later
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import Vue from 'vue'
+
+import AppGetDesktopMediaSource from './AppGetDesktopMediaSource.vue'
+
+/** @type {import('vue').ComponentPublicInstance<AppGetDesktopMediaSource>} */
+let appGetDesktopMediaSourceInstance
+
+/**
+ * Prompt user to select a desktop media source to share and return the selected sourceId or an empty string if canceled
+ *
+ * @return {Promise<{ sourceId: string }>} sourceId of the selected mediaSource or an empty string if canceled
+ */
+export async function getDesktopMediaSource() {
+	if (!appGetDesktopMediaSourceInstance) {
+		const container = document.body.appendChild(document.createElement('div'))
+		appGetDesktopMediaSourceInstance = new Vue(AppGetDesktopMediaSource).$mount(container)
+	}
+
+	return appGetDesktopMediaSourceInstance.promptDesktopMediaSource()
+}

--- a/src/talk/renderer/talk.main.js
+++ b/src/talk/renderer/talk.main.js
@@ -25,6 +25,7 @@ import './assets/styles.css'
 import 'regenerator-runtime' // TODO: Why isn't it added on bundling
 import { init, initTalkHashIntegration } from './init.js'
 import { setupWebPage } from '../../shared/setupWebPage.js'
+import { getDesktopMediaSource } from './getDesktopMediaSource.js'
 
 // Initially open the welcome page, if not specified
 if (!window.location.hash) {
@@ -43,3 +44,7 @@ await import('@talk/src/main.js')
 initTalkHashIntegration(OCA.Talk.instance)
 
 await import('./notifications/notifications.store.js')
+
+window.OCA.Talk.Desktop = {
+	getDesktopMediaSource,
+}


### PR DESCRIPTION
### ☑️ Resolves

* Fix #11

### 🖼️ Screenshots

![image](https://github.com/nextcloud/talk-desktop/assets/25978914/c4339f6c-a8e6-48c5-8615-9996cefa6648)

- With live previews (except on Wayland)
- Supports "All screens with audio". All of the other options don't support audio streaming.
- When there is only one screen, the first option is renamed to "Entire screen with audio"
- On Mac - opens settings to allow screensharing if it is not allowed

#### Windows / Mac / Linux (xorg)

https://github.com/nextcloud/talk-desktop/assets/25978914/7f29e4ec-86ca-4597-8e10-cfd5f79527fc

#### Linux (Wayland)

Wayland with PipeWire has a different workflow:
- Requesting all available sources (screens, windows) - triggers native system dialog to choose what to share
- Showing the stream for the selected source also triggers the system dialog
- So live preview for all options is not possible, each preview triggers the dialog
- Instead, only one static image preview is shown for the selected source
- Starting screensharing also triggers the dialog, and the second selected source is actually streamed
- Unfortunately, this is a known issue with double dialog. There is the same issue in Chromium

https://github.com/nextcloud/talk-desktop/assets/25978914/19d3a628-777b-4bf2-ade8-69cf00d5cc01

### 🚧 Tasks

- [x] Add `app:getDesktopCaptureSources` method to get the list of available sources on backend
- [x] Add `DesktopMediaSourceDialog` with the list of available sources to share (screens, windows)
- [x] Add `OCA.Talk.Desktop.getDesktopMediaSource` to invoke the dialog and get the selected source
- [x] On Talk side, use `OCA.Talk.Desktop.getDesktopMediaSource` instead of unavailable `navigator.mediaDevices.getDisplayMedia` (https://github.com/nextcloud/spreed/pull/12003)
- [x] Polishing
