### PR TITLE
fix: make Talk window more compact to fit into full HD

### DIFF
--- a/src/talk/talk.window.js
+++ b/src/talk/talk.window.js
@@ -44,8 +44,8 @@ function createTalkWindow() {
 
 	const window = new BrowserWindow({
 		...talkWindowOptions,
-		width: Math.min(1680, screenWidth),
-		height: Math.min(1050, screenHeight),
+		width: Math.min(1400, screenWidth),
+		height: Math.min(900, screenHeight),
 		show: false,
 	})
 


### PR DESCRIPTION
### ☑️ Resolves

* Previous 1680x1050 was too huge for FHD screen (1050 + title bar > 1080 - task bar)
  * With a new compact design we can make it smaller and yet fit Media Settings
  * Ref: https://github.com/nextcloud/talk-desktop/pull/682
* ~~Make the window initially maximized~~
  * ~~It seems like most of the users use it maximized anyway~~
  * Dropped

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![image](https://github.com/user-attachments/assets/7f9f154c-f7ac-49b4-adc2-e2ff27cd5881) | ![image](https://github.com/user-attachments/assets/58888882-e81c-4264-9370-8f0843dc5934)
