### PR TITLE
build: use pwsh for release:package on Windows

### DIFF
--- a/scripts/prepare-release-packages.mjs
+++ b/scripts/prepare-release-packages.mjs
@@ -6,7 +6,7 @@
 const TALK_PATH = './out/.temp/spreed/'
 const talkDotGit = `${TALK_PATH}.git`
 
-import { $, echo, spinner, argv, fs, os, usePowerShell } from 'zx'
+import { $, echo, spinner, argv, fs, os, usePwsh } from 'zx'
 
 $.quiet = true
 
@@ -113,7 +113,7 @@ async function prepareRelease() {
 }
 
 if (os.platform() === 'win32') {
-	usePowerShell()
+	usePwsh()
 }
 
 if (argv.help) {


### PR DESCRIPTION
### ☑️ Resolves

- ~~⚠️ Waiting for the release~~
- After https://github.com/nextcloud/talk-desktop/pull/602 `release:package` doesn't work on Windows. Manual setting `pwsh` (modern `PowerShell v7`) was replaced with `usePowerShell` that uses old unsupported and yet default one `PowerShell v5` instead of new `PowerShell v7+`.

```
At line:1 char:24
+ npm run package:windows && npm run make:windows; exit $LastExitCode
+                         ~~
The token '&&' is not a valid statement separator in this version.
    + CategoryInfo          : ParserError: (:) [], ParentContainsErrorRecordException
    + FullyQualifiedErrorId : InvalidEndOfLine
```

This PR sets up `pwsh` with new `usePwsh` from `zx@8.1.0`.