### PR TITLE
fix(UserMenu): reset default button color style

### DIFF
--- a/src/talk/renderer/components/UiMenuItem.vue
+++ b/src/talk/renderer/components/UiMenuItem.vue
@@ -58,6 +58,7 @@ defineProps({
 	width: 100%;
 	/* Override default global button styles */
 	margin: 0 !important;
+	color: var(--color-main-text);
 }
 
 /*.menu-item__action:active,*/


### PR DESCRIPTION
### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![image](https://github.com/user-attachments/assets/a87d791d-3003-43a2-bcb6-23d8658d5cc0) | ![image](https://github.com/user-attachments/assets/778df222-a168-40b4-8615-c46343e22110)