### PR TITLE
refactor: migrate to Composition API with SFC Setup and new defaults

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -92,6 +92,7 @@ module.exports = {
 		// All Rules enabled
 		/** Vue / Uncategorized */
 		'vue/attribute-hyphenation': 'error',
+		'vue/block-order': ['error', { order: ['script', 'template', 'style'] }], // Follow new Vue standards
 		'vue/component-api-style': ['error', ['script-setup']], // Follow new Vue standards
 		'vue/component-name-in-template-casing': 'error',
 		'vue/component-options-name-casing': 'error',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -92,6 +92,7 @@ module.exports = {
 		// All Rules enabled
 		/** Vue / Uncategorized */
 		'vue/attribute-hyphenation': 'error',
+		'vue/component-api-style': ['error', ['script-setup']], // Follow new Vue standards
 		'vue/component-name-in-template-casing': 'error',
 		'vue/component-options-name-casing': 'error',
 		// 'vue/custom-event-name-casing': 'error',

--- a/src/authentication/renderer/AuthenticationApp.vue
+++ b/src/authentication/renderer/AuthenticationApp.vue
@@ -3,56 +3,6 @@
   - SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 
-<template>
-	<div class="wrapper">
-		<div class="spacer">
-			<div class="logo" />
-		</div>
-		<div class="login-box">
-			<form @submit.prevent="login">
-				<fieldset :disabled="state === 'loading'">
-					<h2 class="login-box__header">
-						{{ t('talk_desktop', 'Log in to Nextcloud') }}
-					</h2>
-					<NcTextField :label="t('talk_desktop', 'Nextcloud server address')"
-						label-visible
-						:value.sync="rawServerUrl"
-						placeholder="https://try.nextcloud.com"
-						inputmode="url"
-						:success="state === 'success'"
-						:error="state === 'error'"
-						:helper-text="stateText" />
-					<NcButton v-if="state !== 'loading'"
-						class="submit-button"
-						type="primary"
-						native-type="submit"
-						wide>
-						<template #icon>
-							<MdiArrowRight :size="20" />
-						</template>
-						{{ t('talk_desktop', 'Log in') }}
-					</NcButton>
-					<NcButton v-else-if="state ==='loading'"
-						class="submit-button"
-						type="primary"
-						native-type="submit"
-						wide>
-						<template #icon>
-							<NcLoadingIcon appearance="light" />
-						</template>
-						{{ t('talk_desktop', 'Logging in …') }}
-					</NcButton>
-				</fieldset>
-			</form>
-		</div>
-		<div class="spacer">
-			<footer class="footer">
-				Nextcloud Talk Desktop {{ version }}
-			</footer>
-		</div>
-	</div>
-</template>
-
 <script setup>
 import { computed, ref } from 'vue'
 import MdiArrowRight from 'vue-material-design-icons/ArrowRight.vue'
@@ -187,6 +137,56 @@ async function login() {
 	await window.TALK_DESKTOP.login()
 }
 </script>
+
+<template>
+	<div class="wrapper">
+		<div class="spacer">
+			<div class="logo" />
+		</div>
+		<div class="login-box">
+			<form @submit.prevent="login">
+				<fieldset :disabled="state === 'loading'">
+					<h2 class="login-box__header">
+						{{ t('talk_desktop', 'Log in to Nextcloud') }}
+					</h2>
+					<NcTextField :label="t('talk_desktop', 'Nextcloud server address')"
+						label-visible
+						:value.sync="rawServerUrl"
+						placeholder="https://try.nextcloud.com"
+						inputmode="url"
+						:success="state === 'success'"
+						:error="state === 'error'"
+						:helper-text="stateText" />
+					<NcButton v-if="state !== 'loading'"
+						class="submit-button"
+						type="primary"
+						native-type="submit"
+						wide>
+						<template #icon>
+							<MdiArrowRight :size="20" />
+						</template>
+						{{ t('talk_desktop', 'Log in') }}
+					</NcButton>
+					<NcButton v-else-if="state ==='loading'"
+						class="submit-button"
+						type="primary"
+						native-type="submit"
+						wide>
+						<template #icon>
+							<NcLoadingIcon appearance="light" />
+						</template>
+						{{ t('talk_desktop', 'Logging in …') }}
+					</NcButton>
+				</fieldset>
+			</form>
+		</div>
+		<div class="spacer">
+			<footer class="footer">
+				Nextcloud Talk Desktop {{ version }}
+			</footer>
+		</div>
+	</div>
+</template>
 
 <style scoped>
 .wrapper {

--- a/src/authentication/renderer/AuthenticationApp.vue
+++ b/src/authentication/renderer/AuthenticationApp.vue
@@ -53,7 +53,8 @@
 	</div>
 </template>
 
-<script>
+<script setup>
+import { computed, ref } from 'vue'
 import MdiArrowRight from 'vue-material-design-icons/ArrowRight.vue'
 import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
 import NcLoadingIcon from '@nextcloud/vue/dist/Components/NcLoadingIcon.js'
@@ -64,138 +65,126 @@ import { appData } from '../../app/AppData.js'
 import { MIN_REQUIRED_NEXTCLOUD_VERSION, MIN_REQUIRED_TALK_VERSION } from '../../constants.js'
 import { refetchAppData } from '../../app/appData.service.js'
 
-export default {
-	name: 'AuthenticationApp',
+const version = window.TALK_DESKTOP.packageInfo.version
+const rawServerUrl = ref(process.env.NODE_ENV !== 'production' ? process.env.NEXTCLOUD_DEV_SERVER_HOSTS?.split?.(' ')?.[0] : '')
 
-	components: {
-		MdiArrowRight,
-		NcButton,
-		NcLoadingIcon,
-		NcTextField,
-	},
+const serverUrl = computed(() => {
+	const addHTTPS = (url) => url.startsWith('http') ? url : `https://${url}`
+	const removeIndexPhp = (url) => url.includes('/index.php') ? url.slice(0, url.indexOf('/index.php')) : url
+	const removeTrailingSlash = (url) => url.endsWith('/') ? url.slice(0, -1) : url
+	return removeTrailingSlash(removeIndexPhp(addHTTPS(rawServerUrl.value))).trim()
+})
 
-	setup() {
-		return {
-			version: window.TALK_DESKTOP.packageInfo.version,
+/** @type {import('vue').Ref<'idle'|'loading'|'error'|'success'>} */
+const state = ref('idle')
+const stateText = ref('')
+
+/**
+ * Switch state to success
+ */
+function setSuccess() {
+	state.value = 'success'
+	stateText.value = t('talk_desktop', 'Logged in successfully')
+}
+
+/**
+ * Switch state to loading
+ */
+function setLoading() {
+	state.value = 'loading'
+	stateText.value = ''
+}
+
+/**
+ * Switch state to error
+ * @param {string} error - Error message
+ */
+function setError(error) {
+	state.value = 'error'
+	stateText.value = error
+}
+
+/**
+ * Login
+ */
+async function login() {
+	setLoading()
+
+	// Check if valid URL
+	try {
+		// new URL will throw an exception on invalid URL
+		// eslint-disable-next-line no-new
+		new URL(serverUrl.value)
+	} catch {
+		return setError(t('talk_desktop', 'Invalid server address'))
+	}
+
+	// Prepare to request the server
+	window.TALK_DESKTOP.disableWebRequestInterceptor()
+	window.TALK_DESKTOP.enableWebRequestInterceptor(serverUrl.value, { enableCors: true })
+	appData.reset()
+	appData.serverUrl = serverUrl.value
+
+	// Check if there is Nextcloud server and get capabilities
+	let capabilitiesResponse
+	try {
+		capabilitiesResponse = await getCapabilities()
+	} catch {
+		return setError(t('talk_desktop', 'Nextcloud server not found'))
+	}
+
+	// Check if Talk is installed and enabled
+	const talkCapabilities = capabilitiesResponse.capabilities.spreed
+	if (!talkCapabilities) {
+		return setError(t('talk_desktop', 'Nextcloud Talk is not installed in the server'))
+	}
+
+	// Check versions compatibilities
+	const createVersionError = (componentName, minRequiredVersion, foundVersion) => t('talk_desktop', '{componentName} {minRequiredVersion} or higher is required but {foundVersion} is installed', {
+		componentName,
+		minRequiredVersion,
+		foundVersion,
+	})
+	if (capabilitiesResponse.version.major < MIN_REQUIRED_NEXTCLOUD_VERSION) {
+		return setError(createVersionError('Nextcloud', MIN_REQUIRED_NEXTCLOUD_VERSION, capabilitiesResponse.version.string))
+	}
+	if (parseInt(talkCapabilities.version.split('.')[0]) < MIN_REQUIRED_TALK_VERSION) {
+		// TODO: use semver package and check not only major version?
+		return setError(createVersionError('Nextcloud Talk', MIN_REQUIRED_TALK_VERSION, talkCapabilities.version,
+		))
+	}
+
+	// Login with web view
+	let credentials
+	try {
+		const maybeCredentials = await window.TALK_DESKTOP.openLoginWebView(serverUrl.value)
+		if (maybeCredentials instanceof Error) {
+			return setError(maybeCredentials.message)
 		}
-	},
+		credentials = maybeCredentials
+	} catch (error) {
+		console.error(error)
+		return setError(t('talk_desktop', 'Unexpected error'))
+	}
 
-	data() {
-		return {
-			rawServerUrl: process.env.NODE_ENV !== 'production' ? process.env.NEXTCLOUD_DEV_SERVER_HOSTS?.split?.(' ')?.[0] : '',
-			/** @type {'idle'|'loading'|'error'|'success'} */
-			state: 'idle',
-			stateText: '',
-		}
-	},
+	// Add credentials to the request
+	window.TALK_DESKTOP.enableWebRequestInterceptor(serverUrl.value, { enableCors: true, enableCookies: true, credentials })
+	// Save credentials
+	appData.credentials = credentials
 
-	computed: {
-		serverUrl() {
-			const addHTTPS = (url) => url.startsWith('http') ? url : `https://${url}`
-			const removeIndexPhp = (url) => url.includes('/index.php') ? url.slice(0, url.indexOf('/index.php')) : url
-			const removeTrailingSlash = (url) => url.endsWith('/') ? url.slice(0, -1) : url
-			return removeTrailingSlash(removeIndexPhp(addHTTPS(this.rawServerUrl))).trim()
-		},
-	},
+	// Get user's metadata and update capabilities for an authenticated user
+	try {
+		await refetchAppData(appData)
+	} catch (error) {
+		// A network connection was lost after successful requests or something unexpected went wrong
+		console.error(error)
+		return setError(t('talk_desktop', 'Login was successful but something went wrong.'))
+	}
 
-	methods: {
-		t,
-
-		setSuccess() {
-			this.state = 'success'
-			this.stateText = t('talk_desktop', 'Logged in successfully')
-		},
-
-		setLoading() {
-			this.state = 'loading'
-			this.stateText = ''
-		},
-
-		setError(error) {
-			this.state = 'error'
-			this.stateText = error
-		},
-
-		async login() {
-			this.setLoading()
-
-			// Check if valid URL
-			try {
-				// new URL will throw an exception on invalid URL
-				// eslint-disable-next-line no-new
-				new URL(this.serverUrl)
-			} catch {
-				return this.setError(t('talk_desktop', 'Invalid server address'))
-			}
-
-			// Prepare to request the server
-			window.TALK_DESKTOP.disableWebRequestInterceptor()
-			window.TALK_DESKTOP.enableWebRequestInterceptor(this.serverUrl, { enableCors: true })
-			appData.reset()
-			appData.serverUrl = this.serverUrl
-
-			// Check if there is Nextcloud server and get capabilities
-			let capabilitiesResponse
-			try {
-				capabilitiesResponse = await getCapabilities()
-			} catch {
-				return this.setError(t('talk_desktop', 'Nextcloud server not found'))
-			}
-
-			// Check if Talk is installed and enabled
-			const talkCapabilities = capabilitiesResponse.capabilities.spreed
-			if (!talkCapabilities) {
-				return this.setError(t('talk_desktop', 'Nextcloud Talk is not installed in the server'))
-			}
-
-			// Check versions compatibilities
-			const createVersionError = (componentName, minRequiredVersion, foundVersion) => t('talk_desktop', '{componentName} {minRequiredVersion} or higher is required but {foundVersion} is installed', {
-				componentName,
-				minRequiredVersion,
-				foundVersion,
-			})
-			if (capabilitiesResponse.version.major < MIN_REQUIRED_NEXTCLOUD_VERSION) {
-				return this.setError(createVersionError('Nextcloud', MIN_REQUIRED_NEXTCLOUD_VERSION, capabilitiesResponse.version.string))
-			}
-			if (parseInt(talkCapabilities.version.split('.')[0]) < MIN_REQUIRED_TALK_VERSION) {
-				// TODO: use semver package and check not only major version?
-				return this.setError(createVersionError('Nextcloud Talk', MIN_REQUIRED_TALK_VERSION, talkCapabilities.version,
-				))
-			}
-
-			// Login with web view
-			let credentials
-			try {
-				const maybeCredentials = await window.TALK_DESKTOP.openLoginWebView(this.serverUrl)
-				if (maybeCredentials instanceof Error) {
-					return this.setError(maybeCredentials.message)
-				}
-				credentials = maybeCredentials
-			} catch (error) {
-				console.error(error)
-				return this.setError(t('talk_desktop', 'Unexpected error'))
-			}
-
-			// Add credentials to the request
-			window.TALK_DESKTOP.enableWebRequestInterceptor(this.serverUrl, { enableCors: true, enableCookies: true, credentials })
-			// Save credentials
-			appData.credentials = credentials
-
-			// Get user's metadata and update capabilities for an authenticated user
-			try {
-				await refetchAppData(appData)
-			} catch (error) {
-				// A network connection was lost after successful requests or something unexpected went wrong
-				console.error(error)
-				return this.setError(t('talk_desktop', 'Login was successful but something went wrong.'))
-			}
-
-			// Yay!
-			appData.persist()
-			this.setSuccess()
-			await window.TALK_DESKTOP.login()
-		},
-	},
+	// Yay!
+	appData.persist()
+	setSuccess()
+	await window.TALK_DESKTOP.login()
 }
 </script>
 

--- a/src/help/renderer/HelpApp.vue
+++ b/src/help/renderer/HelpApp.vue
@@ -6,19 +6,19 @@
 <template>
 	<div class="about">
 		<h2>{{ t('talk_desktop', 'About') }}</h2>
-		<p>{{ $options.packageInfo.productName }} - {{ $options.packageInfo.description }}</p>
+		<p>{{ packageInfo.productName }} - {{ packageInfo.description }}</p>
 		<ul class="about__list">
 			<li>
 				{{ t('talk_desktop', 'Privacy and Legal Policy') }}: <a class="link" href="https://nextcloud.com/privacy/" target="_blank">https://nextcloud.com/privacy/</a>
 			</li>
 			<li>
-				{{ t('talk_desktop', 'License') }}: <a class="link" href="https://www.gnu.org/licenses/agpl-3.0.txt" target="_blank">{{ $options.packageInfo.license }}</a>
+				{{ t('talk_desktop', 'License') }}: <a class="link" href="https://www.gnu.org/licenses/agpl-3.0.txt" target="_blank">{{ packageInfo.license }}</a>
 			</li>
 			<li>
-				{{ t('talk_desktop', 'Issues') }}: <a :href="$options.packageInfo.bugs" class="link" target="_blank">{{ $options.packageInfo.bugs }}</a>
+				{{ t('talk_desktop', 'Issues') }}: <a :href="packageInfo.bugs" class="link" target="_blank">{{ packageInfo.bugs }}</a>
 			</li>
 			<li>
-				{{ t('talk_desktop', 'Source Code') }}: <a :href="$options.packageInfo.repository" class="link" target="_blank">{{ $options.packageInfo.repository }}</a>
+				{{ t('talk_desktop', 'Source Code') }}: <a :href="packageInfo.repository" class="link" target="_blank">{{ packageInfo.repository }}</a>
 			</li>
 		</ul>
 		<NcTextArea :aria-label="t('talk_desktop', 'System report')"
@@ -38,71 +38,60 @@
 	</div>
 </template>
 
-<script>
+<script setup>
+import { onBeforeUnmount, onMounted } from 'vue'
+
 import MdiWindowClose from 'vue-material-design-icons/WindowClose.vue'
 import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
 import NcTextArea from '@nextcloud/vue/dist/Components/NcTextArea.js'
-import { translate as t } from '@nextcloud/l10n'
 
+import { translate as t } from '@nextcloud/l10n'
 import { appData } from '../../app/AppData.js'
 
-export default {
-	name: 'HelpApp',
+const packageInfo = window.TALK_DESKTOP.packageInfo
 
-	components: {
-		MdiWindowClose,
-		NcButton,
-		NcTextArea,
-	},
+const report = [
+	'----------------------------System report----------------------------',
+	`Nextcloud Talk Desktop version ${window.TALK_DESKTOP.packageInfo.version}`,
+	`- Built with Nextcloud Talk version ${window.TALK_DESKTOP.packageInfo.talkVersion}`,
+	'',
+	...(appData.credentials
+		? [
+			'Connected to:',
+			`- Server address: ${appData.serverUrl}`,
+			`- Nextcloud Server version ${appData.version.nextcloud.string}`,
+			`- Nextcloud Talk version ${appData.version.talk}`,
+		]
+		: ['Not connected to any server']),
+	'',
+	`OS: ${window.OS.version}`,
+	'----------------------------System report----------------------------',
+].join('\n')
 
-	inheritAttrs: false,
-
-	packageInfo: window.TALK_DESKTOP.packageInfo,
-
-	computed: {
-		report() {
-			return [
-				'----------------------------System report----------------------------',
-				`Nextcloud Talk Desktop version ${window.TALK_DESKTOP.packageInfo.version}`,
-				`- Built with Nextcloud Talk version ${window.TALK_DESKTOP.packageInfo.talkVersion}`,
-				'',
-				...(appData.credentials
-					? [
-						'Connected to:',
-						`- Server address: ${appData.serverUrl}`,
-						`- Nextcloud Server version ${appData.version.nextcloud.string}`,
-						`- Nextcloud Talk version ${appData.version.talk}`,
-					]
-					: ['Not connected to any server']),
-				'',
-				`OS: ${window.OS.version}`,
-				'----------------------------System report----------------------------',
-			].join('\n')
-		},
-	},
-
-	mounted() {
-		window.addEventListener('keyup', this.handleEscape)
-	},
-
-	beforeDestroy() {
-		window.removeEventListener('keyup', this.handleEscape)
-	},
-
-	methods: {
-		t,
-
-		handleEscape(event) {
-			if (event.key === 'Escape') {
-				this.close()
-			}
-		},
-
-		close() {
-			window.close()
-		},
-	},
+/**
+ * Handle the escape key to close the window
+ * @param {KeyboardEvent} event - Keyboard event
+ */
+function handleEscape(event) {
+	if (event.key === 'Escape') {
+		close()
+	}
 }
+
+/**
+ * Close the window
+ */
+function close() {
+	window.close()
+}
+
+onMounted(() => {
+	window.addEventListener('keyup', handleEscape)
+})
+
+onBeforeUnmount(() => {
+	window.removeEventListener('keyup', handleEscape)
+})
 </script>
 
 <style scoped>

--- a/src/help/renderer/HelpApp.vue
+++ b/src/help/renderer/HelpApp.vue
@@ -3,41 +3,6 @@
   - SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 
-<template>
-	<div class="about">
-		<h2>{{ t('talk_desktop', 'About') }}</h2>
-		<p>{{ packageInfo.productName }} - {{ packageInfo.description }}</p>
-		<ul class="about__list">
-			<li>
-				{{ t('talk_desktop', 'Privacy and Legal Policy') }}: <a class="link" href="https://nextcloud.com/privacy/" target="_blank">https://nextcloud.com/privacy/</a>
-			</li>
-			<li>
-				{{ t('talk_desktop', 'License') }}: <a class="link" href="https://www.gnu.org/licenses/agpl-3.0.txt" target="_blank">{{ packageInfo.license }}</a>
-			</li>
-			<li>
-				{{ t('talk_desktop', 'Issues') }}: <a :href="packageInfo.bugs" class="link" target="_blank">{{ packageInfo.bugs }}</a>
-			</li>
-			<li>
-				{{ t('talk_desktop', 'Source Code') }}: <a :href="packageInfo.repository" class="link" target="_blank">{{ packageInfo.repository }}</a>
-			</li>
-		</ul>
-		<NcTextArea :aria-label="t('talk_desktop', 'System report')"
-			:value="report"
-			rows="11"
-			readonly
-			class="about__report"
-			@focus="$event.target.setSelectionRange(0, -1)" />
-		<p>
-			<NcButton type="secondary" wide @click="close">
-				<template #icon>
-					<MdiWindowClose />
-				</template>
-				{{ t('talk_desktop', 'Close') }}
-			</NcButton>
-		</p>
-	</div>
-</template>
-
 <script setup>
 import { onBeforeUnmount, onMounted } from 'vue'
 
@@ -93,6 +58,41 @@ onBeforeUnmount(() => {
 	window.removeEventListener('keyup', handleEscape)
 })
 </script>
+
+<template>
+	<div class="about">
+		<h2>{{ t('talk_desktop', 'About') }}</h2>
+		<p>{{ packageInfo.productName }} - {{ packageInfo.description }}</p>
+		<ul class="about__list">
+			<li>
+				{{ t('talk_desktop', 'Privacy and Legal Policy') }}: <a class="link" href="https://nextcloud.com/privacy/" target="_blank">https://nextcloud.com/privacy/</a>
+			</li>
+			<li>
+				{{ t('talk_desktop', 'License') }}: <a class="link" href="https://www.gnu.org/licenses/agpl-3.0.txt" target="_blank">{{ packageInfo.license }}</a>
+			</li>
+			<li>
+				{{ t('talk_desktop', 'Issues') }}: <a :href="packageInfo.bugs" class="link" target="_blank">{{ packageInfo.bugs }}</a>
+			</li>
+			<li>
+				{{ t('talk_desktop', 'Source Code') }}: <a :href="packageInfo.repository" class="link" target="_blank">{{ packageInfo.repository }}</a>
+			</li>
+		</ul>
+		<NcTextArea :aria-label="t('talk_desktop', 'System report')"
+			:value="report"
+			rows="11"
+			readonly
+			class="about__report"
+			@focus="$event.target.setSelectionRange(0, -1)" />
+		<p>
+			<NcButton type="secondary" wide @click="close">
+				<template #icon>
+					<MdiWindowClose />
+				</template>
+				{{ t('talk_desktop', 'Close') }}
+			</NcButton>
+		</p>
+	</div>
+</template>
 
 <style scoped>
 .about {

--- a/src/shared/globals/OC/OcDialogsAdapter.vue
+++ b/src/shared/globals/OC/OcDialogsAdapter.vue
@@ -3,17 +3,6 @@
   - SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 
-<template>
-	<div>
-		<NcDialog v-for="dialog in dialogs"
-			:key="dialog.id"
-			:name="dialog.name"
-			:message="dialog.message"
-			:buttons="dialog.buttons"
-			@update:open="deleteDialog(dialog.id)" />
-	</div>
-</template>
-
 <script setup>
 import { del, ref, set } from 'vue'
 import { translate as t } from '@nextcloud/l10n'
@@ -182,3 +171,14 @@ defineExpose({
 	prompt,
 })
 </script>
+
+<template>
+	<div>
+		<NcDialog v-for="dialog in dialogs"
+			:key="dialog.id"
+			:name="dialog.name"
+			:message="dialog.message"
+			:buttons="dialog.buttons"
+			@update:open="deleteDialog(dialog.id)" />
+	</div>
+</template>

--- a/src/shared/globals/OC/OcDialogsAdapter.vue
+++ b/src/shared/globals/OC/OcDialogsAdapter.vue
@@ -14,7 +14,8 @@
 	</div>
 </template>
 
-<script>
+<script setup>
+import { del, ref, set } from 'vue'
 import { translate as t } from '@nextcloud/l10n'
 import NcDialog from '@nextcloud/vue/dist/Components/NcDialog.js'
 
@@ -44,140 +45,140 @@ const OcDialogButtonsENUM = {
 	71: 'OK_BUTTONS',
 }
 
-export default {
-	name: 'OcDialogsAdapter',
+const dialogs = ref({})
 
-	expose: ['info', 'alert', 'confirm', 'confirmDestructive', 'prompt'],
-
-	components: {
-		NcDialog,
-	},
-
-	data() {
-		return {
-			dialogs: {},
-		}
-	},
-
-	methods: {
-		addDialog(dialogProps) {
-			const id = Math.random().toString(36).slice(2, 7)
-			this.$set(this.dialogs, id, {
-				id,
-				...dialogProps,
-			})
-		},
-
-		deleteDialog(id) {
-			this.$delete(this.dialogs, id)
-		},
-
-		/**
-		 * displays info dialog
-		 * @param {string} text content of dialog
-		 * @param {string} title dialog title
-		 * @param {Function} callback which will be triggered when user presses OK
-		 * @param {boolean} [modal] make the dialog modal
-		 */
-		info(text, title, callback, modal) {
-			// TODO: currently not used in Talk, but should be implemented
-			// this.message(text, title, 'info', Dialogs.OK_BUTTON, callback, modal)
-			console.warn('OC.dialogs.info is not implemented in Talk Desktop')
-		},
-
-		/**
-		 * displays alert dialog
-		 * @param {string} text content of dialog
-		 * @param {string} title dialog title
-		 * @param {Function} callback which will be triggered when user presses OK
-		 * @param {boolean} [modal] make the dialog modal
-		 */
-		alert(text, title, callback, modal) {
-			return new Promise((resolve) => {
-				this.addDialog({
-					name: title,
-					message: text,
-					canClose: !modal,
-					buttons: Buttons.OK_BUTTONS((result) => {
-						callback(result)
-						resolve(result)
-					}),
-				})
-			})
-		},
-
-		/**
-		 * displays confirmation dialog
-		 * @param {string} text content of dialog
-		 * @param {string} title dialog title
-		 * @param {Function} callback which will be triggered when user presses OK (true or false would be passed to callback respectively)
-		 * @param {boolean} [modal] make the dialog modal
-		 * @return {Promise}
-		 */
-		confirm(text, title, callback, modal) {
-			return new Promise((resolve) => {
-				this.addDialog({
-					name: title,
-					message: text,
-					canClose: !modal,
-					buttons: Buttons.YES_NO_BUTTONS((result) => {
-						callback(result)
-						resolve(result)
-					}),
-				})
-			})
-		},
-
-		/**
-		 * displays confirmation dialog
-		 * @param {string} text content of dialog
-		 * @param {string} title dialog title
-		 * @param {(number|{type: number, confirm: string, cancel: string, confirmClasses: string})} buttons text content of buttons
-		 * @param {Function} callback which will be triggered when user presses OK (true or false would be passed to callback respectively)
-		 * @param {boolean} [modal] make the dialog modal
-		 * @return {Promise}
-		 */
-		confirmDestructive(text, title, buttons, callback, modal) {
-			return new Promise((resolve) => {
-				const theButtons = (typeof buttons === 'object' && buttons.type === 70)
-					? (callback) => [{
-						label: buttons.cancel || t('talk_desktop', 'No'),
-						callback: () => callback?.(false),
-					},
-					{
-						label: buttons.confirm || t('talk_desktop', 'Yes'),
-						callback: () => callback?.(true),
-						type: 'error',
-						// classes: buttons.confirmClasses,
-					}]
-					: Buttons[OcDialogButtonsENUM[buttons]]
-
-				this.addDialog({
-					name: title,
-					message: text,
-					canClose: !modal,
-					buttons: theButtons((result) => {
-						callback(result)
-						resolve(result)
-					}),
-				})
-			})
-		},
-
-		/**
-		 * displays prompt dialog
-		 * @param {string} text content of dialog
-		 * @param {string} title dialog title
-		 * @param {Function} callback which will be triggered when user presses OK (true or false would be passed to callback respectively)
-		 * @param {boolean} [modal] make the dialog modal
-		 * @param {string} name name of the input field
-		 * @param {boolean} password whether the input should be a password input
-		 * @return {Promise}
-		 */
-		prompt(text, title, callback, modal, name, password) {
-			// TODO: currently not used in Talk, but should be implemented
-			console.warn('OC.dialogs.prompt is not implemented in Talk Desktop')
-		},
-	},
+/**
+ * Base function to add a dialog
+ * @param {object} dialogProps - Dialog properties
+ */
+function addDialog(dialogProps) {
+	const id = Math.random().toString(36).slice(2, 7)
+	set(dialogs.value, id, {
+		id,
+		...dialogProps,
+	})
 }
+
+/**
+ * Delete dialog by id
+ * @param {string} id - Dialog id
+ */
+function deleteDialog(id) {
+	del(dialogs.value, id)
+}
+
+/**
+ * displays info dialog
+ * @param {string} text content of dialog
+ * @param {string} title dialog title
+ * @param {Function} callback which will be triggered when user presses OK
+ * @param {boolean} [modal] make the dialog modal
+ */
+function info(text, title, callback, modal) {
+	// TODO: currently not used in Talk, but should be implemented
+	// this.message(text, title, 'info', Dialogs.OK_BUTTON, callback, modal)
+	console.warn('OC.dialogs.info is not implemented in Talk Desktop')
+}
+
+/**
+ * displays alert dialog
+ * @param {string} text content of dialog
+ * @param {string} title dialog title
+ * @param {Function} callback which will be triggered when user presses OK
+ * @param {boolean} [modal] make the dialog modal
+ */
+function alert(text, title, callback, modal) {
+	return new Promise((resolve) => {
+		addDialog({
+			name: title,
+			message: text,
+			canClose: !modal,
+			buttons: Buttons.OK_BUTTONS((result) => {
+				callback(result)
+				resolve(result)
+			}),
+		})
+	})
+}
+
+/**
+ * displays confirmation dialog
+ * @param {string} text content of dialog
+ * @param {string} title dialog title
+ * @param {Function} callback which will be triggered when user presses OK (true or false would be passed to callback respectively)
+ * @param {boolean} [modal] make the dialog modal
+ * @return {Promise}
+ */
+function confirm(text, title, callback, modal) {
+	return new Promise((resolve) => {
+		addDialog({
+			name: title,
+			message: text,
+			canClose: !modal,
+			buttons: Buttons.YES_NO_BUTTONS((result) => {
+				callback(result)
+				resolve(result)
+			}),
+		})
+	})
+}
+
+/**
+ * displays confirmation dialog
+ * @param {string} text content of dialog
+ * @param {string} title dialog title
+ * @param {(number|{type: number, confirm: string, cancel: string, confirmClasses: string})} buttons text content of buttons
+ * @param {Function} callback which will be triggered when user presses OK (true or false would be passed to callback respectively)
+ * @param {boolean} [modal] make the dialog modal
+ * @return {Promise}
+ */
+function confirmDestructive(text, title, buttons, callback, modal) {
+	return new Promise((resolve) => {
+		const theButtons = (typeof buttons === 'object' && buttons.type === 70)
+			? (callback) => [{
+				label: buttons.cancel || t('talk_desktop', 'No'),
+				callback: () => callback?.(false),
+			},
+			{
+				label: buttons.confirm || t('talk_desktop', 'Yes'),
+				callback: () => callback?.(true),
+				type: 'error',
+				// classes: buttons.confirmClasses,
+			}]
+			: Buttons[OcDialogButtonsENUM[buttons]]
+
+		addDialog({
+			name: title,
+			message: text,
+			canClose: !modal,
+			buttons: theButtons((result) => {
+				callback(result)
+				resolve(result)
+			}),
+		})
+	})
+}
+
+/**
+ * displays prompt dialog
+ * @param {string} text content of dialog
+ * @param {string} title dialog title
+ * @param {Function} callback which will be triggered when user presses OK (true or false would be passed to callback respectively)
+ * @param {boolean} [modal] make the dialog modal
+ * @param {string} name name of the input field
+ * @param {boolean} password whether the input should be a password input
+ * @return {void}
+ */
+function prompt(text, title, callback, modal, name, password) {
+	// TODO: currently not used in Talk, but should be implemented
+	console.warn('OC.dialogs.prompt is not implemented in Talk Desktop')
+}
+
+defineExpose({
+	info,
+	alert,
+	confirm,
+	confirmDestructive,
+	prompt,
+})
 </script>

--- a/src/shared/setupWebPage.js
+++ b/src/shared/setupWebPage.js
@@ -164,7 +164,7 @@ function getInitialStateFromCapabilities(capabilities, userMetadata) {
 			shortcutsDisabled: false, // TODO: Find in Capabilities
 		},
 		core: {
-			capabilities: capabilities,
+			capabilities,
 			config: {
 				version: '25.0.2.3', // TODO: Find in Capabilities
 				versionstring: '25.0.2', // TODO: Find in Capabilities

--- a/src/talk/renderer/DesktopHeader.vue
+++ b/src/talk/renderer/DesktopHeader.vue
@@ -3,31 +3,6 @@
   - SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 
-<template>
-	<header id="header" class="header">
-		<div class="header__inner">
-			<div v-if="!OS.isMac"
-				class="header__title-wrapper"
-				role="button"
-				tabindex="0"
-				@click="pushToRoot">
-				<span class="header__title">Nextcloud Talk</span>
-				<span class="header__preview-badge">Preview</span>
-			</div>
-
-			<div class="spacer" />
-
-			<div class="header__item" data-theme-dark>
-				<MainMenu />
-			</div>
-
-			<div class="header__item">
-				<UserMenu :user="user" @logout="logout" />
-			</div>
-		</div>
-	</header>
-</template>
-
 <script setup>
 import MainMenu from './components/MainMenu.vue'
 import UserMenu from './components/UserMenu.vue'
@@ -74,6 +49,31 @@ onUnmounted(() => {
 	window.removeEventListener('keydown', handleGlobalEscape, { capture: true })
 })
 </script>
+
+<template>
+	<header id="header" class="header">
+		<div class="header__inner">
+			<div v-if="!OS.isMac"
+				class="header__title-wrapper"
+				role="button"
+				tabindex="0"
+				@click="pushToRoot">
+				<span class="header__title">Nextcloud Talk</span>
+				<span class="header__preview-badge">Preview</span>
+			</div>
+
+			<div class="spacer" />
+
+			<div class="header__item" data-theme-dark>
+				<MainMenu />
+			</div>
+
+			<div class="header__item">
+				<UserMenu :user="user" @logout="logout" />
+			</div>
+		</div>
+	</header>
+</template>
 
 <style scoped>
 .header {

--- a/src/talk/renderer/DesktopHeader.vue
+++ b/src/talk/renderer/DesktopHeader.vue
@@ -28,54 +28,51 @@
 	</header>
 </template>
 
-<script>
+<script setup>
 import MainMenu from './components/MainMenu.vue'
 import UserMenu from './components/UserMenu.vue'
 import { appData } from '../../app/AppData.js'
 import { useUserStatusStore } from './UserStatus/userStatus.store.js'
 import { useUserStatusHeartbeat } from './UserStatus/useUserStatusHeartbeat.js'
+import { onMounted, onUnmounted } from 'vue'
 
-export default {
-	name: 'DesktopHeader',
+useUserStatusStore()
+useUserStatusHeartbeat()
 
-	components: {
-		MainMenu,
-		UserMenu,
-	},
+const user = appData.userMetadata
+const OS = window.OS
 
-	setup() {
-		const userStatusStore = useUserStatusStore()
-		useUserStatusHeartbeat()
-
-		return {
-			userStatusStore,
-			user: appData.userMetadata,
-			OS: window.OS,
-		}
-	},
-
-	mounted() {
-		window.addEventListener('keydown', (event) => {
-			if (event.key === 'Escape' && document.activeElement === document.body) {
-				this.pushToRoot()
-			}
-		}, { capture: true })
-	},
-
-	methods: {
-		getTalkRouter() {
-			return window.OCA.Talk.instance.$router
-		},
-
-		pushToRoot() {
-			this.getTalkRouter().push({ name: 'root' }).catch(() => {})
-		},
-
-		logout() {
-			window.TALK_DESKTOP.logout()
-		},
-	},
+/**
+ * Push to root in Talk app to unselect any chat
+ */
+function pushToRoot() {
+	window.OCA.Talk.instance?.$router?.push({ name: 'root' }).catch(() => {})
 }
+
+/**
+ * Logout in Talk Desktop
+ */
+function logout() {
+	window.TALK_DESKTOP.logout()
+}
+
+/**
+ * Handle the global escape key to unselect any chat
+ * @param {KeyboardEvent} event - Keyboard event
+ */
+function handleGlobalEscape(event) {
+	if (event.key === 'Escape' && document.activeElement === document.body) {
+		pushToRoot()
+	}
+}
+
+onMounted(() => {
+	window.addEventListener('keydown', handleGlobalEscape, { capture: true })
+})
+
+onUnmounted(() => {
+	window.removeEventListener('keydown', handleGlobalEscape, { capture: true })
+})
 </script>
 
 <style scoped>

--- a/src/talk/renderer/UserStatus/userStatus.service.js
+++ b/src/talk/renderer/UserStatus/userStatus.service.js
@@ -29,7 +29,7 @@ export async function fetchCurrentUserStatus() {
 /**
  * Fetches the current user-status
  *
- * @param {string} userId
+ * @param {string} userId - User id
  * @return {Promise<import('./userStatus.types.ts').UserStatus>}
  */
 export async function fetchBackupStatus(userId) {

--- a/src/talk/renderer/Viewer/ViewerApp.vue
+++ b/src/talk/renderer/Viewer/ViewerApp.vue
@@ -29,60 +29,49 @@
 	</NcModal>
 </template>
 
-<script>
+<script setup>
+import { computed, ref } from 'vue'
 import NcModal from '@nextcloud/vue/dist/Components/NcModal.js'
 import NcActionLink from '@nextcloud/vue/dist/Components/NcActionLink.js'
 import MdiOpenInNew from 'vue-material-design-icons/OpenInNew.vue'
-
 import { generateUrl } from '@nextcloud/router'
 import { translate as t } from '@nextcloud/l10n'
 
 const noop = () => {}
 
-export default {
-	name: 'ViewerApp',
+const isOpen = ref(false)
+const onClose = ref(noop)
+const file = ref(null)
 
-	components: {
-		MdiOpenInNew,
-		NcModal,
-		NcActionLink,
-	},
+const viewComponent = computed(() => file.value && OCA.Viewer.availableHandlers.find((handler) => handler.mimes.includes(file.value.mime))?.component)
 
-	data() {
-		return {
-			isOpen: false,
-			onClose: noop,
-			file: null,
-		}
-	},
+const link = computed(() => file.value && generateUrl(`/f/${file.value.fileid}`))
 
-	computed: {
-		viewComponent() {
-			return this.file && OCA.Viewer.availableHandlers.find((handler) => handler.mimes.includes(this.file.mime))?.component
-		},
-
-		link() {
-			return this.file && generateUrl(`/f/${this.file.fileid}`)
-		},
-	},
-
-	methods: {
-		t,
-
-		open({ fileInfo, onClose = noop } = {}) {
-			this.onClose = onClose
-			this.file = fileInfo
-			this.isOpen = true
-		},
-
-		close() {
-			this.file = null
-
-			this.onClose()
-			this.onClose = noop
-		},
-	},
+/**
+ * Open the viewer modal
+ * @param {object} options - Options
+ * @param {object} options.fileInfo - File info
+ * @param {Function} options.onClose - Callback called then the modal is closed
+ */
+function open({ fileInfo, onClose = noop } = {}) {
+	onClose.value = onClose
+	file.value = fileInfo
+	isOpen.value = true
 }
+
+/**
+ * Close the viewer modal
+ */
+function close() {
+	file.value = null
+	onClose.value()
+	onClose.value = noop
+}
+
+defineExpose({
+	open,
+	close,
+})
 </script>
 
 <style>

--- a/src/talk/renderer/Viewer/ViewerApp.vue
+++ b/src/talk/renderer/Viewer/ViewerApp.vue
@@ -3,32 +3,6 @@
   - SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 
-<template>
-	<NcModal v-if="file"
-		id="viewer"
-		:show.sync="isOpen"
-		class="viewer-modal"
-		:class="{ 'viewer-modal--open': isOpen }"
-		:name="file.basename"
-		size="full"
-		:close-button-contained="false"
-		dark
-		@close="close">
-		<component :is="viewComponent"
-			v-if="viewComponent"
-			:file="file" />
-
-		<template #actions>
-			<NcActionLink :href="link">
-				<template #icon>
-					<MdiOpenInNew />
-				</template>
-				{{ t('talk_desktop', 'Open in a Web-Browser') }}
-			</NcActionLink>
-		</template>
-	</NcModal>
-</template>
-
 <script setup>
 import { computed, ref } from 'vue'
 import NcModal from '@nextcloud/vue/dist/Components/NcModal.js'
@@ -73,6 +47,32 @@ defineExpose({
 	close,
 })
 </script>
+
+<template>
+	<NcModal v-if="file"
+		id="viewer"
+		:show.sync="isOpen"
+		class="viewer-modal"
+		:class="{ 'viewer-modal--open': isOpen }"
+		:name="file.basename"
+		size="full"
+		:close-button-contained="false"
+		dark
+		@close="close">
+		<component :is="viewComponent"
+			v-if="viewComponent"
+			:file="file" />
+
+		<template #actions>
+			<NcActionLink :href="link">
+				<template #icon>
+					<MdiOpenInNew />
+				</template>
+				{{ t('talk_desktop', 'Open in a Web-Browser') }}
+			</NcActionLink>
+		</template>
+	</NcModal>
+</template>
 
 <style>
 .header {

--- a/src/talk/renderer/Viewer/ViewerHandlerImages.vue
+++ b/src/talk/renderer/Viewer/ViewerHandlerImages.vue
@@ -9,37 +9,32 @@
 	</div>
 </template>
 
-<script>
+<script setup>
+import { computed } from 'vue'
 import { generateUrl } from '@nextcloud/router'
 
-export default {
-	name: 'ViewerHandlerImages',
-
-	props: {
-		file: {
-			type: Object,
-			required: true,
-		},
+const props = defineProps({
+	file: {
+		type: Object,
+		required: true,
 	},
+})
 
-	computed: {
-		src() {
-			if (!this.file) {
-				return null
-			}
+const src = computed(() => {
+	if (!props.file) {
+		return null
+	}
 
-			const searchParams = new URLSearchParams(Object.entries({
-				fileId: this.file.fileid,
-				x: Math.floor(screen.width * devicePixelRatio),
-				y: Math.floor(screen.height * devicePixelRatio),
-				a: 'true',
-				etag: this.file.etag,
-			})).toString()
+	const searchParams = new URLSearchParams(Object.entries({
+		fileId: props.file.fileid,
+		x: Math.floor(screen.width * devicePixelRatio),
+		y: Math.floor(screen.height * devicePixelRatio),
+		a: 'true',
+		etag: props.file.etag,
+	})).toString()
 
-			return generateUrl(`/core/preview?${searchParams}`)
-		},
-	},
-}
+	return generateUrl(`/core/preview?${searchParams}`)
+})
 </script>
 
 <style scoped>

--- a/src/talk/renderer/Viewer/ViewerHandlerImages.vue
+++ b/src/talk/renderer/Viewer/ViewerHandlerImages.vue
@@ -3,12 +3,6 @@
   - SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 
-<template>
-	<div class="media-wrapper">
-		<img :src="src" :alt="file.basename">
-	</div>
-</template>
-
 <script setup>
 import { computed } from 'vue'
 import { generateUrl } from '@nextcloud/router'
@@ -36,6 +30,12 @@ const src = computed(() => {
 	return generateUrl(`/core/preview?${searchParams}`)
 })
 </script>
+
+<template>
+	<div class="media-wrapper">
+		<img :src="src" :alt="file.basename">
+	</div>
+</template>
 
 <style scoped>
 .media-wrapper {

--- a/src/talk/renderer/Viewer/ViewerHandlerVideos.vue
+++ b/src/talk/renderer/Viewer/ViewerHandlerVideos.vue
@@ -9,30 +9,25 @@
 	</div>
 </template>
 
-<script>
+<script setup>
+import { computed } from 'vue'
 import { generateRemoteUrl } from '@nextcloud/router'
 import { getCurrentUser } from '@nextcloud/auth'
 
-export default {
-	name: 'ViewerHandlerVideos',
-
-	props: {
-		file: {
-			type: Object,
-			required: true,
-		},
+const props = defineProps({
+	file: {
+		type: Object,
+		required: true,
 	},
+})
 
-	computed: {
-		src() {
-			if (!this.file) {
-				return null
-			}
+const src = computed(() => {
+	if (!props.file) {
+		return null
+	}
 
-			return generateRemoteUrl(`dav/files/${getCurrentUser().uid}/${this.file.filename}`)
-		},
-	},
-}
+	return generateRemoteUrl(`dav/files/${getCurrentUser().uid}/${props.file.filename}`)
+})
 </script>
 
 <style scoped>

--- a/src/talk/renderer/Viewer/ViewerHandlerVideos.vue
+++ b/src/talk/renderer/Viewer/ViewerHandlerVideos.vue
@@ -3,12 +3,6 @@
   - SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 
-<template>
-	<div class="media-wrapper">
-		<video :src="src" controls />
-	</div>
-</template>
-
 <script setup>
 import { computed } from 'vue'
 import { generateRemoteUrl } from '@nextcloud/router'
@@ -29,6 +23,12 @@ const src = computed(() => {
 	return generateRemoteUrl(`dav/files/${getCurrentUser().uid}/${props.file.filename}`)
 })
 </script>
+
+<template>
+	<div class="media-wrapper">
+		<video :src="src" controls />
+	</div>
+</template>
 
 <style scoped>
 .media-wrapper {

--- a/src/talk/renderer/components/UiMenu.vue
+++ b/src/talk/renderer/components/UiMenu.vue
@@ -11,10 +11,7 @@
 	</nav>
 </template>
 
-<script>
-export default {
-	name: 'UiMenu',
-}
+<script setup>
 </script>
 
 <style scoped>

--- a/src/talk/renderer/components/UiMenu.vue
+++ b/src/talk/renderer/components/UiMenu.vue
@@ -3,6 +3,9 @@
   - SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 
+<script setup>
+</script>
+
 <template>
 	<nav class="menu">
 		<ul class="menu__inner">
@@ -10,9 +13,6 @@
 		</ul>
 	</nav>
 </template>
-
-<script setup>
-</script>
 
 <style scoped>
 .menu {

--- a/src/talk/renderer/components/UiMenuItem.vue
+++ b/src/talk/renderer/components/UiMenuItem.vue
@@ -3,6 +3,21 @@
   - SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 
+<script>
+export default {
+	inheritAttrs: false,
+}
+</script>
+
+<script setup>
+defineProps({
+	tag: {
+		type: [String, Object, Function],
+		default: 'button',
+	},
+})
+</script>
+
 <template>
 	<li class="menu-item">
 		<component :is="tag" class="menu-item__action unstyled-action" v-bind="$attrs">
@@ -20,21 +35,6 @@
 		</component>
 	</li>
 </template>
-
-<script>
-export default {
-	inheritAttrs: false,
-}
-</script>
-
-<script setup>
-defineProps({
-	tag: {
-		type: [String, Object, Function],
-		default: 'button',
-	},
-})
-</script>
 
 <style scoped>
 .unstyled-action {

--- a/src/talk/renderer/components/UiMenuItem.vue
+++ b/src/talk/renderer/components/UiMenuItem.vue
@@ -22,26 +22,18 @@
 </template>
 
 <script>
-import MdiWeb from 'vue-material-design-icons/Web.vue'
-import MdiInformationOutline from 'vue-material-design-icons/InformationOutline.vue'
-
 export default {
-	name: 'UiMenuItem',
-
-	components: {
-		MdiInformationOutline,
-		MdiWeb,
-	},
-
 	inheritAttrs: false,
-
-	props: {
-		tag: {
-			type: [String, Object, Function],
-			default: 'button',
-		},
-	},
 }
+</script>
+
+<script setup>
+defineProps({
+	tag: {
+		type: [String, Object, Function],
+		default: 'button',
+	},
+})
 </script>
 
 <style scoped>

--- a/src/talk/renderer/components/UiMenuSeparator.vue
+++ b/src/talk/renderer/components/UiMenuSeparator.vue
@@ -3,11 +3,11 @@
   - SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 
+<script setup></script>
+
 <template>
 	<li class="menu-item-separator" />
 </template>
-
-<script setup></script>
 
 <style scoped lang="scss">
 .menu-item-separator {

--- a/src/talk/renderer/components/UiMenuSeparator.vue
+++ b/src/talk/renderer/components/UiMenuSeparator.vue
@@ -7,6 +7,8 @@
 	<li class="menu-item-separator" />
 </template>
 
+<script setup></script>
+
 <style scoped lang="scss">
 .menu-item-separator {
 	border-top: 1px solid var(--color-border-dark);

--- a/src/upgrade/renderer/UpgradeApp.vue
+++ b/src/upgrade/renderer/UpgradeApp.vue
@@ -3,6 +3,18 @@
   - SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 
+<script setup>
+import MdiUpdate from 'vue-material-design-icons/Update.vue'
+import MdiWeb from 'vue-material-design-icons/Web.vue'
+import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
+import { translate as t } from '@nextcloud/l10n'
+import { generateUrl } from '@nextcloud/router'
+
+const packageInfo = window.TALK_DESKTOP.packageInfo
+
+const browserLink = generateUrl('apps/spreed')
+</script>
+
 <template>
 	<div class="upgrade">
 		<h2>{{ t('talk_desktop', 'Upgrade required') }}</h2>
@@ -26,18 +38,6 @@
 		</NcButton>
 	</div>
 </template>
-
-<script setup>
-import MdiUpdate from 'vue-material-design-icons/Update.vue'
-import MdiWeb from 'vue-material-design-icons/Web.vue'
-import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
-import { translate as t } from '@nextcloud/l10n'
-import { generateUrl } from '@nextcloud/router'
-
-const packageInfo = window.TALK_DESKTOP.packageInfo
-
-const browserLink = generateUrl('apps/spreed')
-</script>
 
 <style scoped>
 .upgrade {

--- a/src/upgrade/renderer/UpgradeApp.vue
+++ b/src/upgrade/renderer/UpgradeApp.vue
@@ -9,7 +9,7 @@
 		<p>{{ t('talk_desktop', 'The client version is too old and no longer supported by this server. Update is required.') }}</p>
 		<NcButton type="primary"
 			wide
-			:href="$options.packageInfo.repository"
+			:href="packageInfo.repository"
 			target="_blank">
 			<template #icon>
 				<MdiUpdate />
@@ -27,34 +27,16 @@
 	</div>
 </template>
 
-<script>
+<script setup>
 import MdiUpdate from 'vue-material-design-icons/Update.vue'
 import MdiWeb from 'vue-material-design-icons/Web.vue'
 import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
 import { translate as t } from '@nextcloud/l10n'
 import { generateUrl } from '@nextcloud/router'
 
-export default {
-	name: 'UpgradeApp',
+const packageInfo = window.TALK_DESKTOP.packageInfo
 
-	components: {
-		MdiUpdate,
-		MdiWeb,
-		NcButton,
-	},
-
-	packageInfo: window.TALK_DESKTOP.packageInfo,
-
-	computed: {
-		browserLink() {
-			return generateUrl('apps/spreed')
-		},
-	},
-
-	methods: {
-		t,
-	},
-}
+const browserLink = generateUrl('apps/spreed')
 </script>
 
 <style scoped>


### PR DESCRIPTION
Follow 2022+ Vue recommendations and defaults:

- Migrate to Composition API
  - Using SFC Setup as a new default recommendation and a place with better TS support with new features in Vue 3
- Change block order to `script, template`
  - Places template close to styles

Add corresponding ESLint rules