### PR TITLE
feat: add application config aka settings

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -124,4 +124,13 @@ module.exports = {
 		'@nextcloud/no-deprecations': 'off',
 		'@nextcloud/no-removed-apis': 'off',
 	},
+
+	overrides: [
+		{
+			files: '*.ts',
+			rules: {
+				'jsdoc/require-returns-type': 'off', // TODO upstream
+			},
+		},
+	],
 }

--- a/src/app/AppConfig.ts
+++ b/src/app/AppConfig.ts
@@ -1,0 +1,144 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { join } from 'node:path'
+import { readFile, writeFile } from 'node:fs/promises'
+import { app } from 'electron'
+import { isLinux } from '../shared/os.utils.js'
+
+const APP_CONFIG_FILE_NAME = 'config.json'
+
+// Windows: C:\Users\<username>\AppData\Roaming\Nextcloud Talk\config.json
+// Linux: ~/.config/Nextcloud Talk/config.json (or $XDG_CONFIG_HOME)
+// macOS: ~/Library/Application Support/Nextcloud Talk/config.json
+const APP_CONFIG_FILE_PATH = join(app.getPath('userData'), APP_CONFIG_FILE_NAME)
+
+/**
+ * Application level config. Applied to all accounts and persist on re-login.
+ * Stored in the application data directory.
+ */
+export type AppConfig = {
+	// ----------------
+	// General settings
+	// ----------------
+
+	// Nothing yet...
+
+	// -------------------
+	// Appearance settings
+	// -------------------
+
+	/**
+	 * Application theme.
+	 * Default: 'default' to follow the system theme.
+	 */
+	theme: 'default' | 'dark' | 'light'
+	/**
+	 * Whether to use a custom title bar or the system default.
+	 * Default: true on Linux, false otherwise.
+	 */
+	systemTitleBar: boolean
+
+	// ----------------
+	// Privacy settings
+	// ----------------
+
+	// Nothing yet...
+
+	// ----------------------
+	// Notifications settings
+	// ----------------------
+
+	// Nothing yet...
+}
+
+/**
+ * Get the default config
+ */
+const defaultAppConfig: AppConfig = {
+	theme: 'default',
+	systemTitleBar: isLinux(),
+}
+
+/** Local cache of the config file mixed with the default values */
+const appConfig: Partial<AppConfig> = {}
+/** Whether the application config has been read from the config file and ready to use */
+let initialized = false
+
+/**
+ * Read the application config from the file
+ */
+async function readAppConfigFile(): Promise<Partial<AppConfig>> {
+	try {
+		const content = await readFile(APP_CONFIG_FILE_PATH, 'utf-8')
+		return JSON.parse(content)
+	} catch (error) {
+		if (error instanceof Error && 'code' in error && error.code !== 'ENOENT') {
+			console.error('Failed to read the application config file', error)
+		}
+		// No file or invalid file - no custom config
+		return {}
+	}
+}
+
+/**
+ * Write the application config to the config file
+ * @param config - The config to write
+ */
+async function writeAppConfigFile(config: Partial<AppConfig>) {
+	try {
+		// Format for readability
+		const content = JSON.stringify(config, null, 2)
+		await writeFile(APP_CONFIG_FILE_PATH, content)
+	} catch (error) {
+		console.error('Failed to write the application config file', error)
+		throw error
+	}
+}
+
+/**
+ * Load the application config into the application memory
+ */
+export async function loadAppConfig() {
+	const config = await readAppConfigFile()
+	Object.assign(appConfig, config)
+	initialized = true
+}
+
+export function getAppConfig(): AppConfig
+export function getAppConfig<T extends keyof AppConfig>(key?: T): AppConfig[T]
+/**
+ * Get an application config value
+ * @param key - The config key to get
+ * @return - If key is provided, the value of the key. Otherwise, the full config
+ */
+export function getAppConfig<T extends keyof AppConfig>(key?: T): AppConfig | AppConfig[T] {
+	if (!initialized) {
+		throw new Error('The application config is not initialized yet')
+	}
+
+	const config = Object.assign({}, defaultAppConfig, appConfig)
+
+	if (key) {
+		return config[key]
+	}
+
+	return config
+}
+
+/**
+ * Set an application config value
+ * @param key - Settings key to set
+ * @param value - Value to set or undefined to reset to the default value
+ * @return Promise<AppConfig> - The full settings after the change
+ */
+export async function setAppConfig<K extends keyof AppConfig>(key: K, value?: AppConfig[K]) {
+	if (value !== undefined) {
+		appConfig[key] = value
+	} else {
+		delete appConfig[key]
+	}
+	await writeAppConfigFile(appConfig)
+}

--- a/src/authentication/authentication.window.js
+++ b/src/authentication/authentication.window.js
@@ -7,7 +7,7 @@ const { BrowserWindow } = require('electron')
 const { BASE_TITLE, TITLE_BAR_HEIGHT } = require('../constants.js')
 const { applyContextMenu } = require('../app/applyContextMenu.js')
 const { getBrowserWindowIcon } = require('../shared/icons.utils.js')
-const { isLinux } = require('../shared/os.utils.js')
+const { getAppConfig } = require('../app/AppConfig.ts')
 
 /**
  * @return {import('electron').BrowserWindow}
@@ -29,7 +29,7 @@ function createAuthenticationWindow() {
 			preload: AUTHENTICATION_WINDOW_PRELOAD_WEBPACK_ENTRY,
 		},
 		icon: getBrowserWindowIcon(),
-		titleBarStyle: isLinux() ? 'default' : 'hidden',
+		titleBarStyle: getAppConfig('systemTitleBar') ? 'default' : 'hidden',
 		titleBarOverlay: {
 			color: '#00679E00', // Transparent
 			symbolColor: '#FFFFFF', // White

--- a/src/main.js
+++ b/src/main.js
@@ -100,6 +100,12 @@ ipcMain.handle('app:getDesktopCapturerSources', async () => {
 	}))
 })
 
+/**
+ * Whether the window is being relaunched.
+ * At this moment there are no active windows, but the application should not quit yet.
+ */
+let isInWindowRelaunch = false
+
 app.whenReady().then(async () => {
 	await loadAppConfig()
 
@@ -261,9 +267,17 @@ app.whenReady().then(async () => {
 		mainWindow = upgradeWindow
 	})
 
+	ipcMain.on('app:relaunchWindow', () => {
+		isInWindowRelaunch = true
+		mainWindow.destroy()
+		mainWindow = createMainWindow()
+		mainWindow.once('ready-to-show', () => mainWindow.show())
+		isInWindowRelaunch = false
+	})
+
 	// On OS X it's common to re-create a window in the app when the
 	// dock icon is clicked and there are no other windows open.
-	app.on('activate', function() {
+	app.on('activate', () => {
 		if (BrowserWindow.getAllWindows().length === 0) {
 			mainWindow = createMainWindow()
 		}
@@ -274,7 +288,7 @@ app.whenReady().then(async () => {
 // for applications and their menu bar to stay active until the user quits
 // explicitly with Cmd + Q.
 app.on('window-all-closed', () => {
-	if (process.platform !== 'darwin') {
+	if (process.platform !== 'darwin' && !isInWindowRelaunch) {
 		app.quit()
 	}
 })

--- a/src/main.js
+++ b/src/main.js
@@ -16,6 +16,7 @@ const { getOs, isLinux, isMac, isWayland } = require('./shared/os.utils.js')
 const { createTalkWindow } = require('./talk/talk.window.js')
 const { createWelcomeWindow } = require('./welcome/welcome.window.js')
 const { installVueDevtools } = require('./install-vue-devtools.js')
+const { loadAppConfig, getAppConfig, setAppConfig } = require('./app/AppConfig.ts')
 
 /**
  * Parse command line arguments
@@ -67,6 +68,8 @@ ipcMain.on('app:relaunch', () => {
 	app.relaunch()
 	app.exit(0)
 })
+ipcMain.handle('app:config:get', (event, key) => getAppConfig(key))
+ipcMain.handle('app:config:set', (event, key, value) => setAppConfig(key, value))
 ipcMain.handle('app:getDesktopCapturerSources', async () => {
 	// macOS 10.15 Catalina or higher requires consent for screen access
 	if (isMac() && systemPreferences.getMediaAccessStatus('screen') !== 'granted') {
@@ -98,6 +101,8 @@ ipcMain.handle('app:getDesktopCapturerSources', async () => {
 })
 
 app.whenReady().then(async () => {
+	await loadAppConfig()
+
 	try {
 		await installVueDevtools()
 	} catch (error) {

--- a/src/preload.js
+++ b/src/preload.js
@@ -90,6 +90,19 @@ const TALK_DESKTOP = {
 	 */
 	relaunch: () => ipcRenderer.send('app:relaunch'),
 	/**
+	 * Get an application config value by key
+	 * @param {string} [key] - Config key
+	 * @return {Promise<Record<string, unknown> | unknown>}
+	 */
+	getAppConfig: (key) => ipcRenderer.invoke('app:config:get', key),
+	/**
+	 * Set an application config value by key
+	 * @param {string} key - Config key
+	 * @param {any} [value] - Config value
+	 * @return {Promise<void>}
+	 */
+	setAppConfig: (key, value) => ipcRenderer.invoke('app:config:set', key, value),
+	/**
 	 * Send appData to main process on restore
 	 *
 	 * @param {object} appDataDto appData as plain object

--- a/src/preload.js
+++ b/src/preload.js
@@ -86,9 +86,13 @@ const TALK_DESKTOP = {
 	 */
 	getDesktopCapturerSources: () => ipcRenderer.invoke('app:getDesktopCapturerSources'),
 	/**
-	 * Relaunch the application
+	 * Relaunch an entire application
 	 */
 	relaunch: () => ipcRenderer.send('app:relaunch'),
+	/**
+	 * Relaunch the main window without relaunching an entire application
+	 */
+	relaunchWindow: () => ipcRenderer.send('app:relaunchWindow'),
 	/**
 	 * Get an application config value by key
 	 * @param {string} [key] - Config key

--- a/src/shared/appConfig.service.ts
+++ b/src/shared/appConfig.service.ts
@@ -1,0 +1,44 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type { AppConfig } from '../app/AppConfig.ts'
+
+let appConfig: AppConfig | null = null
+
+/**
+ * Initialize the AppConfig
+ */
+export async function initAppConfig() {
+	if (appConfig) {
+		return
+	}
+
+	appConfig = await window.TALK_DESKTOP.getAppConfig()
+}
+
+/**
+ * Get AppConfig
+ * @return - AppConfig
+ */
+export function getAppConfig() {
+	if (!appConfig) {
+		throw new Error('AppConfig is not initialized')
+	}
+
+	return appConfig
+}
+
+/**
+ * Get an application config value
+ * @param key - The key of the config value
+ * @return - The config value
+ */
+export function getAppConfigValue<K extends keyof AppConfig>(key: K) {
+	if (!appConfig) {
+		throw new Error('AppConfig is not initialized')
+	}
+
+	return appConfig[key]
+}

--- a/src/shared/setupWebPage.js
+++ b/src/shared/setupWebPage.js
@@ -10,6 +10,7 @@ import { applyBodyThemeAttrs } from './theme.utils.js'
 import { appData } from '../app/AppData.js'
 import { initGlobals } from './globals/globals.js'
 import { setupInitialState } from './initialState.service.js'
+import { initAppConfig } from './appConfig.service.ts'
 import { TITLE_BAR_HEIGHT } from '../constants.js'
 
 /**
@@ -204,6 +205,7 @@ function applyHeaderHeight() {
 export async function setupWebPage() {
 	document.title = await window.TALK_DESKTOP.getAppName()
 	appData.restore()
+	await initAppConfig()
 	applyInitialState()
 	initGlobals()
 	window.OS = await window.TALK_DESKTOP.getOs()

--- a/src/shared/setupWebPage.js
+++ b/src/shared/setupWebPage.js
@@ -10,7 +10,7 @@ import { applyBodyThemeAttrs } from './theme.utils.js'
 import { appData } from '../app/AppData.js'
 import { initGlobals } from './globals/globals.js'
 import { setupInitialState } from './initialState.service.js'
-import { initAppConfig } from './appConfig.service.ts'
+import { getAppConfigValue, initAppConfig } from './appConfig.service.ts' // eslint-disable-line import/namespace
 import { TITLE_BAR_HEIGHT } from '../constants.js'
 
 /**
@@ -210,7 +210,7 @@ export async function setupWebPage() {
 	initGlobals()
 	window.OS = await window.TALK_DESKTOP.getOs()
 	applyUserData()
-	applyBodyThemeAttrs()
+	applyBodyThemeAttrs(getAppConfigValue('theme'))
 	applyHeaderHeight()
 	applyAxiosInterceptors()
 	await applyL10n()

--- a/src/talk/renderer/Settings/DesktopSettingsSection.vue
+++ b/src/talk/renderer/Settings/DesktopSettingsSection.vue
@@ -1,0 +1,87 @@
+<!--
+  - SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+  -->
+
+<script setup lang="ts">
+import { t } from '@nextcloud/l10n'
+import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
+import NcCheckboxRadioSwitch from '@nextcloud/vue/dist/Components/NcCheckboxRadioSwitch.js'
+import NcNoteCard from '@nextcloud/vue/dist/Components/NcNoteCard.js'
+import IconThemeLightDark from 'vue-material-design-icons/ThemeLightDark.vue'
+import SettingsSubsection from './components/SettingsSubsection.vue'
+import SettingsSelect from './components/SettingsSelect.vue'
+import { useAppConfigValue } from './useAppConfigValue.ts'
+import { useNcSelectModel } from '../composables/useNcSelectModel.ts'
+import { useAppConfig } from './appConfig.store.ts'
+import { storeToRefs } from 'pinia'
+
+const { isRelaunchRequired } = storeToRefs(useAppConfig())
+
+const theme = useAppConfigValue('theme')
+const themeOptions = [
+	{ label: t('talk_desktop', 'System default'), value: 'default' } as const,
+	{ label: t('talk_desktop', 'Light'), value: 'light' } as const,
+	{ label: t('talk_desktop', 'Dark'), value: 'dark' } as const,
+]
+const themeOption = useNcSelectModel(theme, themeOptions)
+
+const systemTitleBar = useAppConfigValue('systemTitleBar')
+
+/**
+ * Restart the app
+ */
+function relaunch() {
+	window.TALK_DESKTOP.relaunchWindow()
+}
+</script>
+
+<template>
+	<div>
+		<NcNoteCard v-if="isRelaunchRequired" type="info" class="relaunch-require-note-card">
+			<div class="relaunch-require-note-card__content">
+				<span>{{ t('talk_desktop', 'Some changes require a relaunch to take effect') }}</span>
+				<NcButton type="primary"
+					size="small"
+					class="relaunch-require-note-card__button"
+					@click="relaunch">
+					{{ t('talk_desktop', 'Restart') }}
+				</NcButton>
+			</div>
+		</NcNoteCard>
+
+		<SettingsSubsection :name="t('talk_desktop', 'Appearance')">
+			<SettingsSelect v-model="themeOption" :options="themeOptions">
+				<template #icon>
+					<IconThemeLightDark :size="20" />
+				</template>
+				{{ t('talk_desktop', 'Theme') }}
+			</SettingsSelect>
+
+			<NcCheckboxRadioSwitch :checked.sync="systemTitleBar" type="switch">
+				{{ t('talk_desktop', 'Use system title bar') }}
+			</NcCheckboxRadioSwitch>
+		</SettingsSubsection>
+	</div>
+</template>
+
+<style scoped>
+.relaunch-require-note-card {
+	margin-block-start: 0 !important;
+}
+
+.relaunch-require-note-card > :deep(div) {
+	flex: 1; /* TODO: fix in upstream */
+}
+
+.relaunch-require-note-card__content {
+	display: flex;
+	gap: var(--default-grid-baseline);
+	align-items: flex-start;
+}
+
+.relaunch-require-note-card__button {
+	margin-inline-start: auto;
+	flex: 0 0 auto;
+}
+</style>

--- a/src/talk/renderer/Settings/appConfig.store.ts
+++ b/src/talk/renderer/Settings/appConfig.store.ts
@@ -1,0 +1,53 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type { Ref } from 'vue'
+import type { AppConfig } from '../../../app/AppConfig.ts'
+import { readonly, ref, watch } from 'vue'
+import { defineStore } from 'pinia'
+import { getAppConfig } from '../../../shared/appConfig.service.ts'
+import { applyBodyThemeAttrs } from '../../../shared/theme.utils.js'
+
+export const useAppConfig = defineStore('appConfig', () => {
+	const appConfig: Ref<AppConfig> = ref(getAppConfig())
+	const isRelaunchRequired = ref(false)
+	const relaunchRequiredConfigs = ['systemTitleBar'] as const
+
+	const unwatchRelaunch = watch(
+		() => relaunchRequiredConfigs.map((key) => appConfig.value[key]),
+		() => {
+			isRelaunchRequired.value = true
+			unwatchRelaunch()
+		},
+	)
+
+	watch(() => appConfig.value.theme, (newTheme) => applyBodyThemeAttrs(newTheme))
+
+	/**
+	 * Get an application config value
+	 * @param key - The key of the config value
+	 * @return - The config
+	 */
+	function getAppConfigValue<K extends keyof AppConfig>(key: K) {
+		return appConfig.value[key]
+	}
+
+	/**
+	 * Set an application config value
+	 * @param key - The key of the config value
+	 * @param value - The value to set
+	 */
+	function setAppConfigValue<K extends keyof AppConfig>(key: K, value: AppConfig[K]) {
+		appConfig.value[key] = value
+		window.TALK_DESKTOP.setAppConfig(key, value)
+	}
+
+	return {
+		isRelaunchRequired: readonly(isRelaunchRequired),
+		appConfig: readonly(appConfig),
+		getAppConfigValue,
+		setAppConfigValue,
+	}
+})

--- a/src/talk/renderer/Settings/components/SettingsSelect.vue
+++ b/src/talk/renderer/Settings/components/SettingsSelect.vue
@@ -1,0 +1,77 @@
+<!--
+  - SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+  -->
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import NcSelect from '@nextcloud/vue/dist/Components/NcSelect.js'
+import type { NcSelectOption } from '../../composables/useNcSelectModel.ts'
+
+const props = defineProps<{
+	options: NcSelectOption<unknown>[]
+	modelValue: NcSelectOption<unknown>
+}>()
+
+const emit = defineEmits<{
+	(event: 'update:modelValue', value: NcSelectOption<unknown>): void
+}>()
+
+const model = computed({
+	get: () => props.modelValue,
+	set: (value: NcSelectOption<unknown>) => emit('update:modelValue', value),
+})
+</script>
+
+<script lang="ts">
+export default {
+	model: {
+		prop: 'modelValue',
+		event: 'update:modelValue',
+	},
+}
+</script>
+
+<template>
+	<label class="settings-select">
+		<span class="settings-select__label">
+			<span v-if="$slots.icon" class="settings-select__label-icon">
+				<slot name="icon" />
+			</span>
+			<span>
+				<slot />
+			</span>
+		</span>
+		<NcSelect v-model="model"
+			class="settings-select__select"
+			:options="options"
+			:clearable="false"
+			:searchable="false"
+			label-outside />
+	</label>
+</template>
+
+<style scoped>
+.settings-select {
+	--icon-height: 16px;
+	--icon-width: 36px;
+	display: flex;
+	gap: calc(var(--default-grid-baseline) * 2);
+	padding: 0 var(--default-grid-baseline) 0 calc((var(--default-clickable-area) - var(--icon-height)) / 2);
+}
+
+.settings-select__label {
+	display: flex;
+	align-items: center;
+	gap: var(--default-grid-baseline);
+}
+
+.settings-select__label-icon {
+	width: var(--icon-width);
+}
+
+.settings-select__select {
+	/* TODO: fix in upstream? */
+	margin: 0 !important;
+}
+</style>

--- a/src/talk/renderer/Settings/components/SettingsSubsection.vue
+++ b/src/talk/renderer/Settings/components/SettingsSubsection.vue
@@ -1,0 +1,30 @@
+<!--
+  - SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+  -->
+
+<script setup lang="ts">
+defineProps<{
+	name?: string
+}>()
+</script>
+
+<template>
+	<div class="settings-subsection">
+		<h4 v-if="name" class="settings-subsection__title">
+			{{ name }}
+		</h4>
+		<div class="setting-subsection__content">
+			<slot />
+		</div>
+	</div>
+</template>
+
+<style scoped>
+.setting-subsection__content {
+	display: flex;
+	flex-direction: column;
+	gap: var(--default-grid-baseline);
+	align-items: stretch;
+}
+</style>

--- a/src/talk/renderer/Settings/index.ts
+++ b/src/talk/renderer/Settings/index.ts
@@ -1,0 +1,19 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { t } from '@nextcloud/l10n'
+import DesktopSettingsSection from './DesktopSettingsSection.vue'
+import { createCustomElement } from '../utils/createCustomElement.ts'
+
+/**
+ * Register Talk Desktop settings sections
+ */
+export function registerTalkDesktopSettingsSection() {
+	window.OCA.Talk.Settings.registerSection({
+		id: 'talk-desktop-settings-application',
+		name: t('talk_desktop', 'Application'),
+		element: createCustomElement('talk-desktop-settings-application', DesktopSettingsSection).tagName,
+	})
+}

--- a/src/talk/renderer/Settings/useAppConfigValue.ts
+++ b/src/talk/renderer/Settings/useAppConfigValue.ts
@@ -1,0 +1,26 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type { AppConfig } from '../../../app/AppConfig.ts'
+import { computed } from 'vue'
+import { useAppConfig } from './appConfig.store.ts'
+
+/**
+ * Get an application config value
+ * @param key - The key of the config value
+ * @return - A settable config value
+ */
+export function useAppConfigValue<K extends keyof AppConfig>(key: K) {
+	const { getAppConfigValue, setAppConfigValue } = useAppConfig()
+
+	return computed({
+		get() {
+			return getAppConfigValue(key)
+		},
+		set(value: AppConfig[K]) {
+			setAppConfigValue(key, value)
+		},
+	})
+}

--- a/src/talk/renderer/components/MainMenu.vue
+++ b/src/talk/renderer/components/MainMenu.vue
@@ -6,6 +6,7 @@
 <script setup>
 import { computed } from 'vue'
 
+import IconCog from 'vue-material-design-icons/Cog.vue'
 import IconReload from 'vue-material-design-icons/Reload.vue'
 import IconWeb from 'vue-material-design-icons/Web.vue'
 import IconBug from 'vue-material-design-icons/Bug.vue'
@@ -25,6 +26,7 @@ const talkRouter = window.OCA.Talk.Desktop.talkRouter
 const talkWebLink = computed(() => generateUrl(talkRouter.value?.currentRoute?.fullPath ?? ''))
 const showHelp = () => window.TALK_DESKTOP.showHelp()
 const reload = () => window.location.reload()
+const openSettings = () => window.OCA.Talk.Settings.open()
 </script>
 
 <template>
@@ -59,6 +61,12 @@ const reload = () => window.location.reload()
 
 		<NcActionSeparator />
 
+		<NcActionButton close-after-click @click="openSettings">
+			<template #icon>
+				<IconCog :size="20" />
+			</template>
+			{{ t('talk_desktop', 'Settings') }}
+		</NcActionButton>
 		<NcActionButton @click="showHelp">
 			<template #icon>
 				<IconInformationOutline :size="20" />

--- a/src/talk/renderer/composables/useNcSelectModel.ts
+++ b/src/talk/renderer/composables/useNcSelectModel.ts
@@ -1,0 +1,27 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type { Ref, WritableComputedRef } from 'vue'
+import { computed } from 'vue'
+
+export type NcSelectOption<T> = { label: string, value: T }
+
+/**
+ * Create a model proxy for NcSelect
+ * @param modelValue - the model value to bind to
+ * @param options - the list of the select options
+ * @return - a model proxy for NcSelect
+ */
+export function useNcSelectModel<T>(modelValue: Ref<T>, options: NcSelectOption<T>[]): WritableComputedRef<NcSelectOption<T>> {
+	return computed({
+		get() {
+			return options.find(item => item.value === modelValue.value)!
+		},
+
+		set(option: NcSelectOption<T>) {
+			modelValue.value = option.value
+		},
+	})
+}

--- a/src/talk/renderer/talk.main.js
+++ b/src/talk/renderer/talk.main.js
@@ -16,6 +16,7 @@ import {
 import { setupWebPage } from '../../shared/setupWebPage.js'
 import { createViewer } from './Viewer/Viewer.js'
 import { createDesktopApp } from './desktop.app.js'
+import { registerTalkDesktopSettingsSection } from './Settings/index.ts'
 
 // Initially open the welcome page, if not specified
 if (!window.location.hash) {
@@ -35,5 +36,7 @@ await import('@talk/src/main.js')
 initTalkHashIntegration(window.OCA.Talk.instance)
 
 window.OCA.Talk.Desktop.talkRouter.value = window.OCA.Talk.instance.$router
+
+registerTalkDesktopSettingsSection()
 
 await import('./notifications/notifications.store.js')

--- a/src/talk/renderer/utils/createCustomElement.ts
+++ b/src/talk/renderer/utils/createCustomElement.ts
@@ -1,0 +1,44 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type { Component, ComponentInstance, DefineComponent } from 'vue'
+import Vue from 'vue'
+
+/**
+ * Create a custom element from a Vue component
+ * @param name - Name of the element
+ * @param component - Vue component to use as a settings section
+ */
+export function createCustomElement(name: string, component: Component): CustomElementConstructor & { tagName: string } {
+	class CustomElement extends HTMLElement {
+
+		static tagName = name + '-' + Math.random().toString(36).substring(6)
+
+		vm: ComponentInstance
+		rootElement: HTMLElement
+		isMounted: boolean = false
+
+		constructor() {
+			super()
+			this.rootElement = document.createElement('div')
+			const ComponentConstructor = Vue.extend(component as DefineComponent)
+			this.vm = new ComponentConstructor()
+		}
+
+		connectedCallback() {
+			if (this.isMounted) {
+				return
+			}
+			this.isMounted = true
+			this.appendChild(this.rootElement)
+			this.vm.$mount(this.rootElement)
+		}
+
+	}
+
+	window.customElements.define(CustomElement.tagName, CustomElement)
+
+	return CustomElement
+}

--- a/src/talk/talk.window.js
+++ b/src/talk/talk.window.js
@@ -10,8 +10,8 @@ const { applyDownloadNotification } = require('../app/applyDownloadNotification.
 const { applyWheelZoom } = require('../app/applyWheelZoom.js')
 const { setupTray } = require('../app/app.tray.js')
 const { getBrowserWindowIcon } = require('../shared/icons.utils.js')
-const { isLinux } = require('../shared/os.utils.js')
 const { TITLE_BAR_HEIGHT } = require('../constants.js')
+const { getAppConfig } = require('../app/AppConfig.ts')
 
 /**
  * @return {import('electron').BrowserWindow}
@@ -29,7 +29,7 @@ function createTalkWindow() {
 			preload: TALK_WINDOW_PRELOAD_WEBPACK_ENTRY,
 		},
 		icon: getBrowserWindowIcon(),
-		titleBarStyle: isLinux() ? 'default' : 'hidden',
+		titleBarStyle: getAppConfig('systemTitleBar') ? 'default' : 'hidden',
 		titleBarOverlay: {
 			color: '#00679E00', // Transparent
 			symbolColor: '#FFFFFF', // White

--- a/src/welcome/welcome.window.js
+++ b/src/welcome/welcome.window.js
@@ -5,10 +5,7 @@
 
 const { BrowserWindow } = require('electron')
 const { getBrowserWindowIcon } = require('../shared/icons.utils.js')
-const {
-	isMac,
-	isLinux,
-} = require('../shared/os.utils.js')
+const { isMac } = require('../shared/os.utils.js')
 
 /**
  * @return {import('electron').BrowserWindow}
@@ -21,7 +18,7 @@ function createWelcomeWindow() {
 		autoHideMenuBar: true,
 		center: true,
 		fullscreenable: false,
-		titleBarStyle: isLinux() ? 'default' : 'hidden',
+		titleBarStyle: 'hidden',
 		show: false,
 		useContentSize: true,
 		webPreferences: {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,5 +14,10 @@
 	},
 	"vueCompilerOptions": {
 		"target": 2.7,
+		"experimentalModelPropName": {
+			"modelValue": {
+				"SettingsSelect": true,
+			},
+		},
 	},
 }

--- a/webpack.main.config.js
+++ b/webpack.main.config.js
@@ -17,6 +17,13 @@ module.exports = merge(baseConfig, {
 	module: {
 		rules: [
 			{
+				test: /\.ts$/,
+				loader: 'esbuild-loader',
+				options: {
+					target: 'es2022',
+				},
+			},
+			{
 				test: /\.(png|ico|icns)$/,
 				include: path.resolve(__dirname, './img/icons'),
 				type: 'asset/resource',


### PR DESCRIPTION
### ☑️ Resolves

* Fix: https://github.com/nextcloud/talk-desktop/issues/27

### 🖼️ Screenshots

![image](https://github.com/user-attachments/assets/5ddcf8dd-116d-4f18-bb3d-5e7fed0102fa)

### 🚧 Tasks

Separated by commits with 💙

- [x] Add `AppConfig` - application level config
  - Stored in a file
  - Not bind to a specific user session
- [x] Add frontend for Settings, which includes:
 - Frontend API to init the config
 - Store and composables to work with AppConfig
 - Add a Talk Settings Section "Application"
- [x] Add some simple settings

More settings are ready and will come in a separate PR