### PR TITLE
feat: handle download links 

### DIFF
--- a/src/app/applyDownloadNotification.js
+++ b/src/app/applyDownloadNotification.js
@@ -26,14 +26,14 @@ export function applyDownloadNotification(browserWindow) {
 				notification.on('click', () => {
 					shell.showItemInFolder(pathToFile)
 				})
-			} else {
+			} else if (state === 'interrupted') {
 				notification = new Notification({
 					title: 'Download Failed',
 					body: `Something went wrong with the download of '${base}'.`,
 				})
 			}
 
-			notification.show()
+			notification?.show()
 		})
 	})
 }

--- a/src/app/downloads.ts
+++ b/src/app/downloads.ts
@@ -3,16 +3,16 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-const path = require('node:path')
-const { Notification, shell } = require('electron')
+import path from 'node:path'
+import { Notification, shell } from 'electron'
+import type { BrowserWindow } from 'electron'
 
 /**
- * Enable native OS notifications for downloaded files
- *
- * @param {import('electron').BrowserWindow} browserWindow - Browser window
+ * Handle downloads from a browser window to show notifications
+ * @param browserWindow - Browser window
  */
-export function applyDownloadNotification(browserWindow) {
-	browserWindow.webContents.session.on('will-download', (event, item, webContents) => {
+export function applyDownloadHandler(browserWindow: BrowserWindow) {
+	browserWindow.webContents.session.on('will-download', (event, item) => {
 		item.once('done', (event, state) => {
 			const pathToFile = item.getSavePath()
 			const { base, dir } = path.parse(pathToFile)

--- a/src/app/downloads.ts
+++ b/src/app/downloads.ts
@@ -8,11 +8,62 @@ import { Notification, shell } from 'electron'
 import type { BrowserWindow } from 'electron'
 
 /**
- * Handle downloads from a browser window to show notifications
+ * Suggested filenames for download URLs.
+ * In a Web-Browser, "download" attributes is used to suggest a filename for a download URL.
+ * Unfortunately, Electron does not support the `download` attribute on anchor tags.
+ * And there is no way to set the filename in the webContents.downloadURL API to get it on `will-download` event.
+ * It is necessary to keep track of suggested filenames for download URLs manually.
+ */
+const suggestedNames: Map<string, string> = new Map()
+
+/**
+ * Push a suggested filename for a download URL
+ * @param url - The URL to suggest a filename for
+ * @param filename - The suggested filename
+ */
+export function pushDownloadUrlFilenameSuggestion(url: string, filename: string) {
+	suggestedNames.set(url, filename)
+}
+
+/**
+ * Get a suggested filename for a download URL and remove it from the list
+ * @param url - The URL to pop a suggested filename for
+ * @return - The suggested filename if any
+ */
+function popDownloadUrlFilenameSuggestion(url: string): string | undefined {
+	const name = suggestedNames.get(url)
+	suggestedNames.delete(url)
+	return name
+}
+
+/**
+ * Trigger a download of a URL
+ * @param browserWindow - Browser window to use as a download context
+ * @param url - URL to download
+ * @param filename - Suggested filename for the download if any, otherwise determined from the URL
+ */
+export function triggerDownloadUrl(browserWindow: BrowserWindow, url: string, filename?: string) {
+	if (filename) {
+		pushDownloadUrlFilenameSuggestion(url, filename)
+	}
+	browserWindow.webContents.downloadURL(url)
+}
+
+/**
+ * Handle downloads from a browser window to:
+ * - show notifications
+ * - use suggested filenames
  * @param browserWindow - Browser window
  */
 export function applyDownloadHandler(browserWindow: BrowserWindow) {
 	browserWindow.webContents.session.on('will-download', (event, item) => {
+		const suggestedFilename = popDownloadUrlFilenameSuggestion(item.getURL())
+		if (suggestedFilename) {
+			item.setSaveDialogOptions({
+				defaultPath: suggestedFilename,
+			})
+		}
+
 		item.once('done', (event, state) => {
 			const pathToFile = item.getSavePath()
 			const { base, dir } = path.parse(pathToFile)

--- a/src/app/externalLinkHandlers.js
+++ b/src/app/externalLinkHandlers.js
@@ -34,7 +34,6 @@ function isExternalLink(url) {
  * @return {{action: 'deny'} | {action: 'allow', outlivesOpener?: boolean, overrideBrowserWindowOptions?: import('electron').BrowserWindowConstructorOptions}}
  */
 function windowOpenExternalLinkHandler(details, browserWindowOptions = {}) {
-	// TODO: Should handle different types of details.disposition? I.e. save-to-disk?
 	if (isExternalLink(details.url)) {
 		shell.openExternal(details.url)
 		return { action: 'deny' }

--- a/src/main.js
+++ b/src/main.js
@@ -17,6 +17,7 @@ const { createTalkWindow } = require('./talk/talk.window.js')
 const { createWelcomeWindow } = require('./welcome/welcome.window.js')
 const { installVueDevtools } = require('./install-vue-devtools.js')
 const { loadAppConfig, getAppConfig, setAppConfig } = require('./app/AppConfig.ts')
+const { triggerDownloadUrl } = require('./app/downloads.ts')
 
 /**
  * Parse command line arguments
@@ -274,6 +275,8 @@ app.whenReady().then(async () => {
 		mainWindow.once('ready-to-show', () => mainWindow.show())
 		isInWindowRelaunch = false
 	})
+
+	ipcMain.on('app:downloadURL', (event, url, filename) => triggerDownloadUrl(mainWindow, url, filename))
 
 	// On OS X it's common to re-create a window in the app when the
 	// dock icon is clicked and there are no other windows open.

--- a/src/preload.js
+++ b/src/preload.js
@@ -107,6 +107,12 @@ const TALK_DESKTOP = {
 	 */
 	setAppConfig: (key, value) => ipcRenderer.invoke('app:config:set', key, value),
 	/**
+	 * Trigger download of a URL
+	 * @param {string} url - URL to download
+	 * @param {string} [filename] - Filename suggestion for the download
+	 */
+	downloadURL: (url, filename) => ipcRenderer.send('app:downloadURL', url, filename),
+	/**
 	 * Send appData to main process on restore
 	 *
 	 * @param {object} appDataDto appData as plain object

--- a/src/shared/setupWebPage.js
+++ b/src/shared/setupWebPage.js
@@ -200,6 +200,19 @@ function applyHeaderHeight() {
 }
 
 /**
+ * Handle download links
+ */
+function applyDownloadLinkHandler() {
+	document.addEventListener('click', (event) => {
+		const link = event.target.closest('a')
+		if (link && link.hasAttribute('download')) {
+			event.preventDefault()
+			window.TALK_DESKTOP.downloadURL(link.href, link.download)
+		}
+	})
+}
+
+/**
  * Make all required initial setup for the web page for authorized user: server-rendered data, globals and ect.
  */
 export async function setupWebPage() {
@@ -214,4 +227,5 @@ export async function setupWebPage() {
 	applyHeaderHeight()
 	applyAxiosInterceptors()
 	await applyL10n()
+	applyDownloadLinkHandler()
 }

--- a/src/talk/talk.window.js
+++ b/src/talk/talk.window.js
@@ -6,7 +6,7 @@
 const { BrowserWindow, screen, nativeTheme } = require('electron')
 const { applyExternalLinkHandler } = require('../app/externalLinkHandlers.js')
 const { applyContextMenu } = require('../app/applyContextMenu.js')
-const { applyDownloadNotification } = require('../app/applyDownloadNotification.js')
+const { applyDownloadHandler } = require('../app/downloads.ts')
 const { applyWheelZoom } = require('../app/applyWheelZoom.js')
 const { setupTray } = require('../app/app.tray.js')
 const { getBrowserWindowIcon, getTrayIcon } = require('../shared/icons.utils.js')
@@ -63,7 +63,7 @@ function createTalkWindow() {
 	})
 
 	applyContextMenu(window)
-	applyDownloadNotification(window)
+	applyDownloadHandler(window)
 	applyWheelZoom(window)
 
 	const tray = setupTray(window)


### PR DESCRIPTION
### ☑️ Resolves

* Fix: https://github.com/nextcloud/talk-desktop/issues/824
* Requires: https://github.com/nextcloud/spreed/pull/13618

Unfortunately, there is no better way to handle download links. Electron doesn't handle it, doesn't trigger `will-download` nor allows detecting that the link was a download link in `will-navigate`

### 🖼️ Screenshots

![image](https://github.com/user-attachments/assets/6c34cf7d-44c0-4863-a3c4-20c9749c870c)
