### PR TITLE
build: drop support for building with Talk v17

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -33,7 +33,7 @@ const USER_AGENT = `Mozilla/5.0 (${getOsTitle()}) Nextcloud-Talk v${packageJson.
 const DEV_SERVER_ORIGIN = 'http://localhost:3000'
 const MIN_REQUIRED_NEXTCLOUD_VERSION = 27
 const MIN_REQUIRED_TALK_VERSION = 17
-const MIN_REQUIRED_BUILT_IN_TALK_VERSION = '17.0.0'
+const MIN_REQUIRED_BUILT_IN_TALK_VERSION = '18.0.0'
 
 module.exports = {
 	BASE_TITLE,


### PR DESCRIPTION
### ☑️ Resolves

* We always build Talk Desktop with the latest released Talk
* Require only latest released stable version of Talk - currently 18
* Remove support for Babel in Webpack config used from Talk 17