### PR TITLE
build(talk): bump stable Talk to `v20.1.0-rc.1`

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "typecheck": "vue-tsc --noEmit"
   },
   "talk": {
-    "stable": "v20.0.2"
+    "stable": "v20.1.0-rc.1"
   },
   "dependencies": {
     "@mdi/svg": "^7.4.47",


### PR DESCRIPTION
Note: although it's called `stable`, we use `rc` for both Talk and Talk Desktop until the final release. 