### PR TITLE
chore(package): update author and license fields to match product license

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "talk-desktop",
       "version": "0.29.0",
-      "license": "AGPL-3.0",
+      "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@mdi/svg": "^7.4.47",
         "@nextcloud/axios": "^2.5.0",

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
   "bugs": "https://github.com/nextcloud/talk-desktop/issues",
   "license": "AGPL-3.0",
   "author": {
-    "name": "Grigorii Shartsev",
-    "email": "grigorii.shartsev@nextcloud.com"
+    "name": "Grigorii K. Shartsev",
+    "email": "me@shgk.me"
   },
   "main": "./.webpack/main",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "version": "0.29.0",
   "description": "Official Desktop client for Nextcloud Talk",
   "bugs": "https://github.com/nextcloud/talk-desktop/issues",
-  "license": "AGPL-3.0",
+  "license": "AGPL-3.0-or-later",
   "author": {
     "name": "Grigorii K. Shartsev",
     "email": "me@shgk.me"


### PR DESCRIPTION
### ☑️ Resolves

* `AGPL-3.0` may mean both `AGPL-3.0-or-later` and `AGPL-3.0-only`.
* The product license is `AGPL-3.0-or-later`
* Source files are also in `AGPL-3.0-or-later`
* `package.json` and `package-lock.json` themself are `CC0-1.0`, the `license` field does not define their license.
  https://github.com/nextcloud/talk-desktop/blob/ca8b1138d684bcb43f5a9d749f05b8f700e07bab/.reuse/dep5#L20-L23
* Also changed `author` format and email to match `AUTHORS.md`