### PR TITLE
chore(deps): bump vue-material-design-icons to 5.3.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "undici": "6.6.2",
         "unzip-crx-3": "^0.2.0",
         "vue": "^2.7.16",
-        "vue-material-design-icons": "^5.3.0"
+        "vue-material-design-icons": "^5.3.1"
       },
       "devDependencies": {
         "@electron-forge/cli": "^7.5.0",
@@ -19049,9 +19049,9 @@
       }
     },
     "node_modules/vue-material-design-icons": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/vue-material-design-icons/-/vue-material-design-icons-5.3.0.tgz",
-      "integrity": "sha512-wnbRh+48RwX/Gt+iqwCSdWpm0hPBwwv9F7MSouUzZ2PsphYVMJB9KkG9iGs+tgBiT57ZiurFEK07Y/rFKx+Ekg=="
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/vue-material-design-icons/-/vue-material-design-icons-5.3.1.tgz",
+      "integrity": "sha512-6UNEyhlTzlCeT8ZeX5WbpUGFTTPSbOoTQeoASTv7X4Ylh0pe8vltj+36VMK56KM0gG8EQVoMK/Qw/6evalg8lA=="
     },
     "node_modules/vue-resize": {
       "version": "1.0.1",
@@ -33363,9 +33363,9 @@
       }
     },
     "vue-material-design-icons": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/vue-material-design-icons/-/vue-material-design-icons-5.3.0.tgz",
-      "integrity": "sha512-wnbRh+48RwX/Gt+iqwCSdWpm0hPBwwv9F7MSouUzZ2PsphYVMJB9KkG9iGs+tgBiT57ZiurFEK07Y/rFKx+Ekg=="
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/vue-material-design-icons/-/vue-material-design-icons-5.3.1.tgz",
+      "integrity": "sha512-6UNEyhlTzlCeT8ZeX5WbpUGFTTPSbOoTQeoASTv7X4Ylh0pe8vltj+36VMK56KM0gG8EQVoMK/Qw/6evalg8lA=="
     },
     "vue-resize": {
       "version": "1.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,6 @@
         "@vueuse/core": "^11.1.0",
         "core-js": "^3.38.1",
         "electron-squirrel-startup": "^1.0.1",
-        "floating-vue": "^1.0.0-beta.19",
         "howler": "^2.2.4",
         "pinia": "^2.2.4",
         "semver": "^7.6.3",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "@vueuse/core": "^11.1.0",
     "core-js": "^3.38.1",
     "electron-squirrel-startup": "^1.0.1",
-    "floating-vue": "^1.0.0-beta.19",
     "howler": "^2.2.4",
     "pinia": "^2.2.4",
     "semver": "^7.6.3",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "undici": "6.6.2",
     "unzip-crx-3": "^0.2.0",
     "vue": "^2.7.16",
-    "vue-material-design-icons": "^5.3.0"
+    "vue-material-design-icons": "^5.3.1"
   },
   "devDependencies": {
     "@electron-forge/cli": "^7.5.0",


### PR DESCRIPTION
- chained on https://github.com/nextcloud/talk-desktop/pull/828