### PR TITLE
refactor: remove --header-height set on .content

### DIFF
--- a/src/talk/renderer/assets/overrides.css
+++ b/src/talk/renderer/assets/overrides.css
@@ -14,8 +14,6 @@ body {
 }
 
 .content {
-	/* TODO: upstream using --header-height on NcContent margin-top */
-	margin-top: var(--header-height) !important;
 	border-radius: 0 !important;
 }
 


### PR DESCRIPTION
Unneeded after fix on upstream