### PR TITLE
release: v0.38.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@
 
 # Changelog
 
+## v0.38.0 - 2024-09-19
+
+### Build-in Talk update
+
+- Built-in Talk in binaries is updated to v20.0.0
+
+### Fixes
+
+- Fix typing-status sharing being always disabled [#799](https://github.com/nextcloud/talk-desktop/pull/799)
+
 ## v0.37.0 - 2024-09-06
 
 ### Build-in Talk update

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "talk-desktop",
-  "version": "0.37.0",
+  "version": "0.38.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "talk-desktop",
-      "version": "0.37.0",
+      "version": "0.38.0",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@mdi/svg": "^7.4.47",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "name": "talk-desktop",
   "productName": "Nextcloud Talk",
-  "version": "0.37.0",
+  "version": "0.38.0",
   "description": "Official Desktop client for Nextcloud Talk",
   "bugs": "https://github.com/nextcloud/talk-desktop/issues",
   "license": "AGPL-3.0-or-later",


### PR DESCRIPTION
### Build-in Talk update

- Built-in Talk in binaries is updated to v20.0.0

### Fixes

- Fix typing-status sharing being always disabled [#799](https://github.com/nextcloud/talk-desktop/pull/799)

### What's Changed

<details>

* build(deps-dev): Bump eslint-plugin-vue from 9.27.0 to 9.28.0 by @dependabot in https://github.com/nextcloud/talk-desktop/pull/788
* build(deps-dev): Bump eslint-plugin-import from 2.29.1 to 2.30.0 by @dependabot in https://github.com/nextcloud/talk-desktop/pull/789
* build(deps): Bump @nextcloud/files from 3.8.0 to 3.9.0 by @dependabot in https://github.com/nextcloud/talk-desktop/pull/790
* build(deps-dev): Bump electron from 32.0.1 to 32.0.2 by @dependabot in https://github.com/nextcloud/talk-desktop/pull/791
* refactor: rename mdi components from `Mdi*` to `Icon*` by @ShGKme in https://github.com/nextcloud/talk-desktop/pull/787
* chore: ts support by @ShGKme in https://github.com/nextcloud/talk-desktop/pull/755
* build(deps-dev): Bump electron from 32.0.2 to 32.1.0 by @dependabot in https://github.com/nextcloud/talk-desktop/pull/797
* build(deps-dev): Bump typescript from 5.5.4 to 5.6.2 by @dependabot in https://github.com/nextcloud/talk-desktop/pull/798
* build(deps-dev): Bump vue-tsc from 2.0.29 to 2.1.6 by @dependabot in https://github.com/nextcloud/talk-desktop/pull/794
* build(deps-dev): Bump zx from 8.1.5 to 8.1.6 by @dependabot in https://github.com/nextcloud/talk-desktop/pull/796
* build(deps): Bump @nextcloud/vue from 8.17.1 to 8.18.0 by @dependabot in https://github.com/nextcloud/talk-desktop/pull/795
* fix(state): get typing privacy from capabilities by @Antreesy in https://github.com/nextcloud/talk-desktop/pull/799

</details>

**Full Changelog**: https://github.com/nextcloud/talk-desktop/compare/v0.37.0...v0.38.0

> 📥 Download Binaries on https://github.com/nextcloud-releases/talk-desktop/releases/tag/v0.38.0