### PR TITLE
chore(readme): remove contacts menu from unsupported features list

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@
 
 - Currently not supported:
   - Screen sharing ([#11](https://github.com/nextcloud/talk-desktop/issues/11))
-  - Contacts menu on user avatars menus ([#34](https://github.com/nextcloud/talk-desktop/issues/34))
   - Setting User Status ([#26](https://github.com/nextcloud/talk-desktop/issues/26))
   - Search ([#30](https://github.com/nextcloud/talk-desktop/issues/30))
   - Untrusted certificate on Linux ([#23](https://github.com/nextcloud/talk-desktop/issues/23))


### PR DESCRIPTION
### ☑️ Resolves

* Supported since https://github.com/nextcloud/spreed/pull/11675
