### PR TITLE
build: fix default TALK_PATH check

### DIFF
--- a/forge.config.js
+++ b/forge.config.js
@@ -38,7 +38,7 @@ let talkPackageJson
 module.exports = {
 	hooks: {
 		generateAssets() {
-			if (!fs.existsSync(process.env.TALK_PATH)) {
+			if (!fs.existsSync(TALK_PATH)) {
 				throw new Error(`Path does not exist TALK_PATH=${TALK_PATH}`)
 			}
 


### PR DESCRIPTION
A small fix.

Because ENV var was checked instead of a local variable, the default value was ignored.

Allows developing without `.env` file when Talk is cloned to the `./spreed` as said in the README.