### PR TITLE
release: v0.30.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@
 
 # Changelog
 
+## v0.30.0 - 2024-06-14
+
+### Build-in Talk update
+
+- Built-in Talk in binaries is updated to v19.0.2
+
+### Features
+
+- Add user status support [#26](https://github.com/nextcloud/talk-desktop/issues/26)
+- Flash or bounce icon on a new notification [#388](https://github.com/nextcloud/talk-desktop/issues/388)
+
+### Fixes
+
+- Improve user menu design [#683](https://github.com/nextcloud/talk-desktop/pull/683)
+- Make Talk Desktop user appears "online" on server [#634](https://github.com/nextcloud/talk-desktop/pull/634)
+- Disable sounds on Do-Not-Disturb [#415](https://github.com/nextcloud/talk-desktop/issues/415)
+- Increase the default window size to fit the display and include the join call dialog [#682](https://github.com/nextcloud/talk-desktop/pull/682)
+- Define the default outline color for focus visible [#643](https://github.com/nextcloud/talk-desktop/pull/643)
+
 ## v0.29.0 - 2024-04-19
 
 ### Build-in Talk update

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "talk-desktop",
-  "version": "0.29.0",
+  "version": "0.30.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "talk-desktop",
-      "version": "0.29.0",
+      "version": "0.30.0",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@mdi/svg": "^7.4.47",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "name": "talk-desktop",
   "productName": "Nextcloud Talk",
-  "version": "0.29.0",
+  "version": "0.30.0",
   "description": "Official Desktop client for Nextcloud Talk",
   "bugs": "https://github.com/nextcloud/talk-desktop/issues",
   "license": "AGPL-3.0-or-later",


### PR DESCRIPTION
## v0.30.0 - 2024-06-14

### Build-in Talk update

- Built-in Talk in binaries is updated to v19.0.2

### Features

- Add user status support [#26](https://github.com/nextcloud/talk-desktop/issues/26)
- Flash or bounce icon on a new notification [#388](https://github.com/nextcloud/talk-desktop/issues/388)

### Fixes

- Improve user menu design [#683](https://github.com/nextcloud/talk-desktop/pull/683)
- Make Talk Desktop user appears "online" on server [#634](https://github.com/nextcloud/talk-desktop/pull/634)
- Disable sounds on Do-Not-Disturb [#415](https://github.com/nextcloud/talk-desktop/issues/415)
- Increase the default window size to fit the display and include the join call dialog [#682](https://github.com/nextcloud/talk-desktop/pull/682)
- Define the default outline color for focus visible [#643](https://github.com/nextcloud/talk-desktop/pull/643)