### PR TITLE
fix(notifications): remove notification (talk) icon from notification image

### DIFF
--- a/src/talk/renderer/notifications/notifications.store.js
+++ b/src/talk/renderer/notifications/notifications.store.js
@@ -161,7 +161,6 @@ export function createNotificationStore() {
 			title: notification.subject,
 			lang: appData.userMetadata.locale,
 			body: notification.message,
-			icon: notification.icon,
 			tag: notification.notificationId,
 			// We have a custom sound
 			silent: true,


### PR DESCRIPTION
### ☑️ Resolves

In web-browser it makes sense to show Talk logo as notification image.

But on Desktop all Talk Desktop notifications are from the Talk, and there is an application icon already.

Icon show as the notification **image** should be removed.

Also, it is always dark.

![image](https://github.com/user-attachments/assets/f1e3265e-1f00-4abb-9348-a7943bbddfee)
