### PR TITLE
release: v0.37.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@
 
 # Changelog
 
+## v0.37.0 - 2024-09-06
+
+### Build-in Talk update
+
+- Built-in Talk in binaries is updated to v20.0.0-rc.4
+
+### Features
+
+- Add PDF Viewer [#784](https://github.com/nextcloud/talk-desktop/pull/784)
+- Add Text, Markdown, and Source Code Viewer (read-only) [#785](https://github.com/nextcloud/talk-desktop/pull/785)
+
+### Fixes
+
+- Improve Viewer styling and loading/error handling [#783](https://github.com/nextcloud/talk-desktop/pull/783)
+
 ## v0.36.0 - 2024-08-27
 
 ### Build-in Talk update

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "talk-desktop",
-  "version": "0.36.0",
+  "version": "0.37.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "talk-desktop",
-      "version": "0.36.0",
+      "version": "0.37.0",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@mdi/svg": "^7.4.47",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "name": "talk-desktop",
   "productName": "Nextcloud Talk",
-  "version": "0.36.0",
+  "version": "0.37.0",
   "description": "Official Desktop client for Nextcloud Talk",
   "bugs": "https://github.com/nextcloud/talk-desktop/issues",
   "license": "AGPL-3.0-or-later",


### PR DESCRIPTION
## v0.37.0 - 2024-09-06
### Build-in Talk update

- Built-in Talk in binaries is updated to v20.0.0-rc.4

### Features

- Add PDF Viewer [#784](https://github.com/nextcloud/talk-desktop/pull/784)
- Add Text, Markdown, and Source Code Viewer (read-only) [#785](https://github.com/nextcloud/talk-desktop/pull/785)

### Fixes

- Improve Viewer styling and loading/error handling [#783](https://github.com/nextcloud/talk-desktop/pull/783)

### What's Changed

<details>

* chore: update workflows from templates by @nextcloud-command in https://github.com/nextcloud/talk-desktop/pull/765
* build(deps-dev): Bump zx from 8.1.4 to 8.1.5 by @dependabot in https://github.com/nextcloud/talk-desktop/pull/780
* build(deps): Bump @nextcloud/vue from 8.17.0 to 8.17.1 by @dependabot in https://github.com/nextcloud/talk-desktop/pull/779
* fix(viewer): improve styling and loading/error handling by @ShGKme in https://github.com/nextcloud/talk-desktop/pull/783
* feat(viewer): add PDF viewer by @ShGKme in https://github.com/nextcloud/talk-desktop/pull/784
* feat(viewer): add Text, Markdown and Source Code viewer (read-only) by @ShGKme in https://github.com/nextcloud/talk-desktop/pull/785

</details>

**Full Changelog**: https://github.com/nextcloud/talk-desktop/compare/v0.36.0...v0.37.0