### PR TITLE
feat(notifications): flash or bounce icon on new notification

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -218,6 +218,24 @@ app.whenReady().then(async () => {
 		})
 	})
 
+	let macDockBounceId
+	ipcMain.on('talk:flashAppIcon', async (event, shouldFlash) => {
+		// MacOS has no "flashing" but "bouncing" of the dock icon
+		if (isMac()) {
+			// Stop previous bounce if any
+			if (macDockBounceId) {
+				app.dock.cancelBounce(macDockBounceId)
+				macDockBounceId = undefined
+			}
+			// (Re)start bouncing if needed
+			if (shouldFlash) {
+				macDockBounceId = app.dock.bounce()
+			}
+		} else {
+			mainWindow.flashFrame(shouldFlash)
+		}
+	})
+
 	ipcMain.handle('talk:focus', async (event) => focusMainWindow())
 
 	ipcMain.handle('authentication:openLoginWebView', async (event, serverUrl) => openLoginWebView(mainWindow, serverUrl))

--- a/src/preload.js
+++ b/src/preload.js
@@ -90,6 +90,12 @@ const TALK_DESKTOP = {
 	 */
 	setBadgeCount: (count) => ipcRenderer.invoke('app:setBadgeCount', count),
 	/**
+	 * Start or stop flashing (on Windows) or bouncing (on Mac) of app icon
+	 *
+	 * @param {boolean} shouldFlash - True to enable, false to disable
+	 */
+	flashAppIcon: (shouldFlash) => ipcRenderer.send('talk:flashAppIcon', shouldFlash),
+	/**
 	 * Get available desktop capture sources: screens and windows
 	 *
 	 * @return {Promise<{ id: string, name: string, icon?: string }[]|null>}

--- a/src/talk/renderer/notifications/notifications.store.js
+++ b/src/talk/renderer/notifications/notifications.store.js
@@ -100,10 +100,10 @@ export function createNotificationStore() {
 		if (notifications.length > _oldcount) {
 			_oldcount = notifications.length
 			if (state.backgroundFetching && document.hidden) {
+				window.TALK_DESKTOP.setBadgeCount()
+				window.TALK_DESKTOP.flashAppIcon(true)
 				// If we didn't already highlight, store the title so we can restore on tab-view
 				if (!document.title.startsWith('* ')) {
-					window.TALK_DESKTOP.setBadgeCount()
-					window.TALK_DESKTOP.flashAppIcon(true)
 					document.title = '* ' + document.title
 				}
 			}

--- a/src/talk/renderer/notifications/notifications.store.js
+++ b/src/talk/renderer/notifications/notifications.store.js
@@ -103,6 +103,7 @@ export function createNotificationStore() {
 				// If we didn't already highlight, store the title so we can restore on tab-view
 				if (!document.title.startsWith('* ')) {
 					window.TALK_DESKTOP.setBadgeCount()
+					window.TALK_DESKTOP.flashAppIcon(true)
 					document.title = '* ' + document.title
 				}
 			}
@@ -115,8 +116,8 @@ export function createNotificationStore() {
 	 * the Talk might have altered it.
 	 */
 	function _restoreTitle() {
-		// Remove the badge
 		window.TALK_DESKTOP.setBadgeCount(0)
+		window.TALK_DESKTOP.flashAppIcon(false)
 		if (document.title.startsWith('* ')) {
 			document.title = document.title.substring(2)
 		}


### PR DESCRIPTION
### ☑️ Resolves

* Issue #388
* Also fixed an issue when sometimes there was a race condition with Talk around adding `* ` to the title, which skipped icon flushing (see: https://github.com/nextcloud/talk-desktop/issues/291#issuecomment-2068721124)

### 🖼️ Screenshots

![flash](https://github.com/nextcloud/talk-desktop/assets/25978914/7f722017-f374-4634-aa23-c2393c34f5ab)

![flash-mac](https://github.com/nextcloud/talk-desktop/assets/25978914/05444b48-6a22-455b-a49a-a887987dd02c)
