### PR TITLE
fix(authentication): create a new cache partition on open login web-view

### DIFF
--- a/src/authentication/login.window.js
+++ b/src/authentication/login.window.js
@@ -11,6 +11,8 @@ const { getOsTitle } = require('../shared/os.utils.js')
 const { applyContextMenu } = require('../app/applyContextMenu.js')
 const { getBrowserWindowIcon } = require('../shared/icons.utils.js')
 
+const genId = () => Math.random().toString(36).slice(2, 9)
+
 /**
  * Open a web-view modal window with Nextcloud Server login page
  *
@@ -38,7 +40,7 @@ function openLoginWebView(parentWindow, serverUrl) {
 			modal: true,
 			autoHideMenuBar: true,
 			webPreferences: {
-				partition: 'non-persist:login-web-view',
+				partition: `non-persist:login-web-view-${genId()}`,
 				nodeIntegration: false,
 			},
 			icon: getBrowserWindowIcon(),


### PR DESCRIPTION
### ☑️ Resolves

Step to reproduce:
1. Start the login process
2. Log in as **User1**
   ![image](https://github.com/user-attachments/assets/0a018dea-0a0b-4ccd-aa30-18f29323b062)
4. Before finishing the process, realize that you actually wanted to log in as User2
   ![image](https://github.com/user-attachments/assets/1587b35f-81d9-48b8-a534-061d5c480742)
6. Close the login WebView
7. Open again
   - **Expected**: You can log in as User2
     ![image](https://github.com/user-attachments/assets/6e77d7f7-32e5-4acd-94b6-3b39da5ad9c4)
   - **Actual**: You are still logged in as User1 and can only grant access to Talk Desktop
     ![image](https://github.com/user-attachments/assets/1587b35f-81d9-48b8-a534-061d5c480742)

Note: `non-persist` stores partition until app restart, not window reopening.

### 🚧 Tasks

- [x] Create a new cache and storage partition on each Login WebView open, so previous cookies + session are not reused
