### PR TITLE
build: package to ZIP only for Linux

### DIFF
--- a/forge.config.js
+++ b/forge.config.js
@@ -197,8 +197,7 @@ module.exports = {
 			},
 		}),
 
-		// Portable, all platforms
-		new MakerZIP(),
+		new MakerZIP({}, ['linux']),
 	],
 
 	plugins: [


### PR DESCRIPTION
Removing packaging to `zip` from macOS and Windows. This was a temp solution and 

- For macOS it's definitely unnecessary - `.dmg` is a sufficient replacement
- For Windows, I'm not so sure... But until it's directly requested, let's get rid of it

For Linux there is no universal solution that works for everyone, so keeping zip as a universal base.

Note: `.zip` wasn't a completely "portable" installation — user data was always in the user folder.