### PR TITLE
fix(talk): set --header-height

### DIFF
--- a/src/shared/setupWebPage.js
+++ b/src/shared/setupWebPage.js
@@ -10,6 +10,7 @@ import { applyBodyThemeAttrs } from './theme.utils.js'
 import { appData } from '../app/AppData.js'
 import { initGlobals } from './globals/globals.js'
 import { setupInitialState } from './initialState.service.js'
+import { TITLE_BAR_HEIGHT } from '../constants.js'
 
 /**
  * @param {string} lang - language code, TS type: `${lang}_${countryCode}`|`${lang}`
@@ -183,9 +184,17 @@ function getInitialStateFromCapabilities(capabilities, userMetadata) {
  * Apply initial state to the document by rendering <input type="hidden"> elements with initial state data.
  * Used by @nextcloud/initial-state package.
  */
-export function applyInitialState() {
+function applyInitialState() {
 	const initialState = getInitialStateFromCapabilities(appData.capabilities, appData.userMetadata)
 	setupInitialState(initialState)
+}
+
+/**
+ * Set CSS variable for --header-height
+ */
+function applyHeaderHeight() {
+	document.body.style.setProperty('--header-height', `${TITLE_BAR_HEIGHT}px`, 'important')
+	document.documentElement.style.setProperty('--header-height', `${TITLE_BAR_HEIGHT}px`, 'important')
 }
 
 /**
@@ -199,6 +208,7 @@ export async function setupWebPage() {
 	window.OS = await window.TALK_DESKTOP.getOs()
 	applyUserData()
 	applyBodyThemeAttrs()
+	applyHeaderHeight()
 	applyAxiosInterceptors()
 	await applyL10n()
 }

--- a/src/talk/renderer/init.js
+++ b/src/talk/renderer/init.js
@@ -9,7 +9,6 @@ import { getCapabilities } from '../../shared/ocs.service.js'
 import { setInitialState } from '../../shared/initialState.service.js'
 import { subscribe } from '@nextcloud/event-bus'
 import { getCurrentUser } from '@nextcloud/auth'
-import { TITLE_BAR_HEIGHT } from '../../constants.js'
 
 /**
  * Fetch and load server styles.
@@ -49,9 +48,6 @@ export async function initServerStyles() {
 export async function initLocalStyles() {
 	// Load styles overrides
 	await import('./assets/overrides.css')
-
-	document.body.style.setProperty('--header-height', `${TITLE_BAR_HEIGHT}px`, 'important')
-	document.documentElement.style.setProperty('--header-height', `${TITLE_BAR_HEIGHT}px`, 'important')
 }
 
 /**


### PR DESCRIPTION
### ☑️ Resolves

* The header was still visually 50px even its content and system title bar is 50px. It should be 46px.
  * On screenshots see 4px gap under the minimize button
* By mistake I set height in `initLocalStyles` which is not used after another PR made that time

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![image](https://github.com/user-attachments/assets/448923ef-cff4-4c13-9cf8-ca27176d3581) | ![image](https://github.com/user-attachments/assets/a18cfc7d-b61c-449d-afe7-3cb8d3a11b14)
