### PR TITLE
fix(UserMenu): minor visual issues

### DIFF
--- a/src/talk/renderer/assets/overrides.css
+++ b/src/talk/renderer/assets/overrides.css
@@ -18,3 +18,13 @@ body {
 	margin-top: var(--header-height) !important;
 	border-radius: 0 !important;
 }
+
+/* Remove Nextcloud header specific focus-visible style */
+#header {
+	.button-vue,
+	[role=button] {
+		&:focus-visible::after {
+			content: none !important;
+		}
+	}
+}

--- a/src/talk/renderer/components/ThemeLogo.vue
+++ b/src/talk/renderer/components/ThemeLogo.vue
@@ -9,7 +9,7 @@ import { appData } from '../../../app/AppData.js'
 
 const props = defineProps({
 	size: {
-		type: Number,
+		type: [Number, String],
 		default: 20,
 	},
 })
@@ -40,7 +40,7 @@ const cssVars = computed(() => ({
 	width: var(--ThemeLogo-size);
 	height: var(--ThemeLogo-size);
 	background-color: var(--ThemeLogo-background-color);
-	padding: 15%;
+	padding: 10%;
 }
 
 .theme-logo__img {

--- a/src/talk/renderer/components/UiMenuItem.vue
+++ b/src/talk/renderer/components/UiMenuItem.vue
@@ -81,5 +81,6 @@ defineProps({
 
 .menu-item__text {
 	flex: 1;
+	word-break: break-word;
 }
 </style>

--- a/src/talk/renderer/components/UiMenuItem.vue
+++ b/src/talk/renderer/components/UiMenuItem.vue
@@ -76,7 +76,7 @@ defineProps({
 	display: flex;
 	align-items: center;
 	justify-content: center;
-	width: 20px
+	width: 24px;
 }
 
 .menu-item__text {

--- a/src/talk/renderer/components/UserMenu.vue
+++ b/src/talk/renderer/components/UserMenu.vue
@@ -95,7 +95,7 @@ function handleUserStatusChange(status) {
 			</template>
 
 			<template #default>
-				<UiMenu aria-label="Settings menu">
+				<UiMenu aria-label="Settings menu" class="user-menu__menu">
 					<template v-if="userStatusSubMenuOpen">
 						<UiMenuItem tag="button" @click.native.stop="userStatusSubMenuOpen = false">
 							<template #icon>
@@ -205,6 +205,10 @@ function handleUserStatusChange(status) {
 		outline: 2px solid var(--color-main-text);
 		box-shadow: 0 0 0 4px var(--color-main-background);
 	}
+}
+
+.user-menu__menu {
+	max-width: 300px;
 }
 
 .user-menu__server {

--- a/src/talk/renderer/components/UserMenu.vue
+++ b/src/talk/renderer/components/UserMenu.vue
@@ -4,7 +4,7 @@
 -->
 
 <script setup>
-import { computed, ref } from 'vue'
+import { computed, ref, watch } from 'vue'
 import { storeToRefs } from 'pinia'
 
 import { translate as t } from '@nextcloud/l10n'
@@ -49,6 +49,13 @@ const isOpen = ref(false)
 const userMenuContainer = ref(null)
 const isUserStatusDialogOpen = ref(false)
 const userStatusSubMenuOpen = ref(false)
+
+// Close the submenu before opening the menu
+watch(isOpen, () => {
+	if (isOpen.value) {
+		userStatusSubMenuOpen.value = false
+	}
+})
 
 const userProfileLink = computed(() => generateUrl('/u/{userid}', { userid: props.user.id }))
 

--- a/src/talk/renderer/components/UserMenu.vue
+++ b/src/talk/renderer/components/UserMenu.vue
@@ -45,6 +45,7 @@ const serverUrl = appData.serverUrl
 const serverUrlShort = serverUrl.replace(/^https?:\/\//, '')
 const theming = appData.capabilities.theming
 
+const isOpen = ref(false)
 const userMenuContainer = ref(null)
 const isUserStatusDialogOpen = ref(false)
 const userStatusSubMenuOpen = ref(false)
@@ -64,18 +65,26 @@ function handleUserStatusChange(status) {
 <template>
 	<div ref="userMenuContainer" class="user-menu">
 		<NcPopover v-if="userMenuContainer"
+			:shown.sync="isOpen"
 			:container="userMenuContainer"
 			:popper-hide-triggers="triggers => [...triggers, 'click']"
+			:triggers="[]"
 			no-auto-focus>
 			<template #trigger="{ attrs }">
-				<button class="user-menu__trigger unstyled-button" v-bind="attrs">
+				<div class="user-menu__trigger">
+					<!-- Floating-Vue doesn't support open on span[role=button] - opening manually -->
 					<NcAvatar class="user-menu__avatar"
 						:user="user.id"
 						:display-name="user['display-name']"
 						:size="32"
 						disable-tooltip
-						tabindex="0" />
-				</button>
+						v-bind="attrs"
+						tabindex="0"
+						role="button"
+						@click.native="isOpen = !isOpen"
+						@keydown.space.native="isOpen = !isOpen"
+						@keydown.enter.native="isOpen = !isOpen" />
+				</div>
 			</template>
 
 			<template #default>
@@ -167,35 +176,6 @@ function handleUserStatusChange(status) {
 </template>
 
 <style scoped>
-.unstyled-button {
-	cursor: pointer;
-}
-
-.unstyled-button,
-.unstyled-button:active,
-.unstyled-button:hover,
-.unstyled-button:focus {
-	background: unset;
-	border: none;
-	padding: 0;
-	margin: 0;
-}
-
-/*
-	NcPopover is a wrapper around Dropdown from floating-vue.
-  But any NcPopover component added to the web-pages globally changes default floating-vue styles.
-
-  - It is impossible to changes styles of inner block with NcPopover component (no props for that)
-  - It is impossible to use default Dropdown from floating-vue (styles are overrided globally)
-
-  So, let's re-override these styles...
-  Better options:
-  - Fix NcPopover
-  - Create a new Dropdown using renderless components from floating-vue
-*/
-.user-menu :deep(.v-popper--theme-dropdown.v-popper__popper) {
-	margin: -2px 5px 0 0;
-}
 
 .user-menu :deep(.v-popper--theme-dropdown.v-popper__popper .v-popper__inner) {
 	border-radius: var(--border-radius-large);
@@ -204,29 +184,24 @@ function handleUserStatusChange(status) {
 .user-menu__trigger {
 	display: flex;
 	align-items: center;
-	margin: 0 !important; /* Re-define server default styles */
 }
 
 .user-menu__avatar {
 	box-sizing: content-box;
 }
 
+.user-menu__trigger:hover,
+.user-menu__trigger:active,
+.user-menu__trigger:focus,
+.user-menu__trigger:focus-visible {
+	.user-menu__avatar {
+		outline: 2px solid var(--color-main-text);
+		box-shadow: 0 0 0 4px var(--color-main-background);
+	}
+}
+
 .user-menu__server {
 	display: flex;
 	flex-direction: column;
-}
-
-.user-menu__trigger:hover .user-menu__avatar,
-.user-menu__trigger:active .user-menu__avatar,
-.user-menu__trigger:focus .user-menu__avatar {
-	border: 2px solid var(--color-primary-text)
-}
-
-.user-menu__wrapper {
-	/*margin: 0 4px;*/
-	padding: 8px;
-	/*background-color: var(--color-main-background);*/
-	/*border-radius: var(--border-radius-large);*/
-	/*box-shadow: 0 1px 5px var(--color-box-shadow);*/
 }
 </style>


### PR DESCRIPTION
### ☑️ Resolves

* There was a focusable element inside another focusable element
  * Some server global styles from button also have high specificity
  * Made avatar a button instead of wrapping into HTML button
  * Opens manually now, because floating vue doesn't support `role=button` as buttons
* Submenu is kept open after reopening the user menu
  * Closed
* Menu has unlimit width
  * Limited
* Server icon is not a square
  * Adjusted size
* Title bar has server specificfocus-visible underline
  * Removed

### 🖼️ Screenshots

🏚️ Before (2 focus) | 🏡 After (1 focus)
---|---
![image](https://github.com/user-attachments/assets/cb41c47e-bd20-4b2e-8b4b-440a4c675095) | ![image](https://github.com/user-attachments/assets/eca8102d-87ce-47b3-b311-077da2bdd30c)
![image](https://github.com/user-attachments/assets/a2b3ff6f-eed7-494c-aae3-d4a7357c01ba) | .

🏚️ Before | 🏡 After
---|---
![image](https://github.com/user-attachments/assets/d8f6f199-05ef-4b1a-822d-ffdba72386e2) | ![image](https://github.com/user-attachments/assets/c0d74a1a-bdb2-4892-b8be-bb752c0ed3f6)
![before](https://github.com/user-attachments/assets/44494ebc-af3b-4bae-b162-51ed446d2073) | ![after](https://github.com/user-attachments/assets/c325b815-4017-409b-94db-cb75d67ae5cb)
![image](https://github.com/user-attachments/assets/02c9aac2-d482-40ca-9f41-2d34d67199b0) | ![image](https://github.com/user-attachments/assets/24c1bd8c-1d84-425e-820f-719d844ad8d5)
![image](https://github.com/user-attachments/assets/1d62599a-e3b1-4074-976f-41dc50584382) | ![image](https://github.com/user-attachments/assets/66e734e8-4fdc-4da4-937e-e40cef4500bc)
