### PR TITLE
WIP: alternative user status design

### DIFF
--- a/src/talk/renderer/UserStatus/components/UserStatusForm.vue
+++ b/src/talk/renderer/UserStatus/components/UserStatusForm.vue
@@ -28,7 +28,7 @@ import { translate as t } from '@nextcloud/l10n'
 import { useUserStatusStore } from '../userStatus.store.js'
 import UserStatusFormClearAt from './UserStatusFormClearAt.vue'
 import UserStatusFormCustomMessage from './UserStatusFormCustomMessage.vue'
-import UserStatusFormStatusType from './UserStatusFormStatusType.vue'
+// import UserStatusFormStatusType from './UserStatusFormStatusType.vue'
 import UserStatusFormPredefinedOption from './UserStatusFormPredefinedOption.vue'
 import { convertPredefinedStatusToUserStatus } from '../userStatus.utils.js'
 
@@ -86,7 +86,7 @@ const revertStatus = async () => {
 
 <template>
 	<div class="user-status-form">
-		<UserStatusFormStatusType class="user-status-form__row" :status="userStatus.status" @update:status="patchStatus({ status: $event })" />
+		<!--		<UserStatusFormStatusType class="user-status-form__row" :status="userStatus.status" @update:status="patchStatus({ status: $event })" />-->
 
 		<NcNoteCard v-if="backupStatus" type="info" class="user-status-form__row">
 			{{ t('talk_desktop', 'Your status was set automatically') }}
@@ -131,8 +131,11 @@ const revertStatus = async () => {
 		</NcButton>
 
 		<div class="user-status-form__buttons">
-			<NcButton type="primary" :disabled="!isDirty" @click="save">
-				{{ t('talk_desktop', 'Set user status') }}
+			<NcButton type="primary"
+				wide
+				:disabled="!isDirty"
+				@click="save">
+				{{ t('talk_desktop', 'Set custom status') }}
 			</NcButton>
 		</div>
 	</div>

--- a/src/talk/renderer/UserStatus/components/UserStatusForm.vue
+++ b/src/talk/renderer/UserStatus/components/UserStatusForm.vue
@@ -28,7 +28,7 @@ import { translate as t } from '@nextcloud/l10n'
 import { useUserStatusStore } from '../userStatus.store.js'
 import UserStatusFormClearAt from './UserStatusFormClearAt.vue'
 import UserStatusFormCustomMessage from './UserStatusFormCustomMessage.vue'
-// import UserStatusFormStatusType from './UserStatusFormStatusType.vue'
+import UserStatusFormStatusType from './UserStatusFormStatusType.vue'
 import UserStatusFormPredefinedOption from './UserStatusFormPredefinedOption.vue'
 import { convertPredefinedStatusToUserStatus } from '../userStatus.utils.js'
 
@@ -86,7 +86,7 @@ const revertStatus = async () => {
 
 <template>
 	<div class="user-status-form">
-		<!--		<UserStatusFormStatusType class="user-status-form__row" :status="userStatus.status" @update:status="patchStatus({ status: $event })" />-->
+		<UserStatusFormStatusType class="user-status-form__row" :status="userStatus.status" @update:status="patchStatus({ status: $event })" />
 
 		<NcNoteCard v-if="backupStatus" type="info" class="user-status-form__row">
 			{{ t('talk_desktop', 'Your status was set automatically') }}

--- a/src/talk/renderer/UserStatus/components/UserStatusFormStatusType.vue
+++ b/src/talk/renderer/UserStatus/components/UserStatusFormStatusType.vue
@@ -20,11 +20,13 @@
   -->
 
 <script setup>
-import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
+import { computed } from 'vue'
+import { translate as t } from '@nextcloud/l10n'
+import NcSelect from '@nextcloud/vue/dist/Components/NcSelect.js'
 import NcUserStatusIcon from '@nextcloud/vue/dist/Components/NcUserStatusIcon.js'
 import { userStatusTranslations } from '../userStatus.utils.js'
 
-defineProps({
+const props = defineProps({
 	status: {
 		type: String,
 		required: true,
@@ -32,29 +34,68 @@ defineProps({
 })
 
 const emit = defineEmits(['update:status'])
+
+const options = [
+	{
+		value: 'online',
+		label: userStatusTranslations.online,
+	},
+	{
+		value: 'away',
+		label: userStatusTranslations.away,
+	},
+	{
+		value: 'dnd',
+		label: userStatusTranslations.dnd,
+	},
+	{
+		value: 'offline',
+		label: userStatusTranslations.offline,
+	},
+]
+
+const selectedOption = computed(() => options.find((option) => option.value === props.status))
 </script>
 
 <template>
 	<div class="user-status-form-status">
-		<NcButton v-for="option in ['online', 'away', 'dnd', 'offline']"
-			:key="option"
-			type="tertiary"
-			alignment="start"
-			:pressed="option === status"
-			wide
-			@click="emit('update:status', option)">
-			<template #icon>
-				<NcUserStatusIcon :status="option" />
+		<NcSelect class="user-status__select"
+			:aria-label-compobox="t('talk_desktop', 'Online status')"
+			:append-to-body="false"
+			:clearable="false"
+			:searchable="false"
+			:options="options"
+			:value="selectedOption"
+			@input="emit('update:status', $event.value)">
+			<template #selected-option="option">
+				<div class="user-status-select__option">
+					<NcUserStatusIcon :status="option.value" :size="20" />
+					<span>{{ option.label }}</span>
+				</div>
 			</template>
-			{{ userStatusTranslations[option] }}
-		</NcButton>
+			<template #option="option">
+				<div class="user-status-select__option">
+					<NcUserStatusIcon :status="option.value" :size="20" />
+					<span>{{ option.label }}</span>
+				</div>
+			</template>
+		</NcSelect>
 	</div>
 </template>
 
 <style scoped lang="scss">
 .user-status-form-status {
-	display: grid;
-	grid-template-columns: repeat(2, 1fr);
-	gap: var(--default-grid-baseline);
+	height: var(--default-clickable-area);
+}
+
+.user-status__select {
+	width: 100%;
+	--vs-border-color: transparent;
+}
+
+.user-status-select__option {
+	display: flex;
+	gap: calc(2 * var(--default-grid-baseline));
+	align-items: center;
 }
 </style>

--- a/src/talk/renderer/UserStatus/index.js
+++ b/src/talk/renderer/UserStatus/index.js
@@ -1,0 +1,24 @@
+/*
+ * @copyright Copyright (c) 2024 Grigorii Shartsev <me@shgk.me>
+ *
+ * @author Grigorii K. Shartsev <me@shgk.me>
+ *
+ * @license AGPL-3.0-or-later
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// eslint-disable-next-line import/named
+export { default as UserStatusDialog } from './UserStatusDialog.vue'
+export { useUserStatusStore } from './userStatus.store.js'

--- a/src/talk/renderer/components/UiMenuItem.vue
+++ b/src/talk/renderer/components/UiMenuItem.vue
@@ -73,6 +73,7 @@ export default {
 	border-radius: 6px; /* Same as NcActionButton */
 	min-height: var(--default-clickable-area);
 	padding: .5em var(--menu-item-gap);
+	text-align: left;
 	font-weight: normal;
 	width: 100%;
 	gap: var(--menu-item-gap);
@@ -91,5 +92,9 @@ export default {
 	align-items: center;
 	justify-content: center;
 	width: 20px
+}
+
+.menu-item__text {
+	flex: 1;
 }
 </style>

--- a/src/talk/renderer/components/UiMenuSeparator.vue
+++ b/src/talk/renderer/components/UiMenuSeparator.vue
@@ -1,7 +1,7 @@
 <!--
   - @copyright Copyright (c) 2024 Grigorii Shartsev <me@shgk.me>
   -
-  - @author Grigorii Shartsev <me@shgk.me>
+  - @author Grigorii K. Shartsev <me@shgk.me>
   -
   - @license AGPL-3.0-or-later
   -
@@ -19,19 +19,17 @@
   - along with this program. If not, see <http://www.gnu.org/licenses/>.
   -->
 
-<script setup>
-import NcDialog from '@nextcloud/vue/dist/Components/NcDialog.js'
-import { translate as t } from '@nextcloud/l10n'
-import { useUserStatusStore } from './userStatus.store.js'
-import UserStatusForm from './components/UserStatusForm.vue'
+<script setup lang="ts">
 
-const emit = defineEmits(['close'])
-
-const userStatusStore = useUserStatusStore()
 </script>
 
 <template>
-	<NcDialog :name="t('talk_desktop', 'Custom user status')" size="small" @closing="emit('close')">
-		<UserStatusForm v-if="userStatusStore.userStatus" @submit="emit('close')" />
-	</NcDialog>
+	<li class="menu-item-separator" />
 </template>
+
+<style scoped lang="scss">
+.menu-item-separator {
+	border-top: 1px solid var(--color-border-dark);
+	margin:  var(--default-grid-baseline) 0;
+}
+</style>

--- a/src/talk/renderer/components/UserMenu.vue
+++ b/src/talk/renderer/components/UserMenu.vue
@@ -37,83 +37,119 @@
 
 			<template #default>
 				<UiMenu ref="userMenuElement" aria-label="Settings menu">
-					<UiMenuItem tag="a"
-						:href="userProfileLink"
-						target="_blank">
-						<div><strong>{{ user['display-name'] }}</strong></div>
-						<div>{{ t('talk_desktop', 'View profile') }}</div>
-					</UiMenuItem>
-					<template v-if="userStatusStore.userStatus">
-						<UiMenuSeparator />
-						<li>
-							<UserStatusFormStatusType :status="userStatusStore.userStatus.status" @update:status="handleUserStatusChange($event)" @click.native.stop />
-						</li>
-						<UiMenuItem key="custom-status" tag="button" @click.native="isUserStatusDialogOpen = true">
+					<template v-if="userStatusSubMenuOpen">
+						<UiMenuItem tag="button" @click.native.stop="userStatusSubMenuOpen = false">
 							<template #icon>
-								<span v-if="userStatusStore.userStatus.icon" style="font-size: 20px">
-									{{ userStatusStore.userStatus.icon }}
-								</span>
-								<MdiEmoticonOutline v-else :size="20" />
+								<MdiChevronLeft :size="20" />
 							</template>
-							<template v-if="userStatusStore.userStatus.message">
+							{{ t('talk_desktop', 'Back') }}
+						</UiMenuItem>
+						<UiMenuItem v-for="status in ['online', 'away', 'dnd', 'invisible']"
+							:key="status"
+							tag="button"
+							@click.native.stop="handleUserStatusChange(status)">
+							<template #icon>
+								<NcUserStatusIcon :status="status" />
+							</template>
+							<span style="display: flex">
+								<span>
+									{{ userStatusTranslations[status] }}
+								</span>
+								<span v-if="status === userStatusStore.userStatus.status" style="margin-left: auto">
+									<MdiCheck :size="20" />
+								</span>
+							</span>
+						</UiMenuItem>
+					</template>
+					<template v-else>
+						<UiMenuItem tag="a"
+							:href="userProfileLink"
+							target="_blank">
+							<div><strong>{{ user['display-name'] }}</strong></div>
+							<div>{{ t('talk_desktop', 'View profile') }}</div>
+						</UiMenuItem>
+						<template v-if="userStatusStore.userStatus">
+							<UiMenuSeparator />
+							<UiMenuItem tag="button" @click.native.stop="userStatusSubMenuOpen = true">
+								<template #icon>
+									<NcUserStatusIcon :status="userStatusStore.userStatus.status" />
+								</template>
 								<span style="display: flex">
 									<span>
-										{{ userStatusStore.userStatus.message }}
-									</span>
-									<span style="margin-left: auto">
-										<MdiPencil :size="20" />
-									</span>
-								</span>
-							</template>
-							<template v-else>
-								<span style="display: flex">
-									<span>
-										{{ t('talk_desktop', 'Set custom status') }}
+										{{ userStatusTranslations[userStatusStore.userStatus.status] }}
 									</span>
 									<span style="margin-left: auto">
 										<MdiChevronRight :size="20" />
 									</span>
 								</span>
-							</template>
-						</UiMenuItem>
-						<UiMenuSeparator />
-						<UiMenuItem tag="button" @click.native="reload">
-							<template #icon>
-								<MdiReload />
-							</template>
-							{{ t('talk_desktop', 'Force reload') }}
-						</UiMenuItem>
-						<UiMenuItem tag="a" :href="$options.packageInfo.bugs" target="_blank">
-							<template #icon>
-								<MdiBug />
-							</template>
-							{{ t('talk_desktop', 'Report a bug') }}
-						</UiMenuItem>
-						<UiMenuSeparator />
-						<UiMenuItem tag="a" :href="talkWebLink" target="_blank">
-							<template #icon>
-								<MdiWeb />
-							</template>
-							<template #default>
-								{{ t('talk_desktop', 'Open in Web-Browser') }}
-							</template>
-						</UiMenuItem>
-						<UiMenuItem tag="button" @click.native="showHelp">
-							<template #icon>
-								<MdiInformationOutline />
-							</template>
-							<template #default>
-								{{ t('talk_desktop', 'About') }}
-							</template>
-						</UiMenuItem>
-						<UiMenuItem tag="button" @click.native="$emit('logout')">
-							<template #icon>
-								<MdiPower />
-							</template>
-							<template #default>
-								{{ t('talk_desktop', 'Log out') }}
-							</template>
-						</UiMenuItem>
+							</UiMenuItem>
+							<UiMenuItem key="custom-status" tag="button" @click.native="isUserStatusDialogOpen = true">
+								<template #icon>
+									<span v-if="userStatusStore.userStatus.icon" style="font-size: 20px">
+										{{ userStatusStore.userStatus.icon }}
+									</span>
+									<MdiEmoticonOutline v-else :size="20" />
+								</template>
+								<template v-if="userStatusStore.userStatus.message">
+									<span style="display: flex">
+										<span>
+											{{ userStatusStore.userStatus.message }}
+										</span>
+										<span style="margin-left: auto">
+											<MdiPencil :size="20" />
+										</span>
+									</span>
+								</template>
+								<template v-else>
+									<span style="display: flex">
+										<span>
+											{{ t('talk_desktop', 'Set custom status') }}
+										</span>
+										<span style="margin-left: auto">
+											<MdiChevronRight :size="20" />
+										</span>
+									</span>
+								</template>
+							</UiMenuItem>
+							<UiMenuSeparator />
+							<UiMenuItem tag="button" @click.native="reload">
+								<template #icon>
+									<MdiReload />
+								</template>
+								{{ t('talk_desktop', 'Force reload') }}
+							</UiMenuItem>
+							<UiMenuItem tag="a" :href="$options.packageInfo.bugs" target="_blank">
+								<template #icon>
+									<MdiBug />
+								</template>
+								{{ t('talk_desktop', 'Report a bug') }}
+							</UiMenuItem>
+							<UiMenuSeparator />
+							<UiMenuItem tag="a" :href="talkWebLink" target="_blank">
+								<template #icon>
+									<MdiWeb />
+								</template>
+								<template #default>
+									{{ t('talk_desktop', 'Open in Web-Browser') }}
+								</template>
+							</UiMenuItem>
+							<UiMenuItem tag="button" @click.native="showHelp">
+								<template #icon>
+									<MdiInformationOutline />
+								</template>
+								<template #default>
+									{{ t('talk_desktop', 'About') }}
+								</template>
+							</UiMenuItem>
+							<UiMenuItem tag="button" @click.native="$emit('logout')">
+								<template #icon>
+									<MdiPower />
+								</template>
+								<template #default>
+									{{ t('talk_desktop', 'Log out') }}
+								</template>
+							</UiMenuItem>
+						</template>
 					</template>
 				</UiMenu>
 			</template>
@@ -129,6 +165,7 @@ import MdiCheck from 'vue-material-design-icons/Check.vue'
 import MdiChevronDown from 'vue-material-design-icons/ChevronDown.vue'
 import MdiChevronUp from 'vue-material-design-icons/ChevronUp.vue'
 import MdiChevronRight from 'vue-material-design-icons/ChevronRight.vue'
+import MdiChevronLeft from 'vue-material-design-icons/ChevronLeft.vue'
 import MdiEmoticonOutline from 'vue-material-design-icons/EmoticonOutline.vue'
 import MdiInformationOutline from 'vue-material-design-icons/InformationOutline.vue'
 import MdiPencil from 'vue-material-design-icons/Pencil.vue'
@@ -147,7 +184,7 @@ import UserStatusDialog from '../UserStatus/UserStatusDialog.vue'
 import { getVisibleUserStatus, userStatusTranslations } from '../UserStatus/userStatus.utils.js'
 import UiMenuSeparator from './UiMenuSeparator.vue'
 import { ref } from 'vue'
-import UserStatusFormStatusType from '../UserStatus/components/UserStatusFormStatusType.vue'
+// import UserStatusFormStatusType from '../UserStatus/components/UserStatusFormStatusType.vue'
 
 export default {
 	name: 'UserMenu',
@@ -155,16 +192,17 @@ export default {
 	packageInfo: window.TALK_DESKTOP.packageInfo,
 
 	components: {
-		UserStatusFormStatusType,
+		// UserStatusFormStatusType,
 		UiMenuSeparator,
 		UserStatusDialog,
 		UiMenuItem,
 		UiMenu,
 		MdiBug,
 		MdiCheck,
-		MdiChevronDown,
-		MdiChevronUp,
+		// MdiChevronDown,
+		// MdiChevronUp,
 		MdiChevronRight,
+		MdiChevronLeft,
 		MdiEmoticonOutline,
 		MdiInformationOutline,
 		MdiPencil,

--- a/src/talk/renderer/components/UserMenu.vue
+++ b/src/talk/renderer/components/UserMenu.vue
@@ -44,48 +44,41 @@
 						<div>{{ t('talk_desktop', 'View profile') }}</div>
 					</UiMenuItem>
 					<UiMenuSeparator />
-					<NcPopover v-if="userMenuElement && userStatusStore.userStatus"
-						placement="left-start"
-						:shown.sync="userStatusSubMenuOpen"
-						:container="userMenuElement.$el"
-						no-auto-focus>
-						<template #trigger="{ attrs }">
-							<UiMenuItem tag="button"
-								v-bind="attrs">
+					<UiMenuItem tag="button" @click.native.stop="userStatusSubMenuOpen = !userStatusSubMenuOpen">
+						<template #icon>
+							<NcUserStatusIcon :status="userStatusStore.userStatus.status" />
+						</template>
+						<span style="display: flex">
+							<span>
+								{{ userStatusTranslations[userStatusStore.userStatus.status] }}
+							</span>
+							<span style="margin-left: auto">
+								<MdiChevronUp v-if="userStatusSubMenuOpen" :size="20" />
+								<MdiChevronDown v-else :size="20" />
+							</span>
+						</span>
+					</UiMenuItem>
+					<li v-if="userStatusSubMenuOpen">
+						<ul>
+							<UiMenuItem v-for="status in ['online', 'away', 'dnd', 'invisible']"
+								:key="status"
+								tag="button"
+								@click.native.stop="handleUserStatusChange(status)">
 								<template #icon>
-									<NcUserStatusIcon :status="userStatusStore.userStatus.status" />
+									<NcUserStatusIcon :status="status" />
 								</template>
 								<span style="display: flex">
 									<span>
-										{{ userStatusTranslations[userStatusStore.userStatus.status] }}
+										{{ userStatusTranslations[status] }}
 									</span>
-									<span style="margin-left: auto">
-										<MdiChevronRight :size="20" />
+									<span v-if="status === userStatusStore.userStatus.status" style="margin-left: auto">
+										<MdiCheck :size="20" />
 									</span>
 								</span>
 							</UiMenuItem>
-						</template>
-						<template #default>
-							<UiMenu aria-label="Online status">
-								<UiMenuItem v-for="status in ['online', 'away', 'dnd', 'invisible']"
-									:key="status"
-									tag="button"
-									@click.native.stop="handleUserStatusChange(status)">
-									<template #icon>
-										<NcUserStatusIcon :status="status" />
-									</template>
-									<span style="display: flex">
-										<span>
-											{{ userStatusTranslations[status] }}
-										</span>
-										<span v-if="status === userStatusStore.userStatus.status" style="margin-left: auto">
-											<MdiCheck :size="20" />
-										</span>
-									</span>
-								</UiMenuItem>
-							</UiMenu>
-						</template>
-					</NcPopover>
+						</ul>
+					</li>
+					<UiMenuSeparator />
 					<UiMenuItem key="custom-status" tag="button" @click.native="isUserStatusDialogOpen = true">
 						<template #icon>
 							<span v-if="userStatusStore.userStatus.icon" style="font-size: 20px">
@@ -163,6 +156,8 @@
 <script>
 import MdiBug from 'vue-material-design-icons/Bug.vue'
 import MdiCheck from 'vue-material-design-icons/Check.vue'
+import MdiChevronDown from 'vue-material-design-icons/ChevronDown.vue'
+import MdiChevronUp from 'vue-material-design-icons/ChevronUp.vue'
 import MdiChevronRight from 'vue-material-design-icons/ChevronRight.vue'
 import MdiEmoticonOutline from 'vue-material-design-icons/EmoticonOutline.vue'
 import MdiInformationOutline from 'vue-material-design-icons/InformationOutline.vue'
@@ -195,6 +190,8 @@ export default {
 		UiMenu,
 		MdiBug,
 		MdiCheck,
+		MdiChevronDown,
+		MdiChevronUp,
 		MdiChevronRight,
 		MdiEmoticonOutline,
 		MdiInformationOutline,

--- a/src/talk/renderer/components/UserMenu.vue
+++ b/src/talk/renderer/components/UserMenu.vue
@@ -42,109 +42,110 @@
 						target="_blank">
 						<div><strong>{{ user['display-name'] }}</strong></div>
 						<div>{{ t('talk_desktop', 'View profile') }}</div>
-					</UiMenuItem>
-					<UiMenuSeparator />
-					<UiMenuItem tag="button" @click.native.stop="userStatusSubMenuOpen = !userStatusSubMenuOpen">
-						<template #icon>
-							<NcUserStatusIcon :status="userStatusStore.userStatus.status" />
-						</template>
-						<span style="display: flex">
-							<span>
-								{{ userStatusTranslations[userStatusStore.userStatus.status] }}
+					</UiMenuItem><template v-if="userStatusStore.userStatus">
+						<UiMenuSeparator />
+						<UiMenuItem tag="button" @click.native.stop="userStatusSubMenuOpen = !userStatusSubMenuOpen">
+							<template #icon>
+								<NcUserStatusIcon :status="userStatusStore.userStatus.status" />
+							</template>
+							<span style="display: flex">
+								<span>
+									{{ userStatusTranslations[userStatusStore.userStatus.status] }}
+								</span>
+								<span style="margin-left: auto">
+									<MdiChevronUp v-if="userStatusSubMenuOpen" :size="20" />
+									<MdiChevronDown v-else :size="20" />
+								</span>
 							</span>
-							<span style="margin-left: auto">
-								<MdiChevronUp v-if="userStatusSubMenuOpen" :size="20" />
-								<MdiChevronDown v-else :size="20" />
-							</span>
-						</span>
-					</UiMenuItem>
-					<li v-if="userStatusSubMenuOpen">
-						<ul>
-							<UiMenuItem v-for="status in ['online', 'away', 'dnd', 'invisible']"
-								:key="status"
-								tag="button"
-								@click.native.stop="handleUserStatusChange(status)">
-								<template #icon>
-									<NcUserStatusIcon :status="status" />
-								</template>
+						</UiMenuItem>
+						<li v-if="userStatusSubMenuOpen">
+							<ul>
+								<UiMenuItem v-for="status in ['online', 'away', 'dnd', 'invisible']"
+									:key="status"
+									tag="button"
+									@click.native.stop="handleUserStatusChange(status)">
+									<template #icon>
+										<NcUserStatusIcon :status="status" />
+									</template>
+									<span style="display: flex">
+										<span>
+											{{ userStatusTranslations[status] }}
+										</span>
+										<span v-if="status === userStatusStore.userStatus.status" style="margin-left: auto">
+											<MdiCheck :size="20" />
+										</span>
+									</span>
+								</UiMenuItem>
+							</ul>
+						</li>
+						<UiMenuSeparator />
+						<UiMenuItem key="custom-status" tag="button" @click.native="isUserStatusDialogOpen = true">
+							<template #icon>
+								<span v-if="userStatusStore.userStatus.icon" style="font-size: 20px">
+									{{ userStatusStore.userStatus.icon }}
+								</span>
+								<MdiEmoticonOutline v-else :size="20" />
+							</template>
+							<template v-if="userStatusStore.userStatus.message">
 								<span style="display: flex">
 									<span>
-										{{ userStatusTranslations[status] }}
+										{{ userStatusStore.userStatus.message }}
 									</span>
-									<span v-if="status === userStatusStore.userStatus.status" style="margin-left: auto">
-										<MdiCheck :size="20" />
+									<span style="margin-left: auto">
+										<MdiPencil :size="20" />
 									</span>
 								</span>
-							</UiMenuItem>
-						</ul>
-					</li>
-					<UiMenuSeparator />
-					<UiMenuItem key="custom-status" tag="button" @click.native="isUserStatusDialogOpen = true">
-						<template #icon>
-							<span v-if="userStatusStore.userStatus.icon" style="font-size: 20px">
-								{{ userStatusStore.userStatus.icon }}
-							</span>
-							<MdiEmoticonOutline v-else :size="20" />
-						</template>
-						<template v-if="userStatusStore.userStatus.message">
-							<span style="display: flex">
-								<span>
-									{{ userStatusStore.userStatus.message }}
+							</template>
+							<template v-else>
+								<span style="display: flex">
+									<span>
+										{{ t('talk_desktop', 'Set custom status') }}
+									</span>
+									<span style="margin-left: auto">
+										<MdiChevronRight :size="20" />
+									</span>
 								</span>
-								<span style="margin-left: auto">
-									<MdiPencil :size="20" />
-								</span>
-							</span>
-						</template>
-						<template v-else>
-							<span style="display: flex">
-								<span>
-									{{ t('talk_desktop', 'Set custom status') }}
-								</span>
-								<span style="margin-left: auto">
-									<MdiChevronRight :size="20" />
-								</span>
-							</span>
-						</template>
-					</UiMenuItem>
-					<UiMenuSeparator />
-					<UiMenuItem tag="button" @click.native="reload">
-						<template #icon>
-							<MdiReload />
-						</template>
-						{{ t('talk_desktop', 'Force reload') }}
-					</UiMenuItem>
-					<UiMenuItem tag="a" :href="$options.packageInfo.bugs" target="_blank">
-						<template #icon>
-							<MdiBug />
-						</template>
-						{{ t('talk_desktop', 'Report a bug') }}
-					</UiMenuItem>
-					<UiMenuSeparator />
-					<UiMenuItem tag="a" :href="talkWebLink" target="_blank">
-						<template #icon>
-							<MdiWeb />
-						</template>
-						<template #default>
-							{{ t('talk_desktop', 'Open in Web-Browser') }}
-						</template>
-					</UiMenuItem>
-					<UiMenuItem tag="button" @click.native="showHelp">
-						<template #icon>
-							<MdiInformationOutline />
-						</template>
-						<template #default>
-							{{ t('talk_desktop', 'About') }}
-						</template>
-					</UiMenuItem>
-					<UiMenuItem tag="button" @click.native="$emit('logout')">
-						<template #icon>
-							<MdiPower />
-						</template>
-						<template #default>
-							{{ t('talk_desktop', 'Log out') }}
-						</template>
-					</UiMenuItem>
+							</template>
+						</UiMenuItem>
+						<UiMenuSeparator />
+						<UiMenuItem tag="button" @click.native="reload">
+							<template #icon>
+								<MdiReload />
+							</template>
+							{{ t('talk_desktop', 'Force reload') }}
+						</UiMenuItem>
+						<UiMenuItem tag="a" :href="$options.packageInfo.bugs" target="_blank">
+							<template #icon>
+								<MdiBug />
+							</template>
+							{{ t('talk_desktop', 'Report a bug') }}
+						</UiMenuItem>
+						<UiMenuSeparator />
+						<UiMenuItem tag="a" :href="talkWebLink" target="_blank">
+							<template #icon>
+								<MdiWeb />
+							</template>
+							<template #default>
+								{{ t('talk_desktop', 'Open in Web-Browser') }}
+							</template>
+						</UiMenuItem>
+						<UiMenuItem tag="button" @click.native="showHelp">
+							<template #icon>
+								<MdiInformationOutline />
+							</template>
+							<template #default>
+								{{ t('talk_desktop', 'About') }}
+							</template>
+						</UiMenuItem>
+						<UiMenuItem tag="button" @click.native="$emit('logout')">
+							<template #icon>
+								<MdiPower />
+							</template>
+							<template #default>
+								{{ t('talk_desktop', 'Log out') }}
+							</template>
+						</UiMenuItem>
+					</template>
 				</UiMenu>
 			</template>
 		</NcPopover>

--- a/src/talk/renderer/components/UserMenu.vue
+++ b/src/talk/renderer/components/UserMenu.vue
@@ -42,43 +42,12 @@
 						target="_blank">
 						<div><strong>{{ user['display-name'] }}</strong></div>
 						<div>{{ t('talk_desktop', 'View profile') }}</div>
-					</UiMenuItem><template v-if="userStatusStore.userStatus">
+					</UiMenuItem>
+					<template v-if="userStatusStore.userStatus">
 						<UiMenuSeparator />
-						<UiMenuItem tag="button" @click.native.stop="userStatusSubMenuOpen = !userStatusSubMenuOpen">
-							<template #icon>
-								<NcUserStatusIcon :status="userStatusStore.userStatus.status" />
-							</template>
-							<span style="display: flex">
-								<span>
-									{{ userStatusTranslations[userStatusStore.userStatus.status] }}
-								</span>
-								<span style="margin-left: auto">
-									<MdiChevronUp v-if="userStatusSubMenuOpen" :size="20" />
-									<MdiChevronDown v-else :size="20" />
-								</span>
-							</span>
-						</UiMenuItem>
-						<li v-if="userStatusSubMenuOpen">
-							<ul>
-								<UiMenuItem v-for="status in ['online', 'away', 'dnd', 'invisible']"
-									:key="status"
-									tag="button"
-									@click.native.stop="handleUserStatusChange(status)">
-									<template #icon>
-										<NcUserStatusIcon :status="status" />
-									</template>
-									<span style="display: flex">
-										<span>
-											{{ userStatusTranslations[status] }}
-										</span>
-										<span v-if="status === userStatusStore.userStatus.status" style="margin-left: auto">
-											<MdiCheck :size="20" />
-										</span>
-									</span>
-								</UiMenuItem>
-							</ul>
+						<li>
+							<UserStatusFormStatusType :status="userStatusStore.userStatus.status" @update:status="handleUserStatusChange($event)" @click.native.stop />
 						</li>
-						<UiMenuSeparator />
 						<UiMenuItem key="custom-status" tag="button" @click.native="isUserStatusDialogOpen = true">
 							<template #icon>
 								<span v-if="userStatusStore.userStatus.icon" style="font-size: 20px">
@@ -178,6 +147,7 @@ import UserStatusDialog from '../UserStatus/UserStatusDialog.vue'
 import { getVisibleUserStatus, userStatusTranslations } from '../UserStatus/userStatus.utils.js'
 import UiMenuSeparator from './UiMenuSeparator.vue'
 import { ref } from 'vue'
+import UserStatusFormStatusType from '../UserStatus/components/UserStatusFormStatusType.vue'
 
 export default {
 	name: 'UserMenu',
@@ -185,6 +155,7 @@ export default {
 	packageInfo: window.TALK_DESKTOP.packageInfo,
 
 	components: {
+		UserStatusFormStatusType,
 		UiMenuSeparator,
 		UserStatusDialog,
 		UiMenuItem,


### PR DESCRIPTION
### ☑️ Resolves

* The problem: too many clicks to just go to DnD, for example, to disable notifications. Opening a menu, opening a dialog box, working in it
* The proposal: separate online status and the custom status
* This is also a common practice for other messengers

### 🖼️ Screenshots

#### Option 1: sub menu

https://github.com/nextcloud/talk-desktop/assets/25978914/d6e16dd0-4a04-4862-8123-32adbace276e

https://github.com/nextcloud/talk-desktop/assets/25978914/6e2d60f0-d667-4d64-8f3a-619c1b9e2da1

#### Option 2: collapsible menu

https://github.com/nextcloud/talk-desktop/assets/25978914/ba7fccb9-b8d6-4763-9518-bf6d9fbabc21

#### Option 3: collapsible "select" menu

https://github.com/nextcloud/talk-desktop/assets/25978914/1692b126-49b3-4226-a4c3-e644c48bf150

### Option 4: Nextcloud-sub-menu

https://github.com/nextcloud/talk-desktop/assets/25978914/a8400ba2-e67f-4d9a-82a8-96cbd0c98a17

