### PR TITLE
feat: workaround for multi-account support with several instance with different executable names

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,26 @@
 - Works with limitations:
   - File Viewer — only images and videos
 
+## 👥 Multi-account
+
+Full multi-account currently [is not currently supported](https://github.com/nextcloud/talk-desktop/issues/7).
+
+However, using portable `zip` distribution, you can have several Nextcloud Talk instances run simultaneously. Just rename the executable from default  `Nextcloud Talk` to a custom name. For example: 
+
+```
+/path/to/apps/
+├── home-apps/
+│   └── Nextcloud Talk/
+│       ├── ...
+│       ├── Nextcloud Talk (Home).exe
+│       └── ...
+└── work-apps/
+    └── Nextcloud Talk/
+        ├── ...
+        ├── Nextcloud Talk (Work).exe
+        └── ...
+```
+
 ## 🧑‍💻 Development Setup
 
 ### Initial setup

--- a/src/main.js
+++ b/src/main.js
@@ -42,12 +42,12 @@ const ARGUMENTS = {
 }
 
 /**
- * Separate production and development instances, including application and user data
+ * On production use executable name as application name to allow several independent application instances.
+ * On development use "Nextcloud Talk (dev)" instead of the default "electron".
  */
-if (process.env.NODE_ENV === 'development') {
-	app.setName('Nextcloud Talk (dev)')
-	app.setPath('userData', path.join(app.getPath('appData'), 'Nextcloud Talk (dev)'))
-}
+const APP_NAME = process.env.NODE_ENV !== 'development' ? path.parse(app.getPath('exe')).name : 'Nextcloud Talk (dev)'
+app.setName(APP_NAME)
+app.setPath('userData', path.join(app.getPath('appData'), app.getName()))
 app.setAppUserModelId(app.getName())
 
 /**
@@ -71,6 +71,7 @@ if (process.env.NODE_ENV === 'production') {
 
 ipcMain.on('app:quit', () => app.quit())
 ipcMain.handle('app:getOs', () => getOs())
+ipcMain.handle('app:getAppName', () => app.getName())
 ipcMain.handle('app:getSystemL10n', () => ({
 	locale: app.getLocale().replace('-', '_'),
 	language: app.getPreferredSystemLanguages()[0].replace('-', '_'),

--- a/src/preload.js
+++ b/src/preload.js
@@ -49,6 +49,12 @@ const TALK_DESKTOP = {
 	 */
 	packageInfo,
 	/**
+	 * Get app name
+	 *
+	 * @return {Promise<string>}
+	 */
+	getAppName: () => ipcRenderer.invoke('app:getAppName'),
+	/**
 	 * Quit the application
 	 */
 	quit: () => ipcRenderer.send('app:quit'),

--- a/src/shared/setupWebPage.js
+++ b/src/shared/setupWebPage.js
@@ -84,6 +84,7 @@ async function applyL10n() {
 
 /**
  * Make all required initial setup for the web page:
+ * - set title according to app name
  * - restore app data
  * - get OS info
  * - apply theme to HTML data-attrs
@@ -91,6 +92,7 @@ async function applyL10n() {
  * - register translation bundles for Talk and Talk Desktop
  */
 export async function setupWebPage() {
+	document.title = await window.TALK_DESKTOP.getAppName()
 	initGlobals()
 	appData.restore()
 	window.OS = await window.TALK_DESKTOP.getOs()


### PR DESCRIPTION
### ☑️ Resolves

* Multi-account support is covered by https://github.com/nextcloud/talk-desktop/issues/7
* But full multi-account support is not a simple feature...
* As a temporal workaround allow renaming executable to have several simultaneously running Talk Desktop instances
* Also useful for testing federations

```
/path/to/apps/
├── home-apps/
│   └── Nextcloud Talk/
│       ├── ...
│       ├── Nextcloud Talk (Home).exe
│       └── ...
└── work-apps/
    └── Nextcloud Talk/
        ├── ...
        ├── Nextcloud Talk (Work).exe
        └── ...
```

### 🖼️ Screenshots

![image](https://github.com/nextcloud/talk-desktop/assets/25978914/ef189cc7-ebf7-4e95-bf63-a8ac33448b2f)