### PR TITLE
fix: open second instance in edge cases

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -132,10 +132,27 @@ app.whenReady().then(async () => {
 
 	setupMenu()
 
-	const focusMainWindow = () => {
+	/**
+	 * Focus the main window. Restore/re-create it if needed.
+	 */
+	function focusMainWindow() {
+		// There is no main window at all, the app is not initialized yet - ignore
+		if (!createMainWindow) {
+			return
+		}
+
+		// There is no window (possible on macOS) - create
+		if (!mainWindow || mainWindow.isDestroyed()) {
+			mainWindow = createMainWindow()
+			mainWindow.once('ready-to-show', () => mainWindow.show())
+			return
+		}
+
+		// The window is minimized - restore
 		if (mainWindow.isMinimized()) {
 			mainWindow.restore()
 		}
+
 		// Show the window in case it is hidden in the system tray and focus it
 		mainWindow.show()
 	}

--- a/src/main.js
+++ b/src/main.js
@@ -214,10 +214,13 @@ app.whenReady().then(async () => {
  		*/
 	})
 
-	const welcomeWindow = createWelcomeWindow()
-	welcomeWindow.once('ready-to-show', () => welcomeWindow.show())
+	mainWindow = createWelcomeWindow()
+	createMainWindow = createWelcomeWindow
+	mainWindow.once('ready-to-show', () => mainWindow.show())
 
 	ipcMain.once('appData:receive', async (event, appData) => {
+		const welcomeWindow = mainWindow
+
 		if (appData.credentials) {
 			// User is authenticated - setup and start main window
 			enableWebRequestInterceptor(appData.serverUrl, {


### PR DESCRIPTION
### ☑️ Resolves

* Fix opening the second instance when the first one is not fully initialized (on welcome or creating a window)
* Fix opening the second instance when there are no windows in the first one (on macOS where app can run without windows)

![image](https://github.com/user-attachments/assets/f4dd1961-4e67-4233-a9ee-dbad98191aae)
