### PR TITLE
fix(patchers): ignore unset baseURL in @nextcloud/router

### DIFF
--- a/src/patchers/@nextcloud/router.js
+++ b/src/patchers/@nextcloud/router.js
@@ -30,8 +30,8 @@ export const linkTo = (...args) => window.OCA.Talk.Desktop.runWithAbsoluteWebroo
 export const getBaseUrl = (...args) => window.OCA.Talk.Desktop.runWithAbsoluteWebroot(_getRootUrl, ...args)
 
 // Requires changing the default options.baseUrl from original relative getBaseUrl to new absolute getBaseUrl
-export const generateRemoteUrl = (service, options = {}) => _generateRemoteUrl(service, { baseURL: getBaseUrl(), ...options })
-export const generateOcsUrl = (url, params, options = {}) => _generateOcsUrl(url, params, { baseURL: getBaseUrl(), ...options })
+export const generateRemoteUrl = (service, options = {}) => _generateRemoteUrl(service, { ...options, baseURL: options.baseURL || getBaseUrl() })
+export const generateOcsUrl = (url, params, options = {}) => _generateOcsUrl(url, params, { ...options, baseURL: options.baseURL || getBaseUrl() })
 
 // By default, Talk requests images and sounds as a file from server assets using generateFilePath
 // Desktop app should use path to the local file in the bundle


### PR DESCRIPTION
### ☑️ Resolves

* Talk Desktop defines the default value for `baseUrl` in `@nextcloud/router` requests, it is it not explicitly set
* But if it's set as `undefined` or other `falsy` value, Nextcloud Talk keeps it as a set value
* It results in requesting without `baseURL`
* Solution: only set `baseURL` if it is not actually set with `truthy` value

Example of the problematic place:
https://github.com/nextcloud/spreed/blob/29af6dac6325af9bba16b4706bb09066b601165e/src/utils/signaling.js#L980-L981