### PR TITLE
fix(app): show window on activate on macOS

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -283,6 +283,7 @@ app.whenReady().then(async () => {
 	app.on('activate', () => {
 		if (BrowserWindow.getAllWindows().length === 0) {
 			mainWindow = createMainWindow()
+			mainWindow.once('ready-to-show', () => mainWindow.show())
 		}
 	})
 })


### PR DESCRIPTION
### ☑️ Resolves

* Fix: https://github.com/nextcloud/talk-desktop/issues/845

Unlike other OS, when all windows are closed on macOS, the app is still kept running (app's menu bar is active, icon in the Dock looks like open's app icon).

New click on the Dock icon should "activate" the app and create the window again.

But the window is created hidden by default (stays in the system tray).

The fix - explicitly show the window on activate.