### PR TITLE
build: specify built-in Talk version in package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,8 +162,8 @@ npm run package:all
       ### Build-in Talk update
 
       Built-in Talk in binaries is updated to $(VERSION) Talk changelog: https://github.com/nextcloud/spreed/blob/master/CHANGELOG.md
-      ``` 
-3. Update `package.json`:  
+      ```
+3. Update `package.json`:
    - For minor update:
      ```sh
      npm version minor
@@ -198,9 +198,9 @@ npm run package:all
       ```md
       > 📥 Download Binaries on https://github.com/nextcloud-releases/talk-desktop/releases/tag/v$(version)
       ```
-9. Package release, specify version and platforms:
+9. Package release for specified platforms:
    ```sh
-   npm run release:package -- --version v$(talkVersion) --windows --linux --mac
+   npm run release:package -- --windows --linux --mac
    ```
 10. Upload packages to the GitHub Releases on [nextcloud-releases/talk-desktop](https://github.com/nextcloud-releases/talk-desktop/releases/lastest)
 11. Publish both releases on GitHub Releases

--- a/package.json
+++ b/package.json
@@ -34,6 +34,9 @@
     "lint": "eslint --ext .js,.vue src/ --fix",
     "typecheck": "vue-tsc --noEmit"
   },
+  "talk": {
+    "stable": "v20.0.1"
+  },
   "dependencies": {
     "@mdi/svg": "^7.4.47",
     "@nextcloud/axios": "^2.5.1",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "typecheck": "vue-tsc --noEmit"
   },
   "talk": {
-    "stable": "v20.0.1"
+    "stable": "v20.0.2"
   },
   "dependencies": {
     "@mdi/svg": "^7.4.47",

--- a/scripts/prepare-release-packages.mjs
+++ b/scripts/prepare-release-packages.mjs
@@ -3,10 +3,11 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+import { $, echo, spinner, argv, fs, os, usePwsh } from 'zx'
+const packageJson = require('../package.json')
+
 const TALK_PATH = './out/.temp/spreed/'
 const talkDotGit = `${TALK_PATH}.git`
-
-import { $, echo, spinner, argv, fs, os, usePwsh } from 'zx'
 
 $.quiet = true
 
@@ -21,11 +22,11 @@ function exit(message, code) {
 function help() {
 	echo`Prepare release packages for Talk Desktop with Talk in ${TALK_PATH}
 
-	Usage: npm run release:package -- --version=v17.0.0 --linux --mac --windows
+	Usage: npm run release:package -- --linux --mac --windows --version=v20.0.0
 
 	Args:
 	--help - show help
-	--version - Talk version to be build-in in the release, for example, v17.0.0-rc.1 or master
+	--version - Optionally a specific Talk version/branch to build with, for example, v20.0.0-rc.1 or main. Default to stable in package.json.
 	--windows - build Windows package
 	--linux - build Linux package
 	--mac - build macOS package
@@ -40,14 +41,14 @@ function help() {
  * @return {Promise<void>}
  */
 async function prepareRelease() {
+	const version = argv.version ?? packageJson.talk.stable
+
 	// Validate arguments
-	const version = argv.version
-	if (!version) {
-		exit(`❌ You must specify --version`, 1)
-	}
 	if (!argv.windows && !argv.linux && !argv.mac) {
 		exit('❌ You must specify at least one of --windows, --linux or --mac', 1)
 	}
+
+	echo`Packaging Nextcloud Talk v${packageJson.version} with Talk ${version}...`
 
 	// Git wrapper for Talk repository
 	const gitSpreed = (command) => $`git --git-dir=${talkDotGit} --work-tree=${TALK_PATH} ${command}`


### PR DESCRIPTION
### ☑️ Resolves

Allows to:
- Have the built-in Talk version in the repository history
- Have a PR to explicitly bump the built-in Talk version
- Reproduce a release package with a simple `git checkout version + release:package` instead of searching in the changelog for the Talk version
- Build release on CI. Before, a Talk version was manually specified by a developer during the release

Currently, it only affects the `release:package` script used in the releases.

Follow-ups:
- Use it for repo init instead of `git clone spreed`
- Automate built-in Talk version bump