### PR TITLE
fix(screensharing): better sort and name available sources

### DIFF
--- a/src/talk/renderer/components/DesktopMediaSourcePreview.vue
+++ b/src/talk/renderer/components/DesktopMediaSourcePreview.vue
@@ -24,7 +24,7 @@ import { onBeforeUnmount, onMounted, ref } from 'vue'
 
 import MdiMonitor from 'vue-material-design-icons/Monitor.vue'
 import MdiApplicationOutline from 'vue-material-design-icons/ApplicationOutline.vue'
-import MdiMonitorSpeaker from 'vue-material-design-icons/MonitorSpeaker.vue'
+import MdiVolumeHigh from 'vue-material-design-icons/VolumeHigh.vue'
 
 // On Wayland getting each stream for the live preview requests user to select the source via system dialog again
 // Instead - show static images.
@@ -130,7 +130,7 @@ onBeforeUnmount(() => {
 				alt=""
 				:src="source.icon"
 				class="capture-source__caption-icon">
-			<MdiMonitorSpeaker v-else-if="source.id.startsWith('entire-desktop:')" :size="16" />
+			<MdiVolumeHigh v-else-if="source.id.startsWith('entire-desktop:')" :size="16" />
 			<MdiMonitor v-else-if="source.id.startsWith('screen:')" :size="16" />
 			<MdiApplicationOutline v-else-if="source.id.startsWith('window:')" :size="16" />
 			<span class="capture-source__caption-text">{{ source.name }}</span>


### PR DESCRIPTION
### ☑️ Resolves

Yesterday during the call, I suddenly selected "Entire screen with audio" option, so other attendants heard themselves. This is not the options I wanted to choose, just mixed-up. And that's me who developed the feature 🙈 

### 🚧 Tasks

- [x] Make a name for the entire screen with audio shorter, and with **Audio** in the beginning
- [x] Change the **icon to just audio** instead of screen with a speaker
- [x] Put this option **after** the screen, not as the first option
- [x] Manually sort sources to always have **screens before windows**

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![image](https://github.com/nextcloud/talk-desktop/assets/25978914/54a5d962-1684-4514-9b23-d132ded7277b) | ![image](https://github.com/nextcloud/talk-desktop/assets/25978914/9cca9699-533c-4f32-86a7-02a0e3b59938)

Also, sometimes it was randomly in this order before:

![image](https://github.com/nextcloud/talk-desktop/assets/25978914/fe25c1d2-4a91-4d20-9cb6-5391a168c142)
