### PR TITLE
refactor: rename mdi components from `Mdi*` to `Icon*`

### DIFF
--- a/src/authentication/renderer/AuthenticationApp.vue
+++ b/src/authentication/renderer/AuthenticationApp.vue
@@ -5,7 +5,7 @@
 
 <script setup>
 import { computed, ref } from 'vue'
-import MdiArrowRight from 'vue-material-design-icons/ArrowRight.vue'
+import IconArrowRight from 'vue-material-design-icons/ArrowRight.vue'
 import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
 import NcLoadingIcon from '@nextcloud/vue/dist/Components/NcLoadingIcon.js'
 import NcTextField from '@nextcloud/vue/dist/Components/NcTextField.js'
@@ -163,7 +163,7 @@ async function login() {
 						native-type="submit"
 						wide>
 						<template #icon>
-							<MdiArrowRight :size="20" />
+							<IconArrowRight :size="20" />
 						</template>
 						{{ t('talk_desktop', 'Log in') }}
 					</NcButton>

--- a/src/help/renderer/HelpApp.vue
+++ b/src/help/renderer/HelpApp.vue
@@ -6,7 +6,7 @@
 <script setup>
 import { onBeforeUnmount, onMounted } from 'vue'
 
-import MdiWindowClose from 'vue-material-design-icons/WindowClose.vue'
+import IconWindowClose from 'vue-material-design-icons/WindowClose.vue'
 import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
 
 import { translate as t } from '@nextcloud/l10n'
@@ -89,7 +89,7 @@ onBeforeUnmount(() => {
 
 		<NcButton type="secondary" wide @click="close">
 			<template #icon>
-				<MdiWindowClose />
+				<IconWindowClose />
 			</template>
 			{{ t('talk_desktop', 'Close') }}
 		</NcButton>

--- a/src/talk/renderer/UserStatus/components/UserStatusFormCustomMessage.vue
+++ b/src/talk/renderer/UserStatus/components/UserStatusFormCustomMessage.vue
@@ -8,7 +8,7 @@ import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
 import NcEmojiPicker from '@nextcloud/vue/dist/Components/NcEmojiPicker.js'
 import NcTextField from '@nextcloud/vue/dist/Components/NcTextField.js'
 import { translate as t } from '@nextcloud/l10n'
-import MdiEmoticonOutline from 'vue-material-design-icons/EmoticonOutline.vue'
+import IconEmoticonOutline from 'vue-material-design-icons/EmoticonOutline.vue'
 
 defineProps({
 	icon: {
@@ -43,7 +43,7 @@ const handleUserStatusMessageChange = (message) => {
 					<template v-if="icon">
 						{{ icon }}
 					</template>
-					<MdiEmoticonOutline v-else :size="20" />
+					<IconEmoticonOutline v-else :size="20" />
 				</template>
 			</NcButton>
 		</NcEmojiPicker>

--- a/src/talk/renderer/Viewer/ViewerApp.vue
+++ b/src/talk/renderer/Viewer/ViewerApp.vue
@@ -7,7 +7,7 @@
 import { computed, ref } from 'vue'
 import NcModal from '@nextcloud/vue/dist/Components/NcModal.js'
 import NcActionLink from '@nextcloud/vue/dist/Components/NcActionLink.js'
-import MdiOpenInNew from 'vue-material-design-icons/OpenInNew.vue'
+import IconOpenInNew from 'vue-material-design-icons/OpenInNew.vue'
 import { generateUrl } from '@nextcloud/router'
 import { translate as t } from '@nextcloud/l10n'
 
@@ -65,7 +65,7 @@ defineExpose({
 		<template #actions>
 			<NcActionLink :href="link">
 				<template #icon>
-					<MdiOpenInNew :size="20" />
+					<IconOpenInNew :size="20" />
 				</template>
 				{{ t('talk_desktop', 'Open in a Web-Browser') }}
 			</NcActionLink>

--- a/src/talk/renderer/components/DesktopMediaSourceDialog.vue
+++ b/src/talk/renderer/components/DesktopMediaSourceDialog.vue
@@ -6,8 +6,8 @@
 <script setup>
 import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
 
-import MdiCancel from '@mdi/svg/svg/cancel.svg?raw'
-import MdiMonitorShare from '@mdi/svg/svg/monitor-share.svg?raw'
+import IconCancel from '@mdi/svg/svg/cancel.svg?raw'
+import IconMonitorShare from '@mdi/svg/svg/monitor-share.svg?raw'
 
 import NcDialog from '@nextcloud/vue/dist/Components/NcDialog.js'
 import NcEmptyContent from '@nextcloud/vue/dist/Components/NcEmptyContent.js'
@@ -34,13 +34,13 @@ const handleCancel = () => emit('cancel')
 const dialogButtons = computed(() => [
 	{
 		label: t('talk_desktop', 'Cancel'),
-		icon: MdiCancel,
+		icon: IconCancel,
 		callback: handleCancel,
 	},
 	{
 		label: t('talk_desktop', 'Share screen'),
 		type: 'primary',
-		icon: MdiMonitorShare,
+		icon: IconMonitorShare,
 		disabled: !selectedSourceId.value,
 		callback: handleSubmit,
 	},

--- a/src/talk/renderer/components/DesktopMediaSourcePreview.vue
+++ b/src/talk/renderer/components/DesktopMediaSourcePreview.vue
@@ -6,9 +6,9 @@
 <script setup>
 import { onBeforeUnmount, onMounted, ref } from 'vue'
 
-import MdiMonitor from 'vue-material-design-icons/Monitor.vue'
-import MdiApplicationOutline from 'vue-material-design-icons/ApplicationOutline.vue'
-import MdiVolumeHigh from 'vue-material-design-icons/VolumeHigh.vue'
+import IconMonitor from 'vue-material-design-icons/Monitor.vue'
+import IconApplicationOutline from 'vue-material-design-icons/ApplicationOutline.vue'
+import IconVolumeHigh from 'vue-material-design-icons/VolumeHigh.vue'
 
 // On Wayland getting each stream for the live preview requests user to select the source via system dialog again
 // Instead - show static images.
@@ -114,9 +114,9 @@ onBeforeUnmount(() => {
 				alt=""
 				:src="source.icon"
 				class="capture-source__caption-icon">
-			<MdiVolumeHigh v-else-if="source.id.startsWith('entire-desktop:')" :size="16" />
-			<MdiMonitor v-else-if="source.id.startsWith('screen:')" :size="16" />
-			<MdiApplicationOutline v-else-if="source.id.startsWith('window:')" :size="16" />
+			<IconVolumeHigh v-else-if="source.id.startsWith('entire-desktop:')" :size="16" />
+			<IconMonitor v-else-if="source.id.startsWith('screen:')" :size="16" />
+			<IconApplicationOutline v-else-if="source.id.startsWith('window:')" :size="16" />
 			<span class="capture-source__caption-text">{{ source.name }}</span>
 		</span>
 	</label>

--- a/src/talk/renderer/components/MainMenu.vue
+++ b/src/talk/renderer/components/MainMenu.vue
@@ -6,11 +6,11 @@
 <script setup>
 import { computed } from 'vue'
 
-import MdiReload from 'vue-material-design-icons/Reload.vue'
-import MdiWeb from 'vue-material-design-icons/Web.vue'
-import MdiBug from 'vue-material-design-icons/Bug.vue'
-import MdiInformationOutline from 'vue-material-design-icons/InformationOutline.vue'
-import MdiMenu from 'vue-material-design-icons/Menu.vue'
+import IconReload from 'vue-material-design-icons/Reload.vue'
+import IconWeb from 'vue-material-design-icons/Web.vue'
+import IconBug from 'vue-material-design-icons/Bug.vue'
+import IconInformationOutline from 'vue-material-design-icons/InformationOutline.vue'
+import IconMenu from 'vue-material-design-icons/Menu.vue'
 
 import NcActions from '@nextcloud/vue/dist/Components/NcActions.js'
 import NcActionButton from '@nextcloud/vue/dist/Components/NcActionButton.js'
@@ -32,12 +32,12 @@ const reload = () => window.location.reload()
 		type="tertiary-no-background"
 		container="body">
 		<template #icon>
-			<MdiMenu :size="20" fill-color="var(--color-header-contrast)" />
+			<IconMenu :size="20" fill-color="var(--color-header-contrast)" />
 		</template>
 
 		<NcActionLink :href="talkWebLink" target="_blank">
 			<template #icon>
-				<MdiWeb :size="20" />
+				<IconWeb :size="20" />
 			</template>
 			{{ t('talk_desktop', 'Open in Web-Browser') }}
 		</NcActionLink>
@@ -46,13 +46,13 @@ const reload = () => window.location.reload()
 
 		<NcActionButton @click="reload">
 			<template #icon>
-				<MdiReload :size="20" />
+				<IconReload :size="20" />
 			</template>
 			{{ t('talk_desktop', 'Force reload') }}
 		</NcActionButton>
 		<NcActionLink :href="packageInfo.bugs" target="_blank">
 			<template #icon>
-				<MdiBug />
+				<IconBug />
 			</template>
 			{{ t('talk_desktop', 'Report a bug') }}
 		</NcActionLink>
@@ -61,7 +61,7 @@ const reload = () => window.location.reload()
 
 		<NcActionButton @click="showHelp">
 			<template #icon>
-				<MdiInformationOutline :size="20" />
+				<IconInformationOutline :size="20" />
 			</template>
 			{{ t('talk_desktop', 'About') }}
 		</NcActionButton>

--- a/src/talk/renderer/components/UserMenu.vue
+++ b/src/talk/renderer/components/UserMenu.vue
@@ -14,12 +14,12 @@ import NcAvatar from '@nextcloud/vue/dist/Components/NcAvatar.js'
 import NcPopover from '@nextcloud/vue/dist/Components/NcPopover.js'
 import NcUserStatusIcon from '@nextcloud/vue/dist/Components/NcUserStatusIcon.js'
 
-import MdiCheck from 'vue-material-design-icons/Check.vue'
-import MdiChevronRight from 'vue-material-design-icons/ChevronRight.vue'
-import MdiChevronLeft from 'vue-material-design-icons/ChevronLeft.vue'
-import MdiEmoticonOutline from 'vue-material-design-icons/EmoticonOutline.vue'
-import MdiPencil from 'vue-material-design-icons/Pencil.vue'
-import MdiLogout from 'vue-material-design-icons/Logout.vue'
+import IconCheck from 'vue-material-design-icons/Check.vue'
+import IconChevronRight from 'vue-material-design-icons/ChevronRight.vue'
+import IconChevronLeft from 'vue-material-design-icons/ChevronLeft.vue'
+import IconEmoticonOutline from 'vue-material-design-icons/EmoticonOutline.vue'
+import IconPencil from 'vue-material-design-icons/Pencil.vue'
+import IconLogout from 'vue-material-design-icons/Logout.vue'
 
 import ThemeLogo from './ThemeLogo.vue'
 import UiMenu from './UiMenu.vue'
@@ -99,7 +99,7 @@ function handleUserStatusChange(status) {
 					<template v-if="userStatusSubMenuOpen">
 						<UiMenuItem tag="button" @click.native.stop="userStatusSubMenuOpen = false">
 							<template #icon>
-								<MdiChevronLeft :size="20" />
+								<IconChevronLeft :size="20" />
 							</template>
 							{{ t('talk_desktop', 'Back') }}
 						</UiMenuItem>
@@ -112,7 +112,7 @@ function handleUserStatusChange(status) {
 							</template>
 							{{ userStatusTranslations[status] }}
 							<template v-if="status === userStatus.status" #action-icon>
-								<MdiCheck :size="20" />
+								<IconCheck :size="20" />
 							</template>
 						</UiMenuItem>
 					</template>
@@ -148,7 +148,7 @@ function handleUserStatusChange(status) {
 								</template>
 								{{ userStatusTranslations[userStatus.status] }}
 								<template #action-icon>
-									<MdiChevronRight :size="20" />
+									<IconChevronRight :size="20" />
 								</template>
 							</UiMenuItem>
 							<UiMenuItem key="custom-status" tag="button" @click.native="isUserStatusDialogOpen = true">
@@ -156,11 +156,11 @@ function handleUserStatusChange(status) {
 									<span v-if="userStatus.icon" style="font-size: 20px">
 										{{ userStatus.icon }}
 									</span>
-									<MdiEmoticonOutline v-else :size="20" />
+									<IconEmoticonOutline v-else :size="20" />
 								</template>
 								{{ userStatus.message || t('talk_desktop', 'Set custom status') }}
 								<template v-if="userStatus.message" #action-icon>
-									<MdiPencil :size="20" />
+									<IconPencil :size="20" />
 								</template>
 							</UiMenuItem>
 
@@ -169,7 +169,7 @@ function handleUserStatusChange(status) {
 
 						<UiMenuItem tag="button" @click.native="emit('logout')">
 							<template #icon>
-								<MdiLogout :size="20" />
+								<IconLogout :size="20" />
 							</template>
 							{{ t('talk_desktop', 'Log out') }}
 						</UiMenuItem>

--- a/src/upgrade/renderer/UpgradeApp.vue
+++ b/src/upgrade/renderer/UpgradeApp.vue
@@ -4,8 +4,8 @@
 -->
 
 <script setup>
-import MdiUpdate from 'vue-material-design-icons/Update.vue'
-import MdiWeb from 'vue-material-design-icons/Web.vue'
+import IconUpdate from 'vue-material-design-icons/Update.vue'
+import IconWeb from 'vue-material-design-icons/Web.vue'
 import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
 import { translate as t } from '@nextcloud/l10n'
 import { generateUrl } from '@nextcloud/router'
@@ -24,7 +24,7 @@ const browserLink = generateUrl('apps/spreed')
 			:href="packageInfo.repository"
 			target="_blank">
 			<template #icon>
-				<MdiUpdate />
+				<IconUpdate />
 			</template>
 			{{ t('talk_desktop', 'Update Talk Desktop ↗') }}
 		</NcButton>
@@ -32,7 +32,7 @@ const browserLink = generateUrl('apps/spreed')
 			wide
 			:href="browserLink">
 			<template #icon>
-				<MdiWeb />
+				<IconWeb />
 			</template>
 			{{ t('talk_desktop', 'Continue in Web-Browser ↗') }}
 		</NcButton>


### PR DESCRIPTION
Small refactoring - rename icons to follow Nextcloud server and some apps convention, which is also in line with Vue style guide.