### PR TITLE
fix(state): get typing privacy from capabilities

### DIFF
--- a/src/shared/setupWebPage.js
+++ b/src/shared/setupWebPage.js
@@ -141,6 +141,7 @@ function getInitialStateFromCapabilities(capabilities, userMetadata) {
 			circles_enabled: false, // TODO: Missed in Capabilities. Is it a problem?
 			guests_accounts_enabled: true, // TODO: Missed in Capabilities. It is a problem
 			read_status_privacy: capabilities?.spreed?.config?.chat?.['read-privacy'],
+			typing_privacy: capabilities?.spreed?.config?.chat?.['typing-privacy'],
 			play_sounds: true, // Consider playing sound enabled by default on desktop until we have settings
 			attachment_folder: capabilities?.spreed?.config?.attachments?.folder,
 			attachment_folder_free_space: userMetadata?.quota?.free ?? 0, // TODO: Is User's Quota free equal to attachment_folder_free_space


### PR DESCRIPTION
### ☑️ Resolves

* Fix disabled typing indicator in conversations

### 🚧 Tasks

- [ ] Follow-up / Fixup: 
	- [ ] Desktop client doesn't refetch capabilities, if they are changed (but hash isn't dirty)
