### PR TITLE
fix: federation feature is always disabled

### DIFF
--- a/src/shared/setupWebPage.js
+++ b/src/shared/setupWebPage.js
@@ -135,7 +135,7 @@ function getInitialStateFromCapabilities(capabilities, userMetadata) {
 			sip_dialin_info: undefined, // TODO: Missed in Capabilities. Is it a problem?
 			grid_videos_limit: 19, // TODO: Missed in Capabilities. Is it a problem?
 			grid_videos_limit_enforced: false, // TODO: Missed in Capabilities. Is it a problem?
-			federation_enabled: false, // TODO: Missed in Capabilities. Is it a problem?
+			federation_enabled: capabilities?.spreed?.config?.federation?.enabled,
 			start_conversations: capabilities?.spreed?.config?.conversations?.['can-create'],
 			circles_enabled: false, // TODO: Missed in Capabilities. Is it a problem?
 			guests_accounts_enabled: true, // TODO: Missed in Capabilities. It is a problem


### PR DESCRIPTION
### ☑️ Resolves

* Federation feature seems disabled on Talk Desktop. For example, you don't see invitations
* `federation_enabled` state in initial state was not set
  * It's better if frontend uses capabilities here...

### 🖼️ Screenshots

![image](https://github.com/user-attachments/assets/dba4eef6-52d9-413a-9743-71dc806bc898)