### PR TITLE
fix(patchers): patch router without permanent absolute _oc_webroot

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@nextcloud/capabilities": "^1.1.0",
         "@nextcloud/event-bus": "^3.1.0",
         "@nextcloud/l10n": "^2.2.0",
+        "@nextcloud/router": "^3.0.0",
         "@nextcloud/vue": "^8.11.1",
         "core-js": "^3.36.1",
         "electron-squirrel-startup": "^1.0.0",
@@ -4180,6 +4181,19 @@
         "npm": "^9.0.0"
       }
     },
+    "node_modules/@nextcloud/axios/node_modules/@nextcloud/router": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@nextcloud/router/-/router-2.2.1.tgz",
+      "integrity": "sha512-ZRc/WI0RaksEJMz08H/6LimIdP+1A1xTHThCYEghs7VgAKNp5917vT2OKSpG0cMRbIwk0ongFVt5FB5qjy/iFg==",
+      "dependencies": {
+        "@nextcloud/typings": "^1.7.0",
+        "core-js": "^3.6.4"
+      },
+      "engines": {
+        "node": "^20.0.0",
+        "npm": "^10.0.0"
+      }
+    },
     "node_modules/@nextcloud/babel-config": {
       "version": "1.0.0",
       "dev": true,
@@ -4382,6 +4396,19 @@
         "npm": "^9.0.0"
       }
     },
+    "node_modules/@nextcloud/l10n/node_modules/@nextcloud/router": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@nextcloud/router/-/router-2.2.1.tgz",
+      "integrity": "sha512-ZRc/WI0RaksEJMz08H/6LimIdP+1A1xTHThCYEghs7VgAKNp5917vT2OKSpG0cMRbIwk0ongFVt5FB5qjy/iFg==",
+      "dependencies": {
+        "@nextcloud/typings": "^1.7.0",
+        "core-js": "^3.6.4"
+      },
+      "engines": {
+        "node": "^20.0.0",
+        "npm": "^10.0.0"
+      }
+    },
     "node_modules/@nextcloud/logger": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/@nextcloud/logger/-/logger-2.7.0.tgz",
@@ -4396,16 +4423,15 @@
       }
     },
     "node_modules/@nextcloud/router": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@nextcloud/router/-/router-2.1.2.tgz",
-      "integrity": "sha512-Jj5fgjeHT1vVIgOyUGOeHfwk2KgaO77QGfqZAT6GWXvpAsN0mkqwljkg4FkHrQRouYqCE4VnJ5o8/w0DAN89tA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/router/-/router-3.0.0.tgz",
+      "integrity": "sha512-RlPrOPw94yT9rmt3+2sUs2cmWzqhX5eFW+i/EHymJEKgURVtnqCcXjIcAiLTfgsCCdAS1hGapBL8j8rhHk1FHQ==",
       "dependencies": {
-        "@nextcloud/typings": "^1.0.0",
-        "core-js": "^3.6.4"
+        "@nextcloud/typings": "^1.7.0"
       },
       "engines": {
-        "node": "^16.0.0",
-        "npm": "^7.0.0 || ^8.0.0"
+        "node": "^20.0.0",
+        "npm": "^10.0.0"
       }
     },
     "node_modules/@nextcloud/typings": {
@@ -4509,18 +4535,6 @@
       "peerDependencies": {
         "ical.js": "^1.5.0",
         "uuid": "^9.0.0"
-      }
-    },
-    "node_modules/@nextcloud/vue/node_modules/@nextcloud/router": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@nextcloud/router/-/router-3.0.0.tgz",
-      "integrity": "sha512-RlPrOPw94yT9rmt3+2sUs2cmWzqhX5eFW+i/EHymJEKgURVtnqCcXjIcAiLTfgsCCdAS1hGapBL8j8rhHk1FHQ==",
-      "dependencies": {
-        "@nextcloud/typings": "^1.7.0"
-      },
-      "engines": {
-        "node": "^20.0.0",
-        "npm": "^10.0.0"
       }
     },
     "node_modules/@nextcloud/vue/node_modules/@types/unist": {
@@ -23356,6 +23370,17 @@
         "@nextcloud/auth": "^2.1.0",
         "@nextcloud/router": "^2.1.2",
         "axios": "^1.4.0"
+      },
+      "dependencies": {
+        "@nextcloud/router": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/@nextcloud/router/-/router-2.2.1.tgz",
+          "integrity": "sha512-ZRc/WI0RaksEJMz08H/6LimIdP+1A1xTHThCYEghs7VgAKNp5917vT2OKSpG0cMRbIwk0ongFVt5FB5qjy/iFg==",
+          "requires": {
+            "@nextcloud/typings": "^1.7.0",
+            "core-js": "^3.6.4"
+          }
+        }
       }
     },
     "@nextcloud/babel-config": {
@@ -23477,6 +23502,17 @@
         "dompurify": "^3.0.3",
         "escape-html": "^1.0.3",
         "node-gettext": "^3.0.0"
+      },
+      "dependencies": {
+        "@nextcloud/router": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/@nextcloud/router/-/router-2.2.1.tgz",
+          "integrity": "sha512-ZRc/WI0RaksEJMz08H/6LimIdP+1A1xTHThCYEghs7VgAKNp5917vT2OKSpG0cMRbIwk0ongFVt5FB5qjy/iFg==",
+          "requires": {
+            "@nextcloud/typings": "^1.7.0",
+            "core-js": "^3.6.4"
+          }
+        }
       }
     },
     "@nextcloud/logger": {
@@ -23489,12 +23525,11 @@
       }
     },
     "@nextcloud/router": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@nextcloud/router/-/router-2.1.2.tgz",
-      "integrity": "sha512-Jj5fgjeHT1vVIgOyUGOeHfwk2KgaO77QGfqZAT6GWXvpAsN0mkqwljkg4FkHrQRouYqCE4VnJ5o8/w0DAN89tA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/router/-/router-3.0.0.tgz",
+      "integrity": "sha512-RlPrOPw94yT9rmt3+2sUs2cmWzqhX5eFW+i/EHymJEKgURVtnqCcXjIcAiLTfgsCCdAS1hGapBL8j8rhHk1FHQ==",
       "requires": {
-        "@nextcloud/typings": "^1.0.0",
-        "core-js": "^3.6.4"
+        "@nextcloud/typings": "^1.7.0"
       }
     },
     "@nextcloud/typings": {
@@ -23573,14 +23608,6 @@
           "resolved": "https://registry.npmjs.org/@nextcloud/calendar-js/-/calendar-js-6.1.0.tgz",
           "integrity": "sha512-thVS6Bz+TV7rUB+LO5yFbOhdm65zICDRKcHDUquaZiWL9r6TyV9hCYDcP7cDRV+62wZJh8QPmf1E+d7ZFUOVeA==",
           "requires": {}
-        },
-        "@nextcloud/router": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@nextcloud/router/-/router-3.0.0.tgz",
-          "integrity": "sha512-RlPrOPw94yT9rmt3+2sUs2cmWzqhX5eFW+i/EHymJEKgURVtnqCcXjIcAiLTfgsCCdAS1hGapBL8j8rhHk1FHQ==",
-          "requires": {
-            "@nextcloud/typings": "^1.7.0"
-          }
         },
         "@types/unist": {
           "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@nextcloud/capabilities": "^1.1.0",
     "@nextcloud/event-bus": "^3.1.0",
     "@nextcloud/l10n": "^2.2.0",
+    "@nextcloud/router": "^3.0.0",
     "@nextcloud/vue": "^8.11.1",
     "core-js": "^3.36.1",
     "electron-squirrel-startup": "^1.0.0",

--- a/src/talk/renderer/talk.main.js
+++ b/src/talk/renderer/talk.main.js
@@ -25,7 +25,6 @@ import './assets/styles.css'
 import 'regenerator-runtime' // TODO: Why isn't it added on bundling
 import { init, initTalkHashIntegration } from './init.js'
 import { setupWebPage } from '../../shared/setupWebPage.js'
-import { getDesktopMediaSource } from './getDesktopMediaSource.js'
 import { createViewer } from './Viewer/Viewer.js'
 
 // Initially open the welcome page, if not specified
@@ -45,9 +44,5 @@ window.OCA.Viewer = createViewer()
 await import('@talk/src/main.js')
 
 initTalkHashIntegration(OCA.Talk.instance)
-
-window.OCA.Talk.Desktop = {
-	getDesktopMediaSource,
-}
 
 await import('./notifications/notifications.store.js')


### PR DESCRIPTION
### ☑️ Resolves

`@nextcloud/router` cannot be used as it is, because it relies on `window.location` which is different on Desktop app.

#### Before

- For functions returning relative link, `window._oc_webroot` was replaced with an absolute base path instead of relative (`https://nextcloud.ltd/cloud` instead of `/cloud`) to return an absolute link
- For functions returning an absolute link, a complete copy-pasting solution was made

It makes it impossible to work with relative links. And it is just not clean

`getBaseUrl` was literally the same as `getRootUrl`.

#### After

`_oc_webroot` is now kept original (relative) and only when needed temporally replaced with an absolute.

Added `OCA.Talk.Desktop.runWithAbsoluteWebroot` helper to run another function having absolute webroot.

`@nextcloud/router` is now patched with this helper and re-defined `baseURL` default value for simplicity, keeping the original implementation.

### 🖼️ Screenshots

Support for relative links in Talk by new autolink in `NcRichText`

🏚️ Before | 🏡 After
---|---
![relative-links-before](https://github.com/nextcloud/talk-desktop/assets/25978914/7a22b1a4-b73f-4f94-8015-461a33d3ac27) | ![relative-links-after](https://github.com/nextcloud/talk-desktop/assets/25978914/46e6df51-384f-4a61-9e54-8ae155097067)

Also works with absolute links, but **only if there is no base (webroot)**.

![links](https://github.com/nextcloud/talk-desktop/assets/25978914/9976c242-4490-4710-bb1d-99d8b01fe068)
