### PR TITLE
build: add Linux flatpak

### DIFF
--- a/forge.config.js
+++ b/forge.config.js
@@ -8,6 +8,7 @@ const fs = require('node:fs')
 const semver = require('semver')
 const { MakerSquirrel } = require('@electron-forge/maker-squirrel')
 const { MakerDMG } = require('@electron-forge/maker-dmg')
+const { MakerFlatpak } = require('@electron-forge/maker-flatpak')
 const { MakerZIP } = require('@electron-forge/maker-zip')
 const packageJSON = require('./package.json')
 const { MIN_REQUIRED_BUILT_IN_TALK_VERSION } = require('./src/constants.js')
@@ -25,6 +26,8 @@ const CONFIG = {
 	appleAppBundleId: 'com.nextcloud.talk.mac',
 	// Windows
 	winAppId: 'NextcloudTalk',
+	// Linux
+	linuxAppId: 'com.nextcloud.talk',
 }
 
 const YEAR = new Date().getFullYear()
@@ -118,6 +121,63 @@ module.exports = {
 			additionalDMGOptions: {
 				// Background does not work when the title has spaces or special characters
 				title: 'NextcloudTalk',
+			},
+		}),
+
+		// Linux
+		new MakerFlatpak({
+			// https://js.electronforge.io/classes/_electron_forge_maker_flatpak.MakerFlatpak-1.html#config
+			options: {
+				id: CONFIG.linuxAppId,
+				// The default binary name in flatpak builder is packageJSON.name while the actual binary name from packager is applicationName
+				// Requires to be set explicitly
+				bin: CONFIG.applicationName,
+				productName: CONFIG.applicationName,
+				description: CONFIG.description,
+				genericName: 'Video and Chat Communication',
+				branch: 'stable',
+				// https://specifications.freedesktop.org/icon-theme-spec/latest/
+				icon: {
+					scalable: path.resolve(__dirname, 'img/talk-icon-rounded.svg'),
+				},
+				// https://specifications.freedesktop.org/menu-spec/latest/category-registry.html
+				categories: [
+					// Main Category
+					'Network',
+					// Additional Categories
+					'InstantMessaging',
+					'Chat',
+					'VideoConference',
+				],
+				finishArgs: [
+					/**
+					 * Default Electron args
+					 * https://github.com/malept/electron-installer-flatpak/blob/main/src/installer.js
+					 */
+
+					// X Rendering
+					'--socket=x11',
+					'--share=ipc',
+					// OpenGL
+					'--device=dri',
+					// Audio output
+					'--socket=pulseaudio',
+					// Read/write home directory access
+					'--filesystem=home',
+					// Chromium uses a socket in tmp for its singleton check
+					'--env=TMPDIR=/var/tmp',
+					// Allow communication with network
+					'--share=network',
+					// System notifications with libnotify
+					'--talk-name=org.freedesktop.Notifications',
+
+					/**
+					 * Additional args
+					 */
+
+					// Enable webcam access
+					'--device=all',
+				],
 			},
 		}),
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
       "devDependencies": {
         "@electron-forge/cli": "^7.5.0",
         "@electron-forge/maker-dmg": "^7.5.0",
+        "@electron-forge/maker-flatpak": "^7.5.0",
         "@electron-forge/maker-squirrel": "^7.5.0",
         "@electron-forge/maker-zip": "^7.5.0",
         "@electron-forge/plugin-webpack": "^7.5.0",
@@ -970,6 +971,23 @@
       },
       "optionalDependencies": {
         "electron-installer-dmg": "^5.0.1"
+      }
+    },
+    "node_modules/@electron-forge/maker-flatpak": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@electron-forge/maker-flatpak/-/maker-flatpak-7.5.0.tgz",
+      "integrity": "sha512-Sfz64NpRQZJq19g/BRGO5M4nTNAlhIxqRjbr0bTFLxs+zYlcn7Pmo+vPOBMHTup9veaBWR6VLFklTR5nRTlAfQ==",
+      "dev": true,
+      "dependencies": {
+        "@electron-forge/maker-base": "7.5.0",
+        "@electron-forge/shared-types": "7.5.0",
+        "fs-extra": "^10.0.0"
+      },
+      "engines": {
+        "node": ">= 16.4.0"
+      },
+      "optionalDependencies": {
+        "@malept/electron-installer-flatpak": "^0.11.4"
       }
     },
     "node_modules/@electron-forge/maker-squirrel": {
@@ -3258,6 +3276,154 @@
         "node": ">= 12.13.0"
       }
     },
+    "node_modules/@malept/electron-installer-flatpak": {
+      "version": "0.11.4",
+      "resolved": "https://registry.npmjs.org/@malept/electron-installer-flatpak/-/electron-installer-flatpak-0.11.4.tgz",
+      "integrity": "sha512-ZdwhT4WeeJWdnsmALUtQ7bn4pzYVh0Vg+4NnF1S3n3OACc9IWg+B+LxI5gT3XSXIrxogouqkjM6gD8S592awyA==",
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin",
+        "linux"
+      ],
+      "dependencies": {
+        "@malept/flatpak-bundler": "^0.4.0",
+        "debug": "^4.1.1",
+        "electron-installer-common": "^0.10.0",
+        "lodash": "^4.17.15",
+        "semver": "^7.1.1",
+        "yargs": "^16.0.0"
+      },
+      "bin": {
+        "electron-installer-flatpak": "bin/electron-installer-flatpak.js"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@malept/electron-installer-flatpak/node_modules/cliui": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      }
+    },
+    "node_modules/@malept/electron-installer-flatpak/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@malept/electron-installer-flatpak/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "optional": true
+    },
+    "node_modules/@malept/electron-installer-flatpak/node_modules/yargs": {
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@malept/electron-installer-flatpak/node_modules/yargs-parser": {
+      "version": "20.2.9",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+      "dev": true,
+      "optional": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@malept/flatpak-bundler": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@malept/flatpak-bundler/-/flatpak-bundler-0.4.0.tgz",
+      "integrity": "sha512-9QOtNffcOF/c1seMCDnjckb3R9WHcG34tky+FHpNKKCW0wc/scYLwMtO+ptyGUfMW0/b/n4qRiALlaFHc9Oj7Q==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "debug": "^4.1.1",
+        "fs-extra": "^9.0.0",
+        "lodash": "^4.17.15",
+        "tmp-promise": "^3.0.2"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@malept/flatpak-bundler/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@malept/flatpak-bundler/node_modules/fs-extra": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@malept/flatpak-bundler/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "optional": true
+    },
     "node_modules/@mapbox/hast-util-table-cell-style": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/@mapbox/hast-util-table-cell-style/-/hast-util-table-cell-style-0.2.0.tgz",
@@ -4370,6 +4536,16 @@
         "@types/qs": "*",
         "@types/range-parser": "*",
         "@types/send": "*"
+      }
+    },
+    "node_modules/@types/fs-extra": {
+      "version": "9.0.13",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-9.0.13.tgz",
+      "integrity": "sha512-nEnwB++1u5lVDM2UI4c1+5R+FYaKfaAzS4OococimjVm3nQw3TuzH5UNsocrcTBbhnerblyHj4A49qXbIiZdpA==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/glob": {
@@ -5969,6 +6145,39 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/asar": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/asar/-/asar-3.2.0.tgz",
+      "integrity": "sha512-COdw2ZQvKdFGFxXwX3oYh2/sOsJWJegrdJCGxnN4MZ7IULgRBp9P6665aqj9z1v9VwP4oP1hRBojRDQ//IGgAg==",
+      "deprecated": "Please use @electron/asar moving forward.  There is no API change, just a package name change",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "chromium-pickle-js": "^0.2.0",
+        "commander": "^5.0.0",
+        "glob": "^7.1.6",
+        "minimatch": "^3.0.4"
+      },
+      "bin": {
+        "asar": "bin/asar.js"
+      },
+      "engines": {
+        "node": ">=10.12.0"
+      },
+      "optionalDependencies": {
+        "@types/glob": "^7.1.1"
+      }
+    },
+    "node_modules/asar/node_modules/commander": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
+      "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
+      "dev": true,
+      "optional": true,
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/asn1.js": {
       "version": "4.10.1",
       "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
@@ -6831,6 +7040,13 @@
       "engines": {
         "node": ">=6.0"
       }
+    },
+    "node_modules/chromium-pickle-js": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/chromium-pickle-js/-/chromium-pickle-js-0.2.0.tgz",
+      "integrity": "sha512-1R5Fho+jBq0DDydt+/vHWj5KJNJCKdARKOCwZUen84I5BreWoLqRLANH1U87eJy1tiASPtMnGqJJq0ZsLoRPOw==",
+      "dev": true,
+      "optional": true
     },
     "node_modules/cipher-base": {
       "version": "1.0.4",
@@ -8038,6 +8254,97 @@
       "engines": {
         "node": ">= 12.20.55"
       }
+    },
+    "node_modules/electron-installer-common": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/electron-installer-common/-/electron-installer-common-0.10.3.tgz",
+      "integrity": "sha512-mYbP+6i+nHMIm0WZHXgGdmmXMe+KXncl6jZYQNcCF9C1WsNA9C5SZ2VP4TLQMSIoFO+X4ugkMEA5uld1bmyEvA==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@malept/cross-spawn-promise": "^1.0.0",
+        "asar": "^3.0.0",
+        "debug": "^4.1.1",
+        "fs-extra": "^9.0.0",
+        "glob": "^7.1.4",
+        "lodash": "^4.17.15",
+        "parse-author": "^2.0.0",
+        "semver": "^7.1.1",
+        "tmp-promise": "^3.0.2"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/electron-userland/electron-installer-common?sponsor=1"
+      },
+      "optionalDependencies": {
+        "@types/fs-extra": "^9.0.1"
+      }
+    },
+    "node_modules/electron-installer-common/node_modules/@malept/cross-spawn-promise": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@malept/cross-spawn-promise/-/cross-spawn-promise-1.1.1.tgz",
+      "integrity": "sha512-RTBGWL5FWQcg9orDOCcp4LvItNzUPcyEU9bwaeJX0rJ1IQxzucC48Y0/sQLp/g6t99IQgAlGIaesJS+gTn7tVQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/malept"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/subscription/pkg/npm-.malept-cross-spawn-promise?utm_medium=referral&utm_source=npm_fund"
+        }
+      ],
+      "optional": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/electron-installer-common/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/electron-installer-common/node_modules/fs-extra": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/electron-installer-common/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "optional": true
     },
     "node_modules/electron-installer-dmg": {
       "version": "5.0.1",
@@ -17559,6 +17866,26 @@
         "node": "*"
       }
     },
+    "node_modules/tmp": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.3.tgz",
+      "integrity": "sha512-nZD7m9iCPC5g0pYmcaxogYKggSfLsdxl8of3Q/oIbqCqLLIO9IAF0GWjX1z9NZRHPiXv8Wex4yDCaZsgEw0Y8w==",
+      "dev": true,
+      "optional": true,
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/tmp-promise": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/tmp-promise/-/tmp-promise-3.0.3.tgz",
+      "integrity": "sha512-RwM7MoPojPxsOBYnyd2hy0bxtIlVrihNs9pj5SUvY8Zz1sQcQG2tG1hSr8PDxfgEB8RNKDhqbIlroIarSNDNsQ==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "tmp": "^0.2.0"
+      }
+    },
     "node_modules/tn1150": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/tn1150/-/tn1150-0.1.0.tgz",
@@ -20306,6 +20633,18 @@
         "fs-extra": "^10.0.0"
       }
     },
+    "@electron-forge/maker-flatpak": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@electron-forge/maker-flatpak/-/maker-flatpak-7.5.0.tgz",
+      "integrity": "sha512-Sfz64NpRQZJq19g/BRGO5M4nTNAlhIxqRjbr0bTFLxs+zYlcn7Pmo+vPOBMHTup9veaBWR6VLFklTR5nRTlAfQ==",
+      "dev": true,
+      "requires": {
+        "@electron-forge/maker-base": "7.5.0",
+        "@electron-forge/shared-types": "7.5.0",
+        "@malept/electron-installer-flatpak": "^0.11.4",
+        "fs-extra": "^10.0.0"
+      }
+    },
     "@electron-forge/maker-squirrel": {
       "version": "7.5.0",
       "resolved": "https://registry.npmjs.org/@electron-forge/maker-squirrel/-/maker-squirrel-7.5.0.tgz",
@@ -21677,6 +22016,120 @@
         "cross-spawn": "^7.0.1"
       }
     },
+    "@malept/electron-installer-flatpak": {
+      "version": "0.11.4",
+      "resolved": "https://registry.npmjs.org/@malept/electron-installer-flatpak/-/electron-installer-flatpak-0.11.4.tgz",
+      "integrity": "sha512-ZdwhT4WeeJWdnsmALUtQ7bn4pzYVh0Vg+4NnF1S3n3OACc9IWg+B+LxI5gT3XSXIrxogouqkjM6gD8S592awyA==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "@malept/flatpak-bundler": "^0.4.0",
+        "debug": "^4.1.1",
+        "electron-installer-common": "^0.10.0",
+        "lodash": "^4.17.15",
+        "semver": "^7.1.1",
+        "yargs": "^16.0.0"
+      },
+      "dependencies": {
+        "cliui": {
+          "version": "7.0.4",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+          "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "string-width": "^4.2.0",
+            "strip-ansi": "^6.0.0",
+            "wrap-ansi": "^7.0.0"
+          }
+        },
+        "debug": {
+          "version": "4.3.7",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+          "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ms": "^2.1.3"
+          }
+        },
+        "ms": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+          "dev": true,
+          "optional": true
+        },
+        "yargs": {
+          "version": "16.2.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+          "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "cliui": "^7.0.2",
+            "escalade": "^3.1.1",
+            "get-caller-file": "^2.0.5",
+            "require-directory": "^2.1.1",
+            "string-width": "^4.2.0",
+            "y18n": "^5.0.5",
+            "yargs-parser": "^20.2.2"
+          }
+        },
+        "yargs-parser": {
+          "version": "20.2.9",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+          "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+          "dev": true,
+          "optional": true
+        }
+      }
+    },
+    "@malept/flatpak-bundler": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@malept/flatpak-bundler/-/flatpak-bundler-0.4.0.tgz",
+      "integrity": "sha512-9QOtNffcOF/c1seMCDnjckb3R9WHcG34tky+FHpNKKCW0wc/scYLwMtO+ptyGUfMW0/b/n4qRiALlaFHc9Oj7Q==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "debug": "^4.1.1",
+        "fs-extra": "^9.0.0",
+        "lodash": "^4.17.15",
+        "tmp-promise": "^3.0.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.7",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+          "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ms": "^2.1.3"
+          }
+        },
+        "fs-extra": {
+          "version": "9.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+          "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "at-least-node": "^1.0.0",
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^6.0.1",
+            "universalify": "^2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+          "dev": true,
+          "optional": true
+        }
+      }
+    },
     "@mapbox/hast-util-table-cell-style": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/@mapbox/hast-util-table-cell-style/-/hast-util-table-cell-style-0.2.0.tgz",
@@ -22440,6 +22893,16 @@
         "@types/qs": "*",
         "@types/range-parser": "*",
         "@types/send": "*"
+      }
+    },
+    "@types/fs-extra": {
+      "version": "9.0.13",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-9.0.13.tgz",
+      "integrity": "sha512-nEnwB++1u5lVDM2UI4c1+5R+FYaKfaAzS4OococimjVm3nQw3TuzH5UNsocrcTBbhnerblyHj4A49qXbIiZdpA==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "@types/node": "*"
       }
     },
     "@types/glob": {
@@ -23644,6 +24107,29 @@
         "is-shared-array-buffer": "^1.0.2"
       }
     },
+    "asar": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/asar/-/asar-3.2.0.tgz",
+      "integrity": "sha512-COdw2ZQvKdFGFxXwX3oYh2/sOsJWJegrdJCGxnN4MZ7IULgRBp9P6665aqj9z1v9VwP4oP1hRBojRDQ//IGgAg==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "@types/glob": "^7.1.1",
+        "chromium-pickle-js": "^0.2.0",
+        "commander": "^5.0.0",
+        "glob": "^7.1.6",
+        "minimatch": "^3.0.4"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
+          "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
+          "dev": true,
+          "optional": true
+        }
+      }
+    },
     "asn1.js": {
       "version": "4.10.1",
       "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
@@ -24290,6 +24776,13 @@
     "chrome-trace-event": {
       "version": "1.0.3",
       "dev": true
+    },
+    "chromium-pickle-js": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/chromium-pickle-js/-/chromium-pickle-js-0.2.0.tgz",
+      "integrity": "sha512-1R5Fho+jBq0DDydt+/vHWj5KJNJCKdARKOCwZUen84I5BreWoLqRLANH1U87eJy1tiASPtMnGqJJq0ZsLoRPOw==",
+      "dev": true,
+      "optional": true
     },
     "cipher-base": {
       "version": "1.0.4",
@@ -25142,6 +25635,67 @@
         "@electron/get": "^2.0.0",
         "@types/node": "^20.9.0",
         "extract-zip": "^2.0.1"
+      }
+    },
+    "electron-installer-common": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/electron-installer-common/-/electron-installer-common-0.10.3.tgz",
+      "integrity": "sha512-mYbP+6i+nHMIm0WZHXgGdmmXMe+KXncl6jZYQNcCF9C1WsNA9C5SZ2VP4TLQMSIoFO+X4ugkMEA5uld1bmyEvA==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "@malept/cross-spawn-promise": "^1.0.0",
+        "@types/fs-extra": "^9.0.1",
+        "asar": "^3.0.0",
+        "debug": "^4.1.1",
+        "fs-extra": "^9.0.0",
+        "glob": "^7.1.4",
+        "lodash": "^4.17.15",
+        "parse-author": "^2.0.0",
+        "semver": "^7.1.1",
+        "tmp-promise": "^3.0.2"
+      },
+      "dependencies": {
+        "@malept/cross-spawn-promise": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/@malept/cross-spawn-promise/-/cross-spawn-promise-1.1.1.tgz",
+          "integrity": "sha512-RTBGWL5FWQcg9orDOCcp4LvItNzUPcyEU9bwaeJX0rJ1IQxzucC48Y0/sQLp/g6t99IQgAlGIaesJS+gTn7tVQ==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "cross-spawn": "^7.0.1"
+          }
+        },
+        "debug": {
+          "version": "4.3.7",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+          "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ms": "^2.1.3"
+          }
+        },
+        "fs-extra": {
+          "version": "9.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+          "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "at-least-node": "^1.0.0",
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^6.0.1",
+            "universalify": "^2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+          "dev": true,
+          "optional": true
+        }
       }
     },
     "electron-installer-dmg": {
@@ -31808,6 +32362,23 @@
     },
     "tinycolor2": {
       "version": "1.4.2"
+    },
+    "tmp": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.3.tgz",
+      "integrity": "sha512-nZD7m9iCPC5g0pYmcaxogYKggSfLsdxl8of3Q/oIbqCqLLIO9IAF0GWjX1z9NZRHPiXv8Wex4yDCaZsgEw0Y8w==",
+      "dev": true,
+      "optional": true
+    },
+    "tmp-promise": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/tmp-promise/-/tmp-promise-3.0.3.tgz",
+      "integrity": "sha512-RwM7MoPojPxsOBYnyd2hy0bxtIlVrihNs9pj5SUvY8Zz1sQcQG2tG1hSr8PDxfgEB8RNKDhqbIlroIarSNDNsQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "tmp": "^0.2.0"
+      }
     },
     "tn1150": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@electron-forge/cli": "^7.5.0",
     "@electron-forge/maker-dmg": "^7.5.0",
+    "@electron-forge/maker-flatpak": "^7.5.0",
     "@electron-forge/maker-squirrel": "^7.5.0",
     "@electron-forge/maker-zip": "^7.5.0",
     "@electron-forge/plugin-webpack": "^7.5.0",


### PR DESCRIPTION
### ☑️ Resolves

* Fix: https://github.com/nextcloud/talk-desktop/issues/848

### How to test an existing build

1. Install [Flatpak](https://flatpak.org/setup/)
2. Get `.flatpak` file
3. Run and follow instructions (yes, password, yes, password)
   ```sh
   flatpak install <path to .flatpak>
   ```

### How to build

1. Install `flatpak`, `flatpak-builder`, and `elfutils`. Example for Ubuntu:
   ```sh
   sudo apt-get install -y flatpak flatpak-builder elfutils
   ```
2. Run 
   ```sh
   flatpak remote-add --if-not-exists --user flathub https://flathub.org/repo/flathub.flatpakrepo
   ```
3. Enable file:// protocol in git (you can disable it later, or try without it)
   ```sh
   git config --global --add protocol.file.allow always
   ```
4. Follow general package steps for Linux
   ```sh
   npm ci
   npm run build
   npm run package
   ```

### 🖼️ Screenshots

![image](https://github.com/user-attachments/assets/0dfabb23-682e-454f-9c79-593fde3083c5)
