### PR TITLE
feat: add "Copy email address" to context menu

### DIFF
--- a/src/app/applyContextMenu.js
+++ b/src/app/applyContextMenu.js
@@ -49,19 +49,26 @@ export function applyContextMenu(browserWindow) {
 		}
 
 		// Add context actions for handling links
-		const menuLinkItems = [
-			{
-				label: 'Copy link address',
-				click: () => clipboard.writeText(params.linkURL),
-			},
-			{
-				label: 'Copy link text',
-				click: () => clipboard.writeText(params.linkText.trim() || params.linkURL),
-			},
-			{ type: 'separator' },
-		]
 		if (params.linkURL && isExternalLink(params.linkURL)) {
-			menuItems.push(...menuLinkItems)
+			const url = params.linkURL
+			const text = params.linkText.trim()
+			menuItems.push({
+				label: 'Copy link address',
+				click: () => clipboard.writeText(url),
+			})
+			if (text) {
+				menuItems.push({
+					label: 'Copy link text',
+					click: () => clipboard.writeText(text),
+				})
+			}
+			if (url.startsWith('mailto:')) {
+				menuItems.push({
+					label: 'Copy email address',
+					click: () => clipboard.writeText(url.slice('mailto:'.length)),
+				})
+			}
+			menuItems.push({ type: 'separator' })
 		}
 
 		// Add context actions for clipboard events and text editing


### PR DESCRIPTION
### ☑️ Resolves

* Fix: https://github.com/nextcloud/talk-desktop/issues/888
* Also remove "Copy link text" when there is no text to copy

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![image](https://github.com/user-attachments/assets/1a405ddd-824f-406b-8769-83409bf1a650) | ![image](https://github.com/user-attachments/assets/239c14b3-d9ea-4e98-8f2d-7d2525001f5d)
![image](https://github.com/user-attachments/assets/40242c8a-e02b-42ac-964c-51e14139943f) | ![image](https://github.com/user-attachments/assets/6f10f734-c92f-489e-b0ab-4b1aa116984f)
![image](https://github.com/user-attachments/assets/61c7e0fd-bd23-4254-b3fc-4091f360fa89) | ![image](https://github.com/user-attachments/assets/abfc4d69-0f05-4a6a-b290-506f25068b95)
