### PR TITLE
release: v0.33.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@
 
 # Changelog
 
+## v0.33.0 - 2024-07-18
+
+### Build-in Talk update
+
+- Built-in Talk in binaries is updated to v19.0.7
+
+### Fixes
+
+- User is kept logged in on the Login Flow Web-View [#683](https://github.com/nextcloud/talk-desktop/pull/717)
+
 ## v0.32.0 - 2024-07-11
 
 ### Fixes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "talk-desktop",
-  "version": "0.32.0",
+  "version": "0.33.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "talk-desktop",
-      "version": "0.32.0",
+      "version": "0.33.0",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@mdi/svg": "^7.4.47",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "name": "talk-desktop",
   "productName": "Nextcloud Talk",
-  "version": "0.32.0",
+  "version": "0.33.0",
   "description": "Official Desktop client for Nextcloud Talk",
   "bugs": "https://github.com/nextcloud/talk-desktop/issues",
   "license": "AGPL-3.0-or-later",


### PR DESCRIPTION
## v0.33.0 - 2024-07-18

### Build-in Talk update

- Built-in Talk in binaries is updated to v19.0.7

### Fixes

- User is kept logged in on the Login Flow Web-View [#683](https://github.com/nextcloud/talk-desktop/pull/717)