### PR TITLE
release: v0.35.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@
 
 # Changelog
 
+## v0.35.0 - 2024-08-16
+
+### Build-in Talk update
+
+- Built-in Talk in binaries is updated to v20.0.0-rc.2
+
+### Fixes
+
+- Adjust About window size and paddings [#754](https://github.com/nextcloud/talk-desktop/pull/754)
+- Fix federated invitations support [#747](https://github.com/nextcloud/talk-desktop/pull/747)
+- Make Talk window default size smaller with new compact design [#746](https://github.com/nextcloud/talk-desktop/pull/746)
+- Fix the connection issue with losing base URL when built with Nextcloud Talk v20 [#742](https://github.com/nextcloud/talk-desktop/pull/742)
+
+### Other changes
+
+- Fix REUSE-compliance and check it on CI [#752](https://github.com/nextcloud/talk-desktop/pull/752)
+- Support building with Talk 21 (Nextcloud 31) [#751](https://github.com/nextcloud/talk-desktop/pull/751)
+
 ## v0.34.0 - 2024-08-05
 
 ### Build-in Talk update

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "talk-desktop",
-  "version": "0.34.0",
+  "version": "0.35.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "talk-desktop",
-      "version": "0.34.0",
+      "version": "0.35.0",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@mdi/svg": "^7.4.47",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "name": "talk-desktop",
   "productName": "Nextcloud Talk",
-  "version": "0.34.0",
+  "version": "0.35.0",
   "description": "Official Desktop client for Nextcloud Talk",
   "bugs": "https://github.com/nextcloud/talk-desktop/issues",
   "license": "AGPL-3.0-or-later",


### PR DESCRIPTION
## v0.35.0 - 2024-08-16

### Build-in Talk update

- Built-in Talk in binaries is updated to v20.0.0-rc.2

### Fixes

- Adjust About window size and paddings [#754](https://github.com/nextcloud/talk-desktop/pull/754)
- Fix federated invitations support [#747](https://github.com/nextcloud/talk-desktop/pull/747)
- Make Talk window default size smaller with new compact design [#746](https://github.com/nextcloud/talk-desktop/pull/746)
- Fix the connection issue with losing base URL when built with Nextcloud Talk v20 [#742](https://github.com/nextcloud/talk-desktop/pull/742)

### Other changes

- Fix REUSE-compliance and check it on CI [#752](https://github.com/nextcloud/talk-desktop/pull/752)
- Support building with Talk 21 (Nextcloud 31) [#751](https://github.com/nextcloud/talk-desktop/pull/751)

### What's Changed

<details>

* fix: federation feature is always disabled by @ShGKme in https://github.com/nextcloud/talk-desktop/pull/747
* build(deps): Bump pinia from 2.2.0 to 2.2.1 by @dependabot in https://github.com/nextcloud/talk-desktop/pull/749
* build(deps): Bump core-js from 3.37.1 to 3.38.0 by @dependabot in https://github.com/nextcloud/talk-desktop/pull/750
* build(deps): Bump @nextcloud/vue from 8.15.1 to 8.16.0 by @dependabot in https://github.com/nextcloud/talk-desktop/pull/748
* fix: make Talk window more compact to fit into full HD by @ShGKme in https://github.com/nextcloud/talk-desktop/pull/746
* build: server 31 support by @ShGKme in https://github.com/nextcloud/talk-desktop/pull/751
* chore(ci): add reuse check and fix reuse by @ShGKme in https://github.com/nextcloud/talk-desktop/pull/752
* fix(help): adjust paddings and elements size by @ShGKme in https://github.com/nextcloud/talk-desktop/pull/754

</details>

**Full Changelog**: https://github.com/nextcloud/talk-desktop/compare/v0.34.0...v0.35.0

> 📥 Download Binaries on https://github.com/nextcloud-releases/talk-desktop/releases/tag/v0.35.0