### PR TITLE
build: remove hotfix for TS files used for Talk 19 betas

### DIFF
--- a/webpack.renderer.config.js
+++ b/webpack.renderer.config.js
@@ -119,9 +119,6 @@ const webpackRendererConfig = mergeWithRules({
 	},
 
 	resolve: {
-		// FIXME: temporary solution to allow import TS modules without extension in Talk
-		extensions: ['.js', '.ts'],
-
 		alias: {
 			'@talk': TALK_PATH,
 			...createPatcherAliases('@nextcloud/initial-state'),


### PR DESCRIPTION
### ☑️ Resolves

* Was required only for one release with Talk 19.0.0-beta.1
* Not needed after https://github.com/nextcloud/spreed/pull/11770
