### PR TITLE
fix(talk): define default outline color for focus visible

### DIFF
--- a/src/talk/renderer/assets/styles.css
+++ b/src/talk/renderer/assets/styles.css
@@ -27,3 +27,7 @@
 	*/
 	box-sizing: border-box;
 }
+
+:focus-visible {
+	outline-color: var(--color-main-text);
+}


### PR DESCRIPTION
### ☑️ Resolves

* Outline color is a bit unpredictable and may look weird
* Use `var(--color-main-text)` as a default value when it is not defined explicitly 

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![image](https://github.com/nextcloud/talk-desktop/assets/25978914/b5e2a6de-129b-46e0-9edd-12260fe77298) | ![image](https://github.com/nextcloud/talk-desktop/assets/25978914/a6974751-0392-444e-b23f-af70ec1819c8)
![image](https://github.com/nextcloud/talk-desktop/assets/25978914/ac8643bb-a47b-41ca-ae88-b4e346445346) | ![image](https://github.com/nextcloud/talk-desktop/assets/25978914/1c4658f4-24b8-4faf-91f6-ba51e2237c2b)


