### PR TITLE
release: v1.0.0-rc.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,31 @@
 
 # Changelog
 
+## v1.0.0-rc.2 - 2024-11-22
+
+### Features
+
+- Add new About window with an improved diagnosis report [#917](https://github.com/nextcloud/talk-desktop/pull/917)
+- Add "Copy email address" to `mailto:` links context menu [#890](https://github.com/nextcloud/talk-desktop/pull/890)
+
+### Fixes
+
+- Fix light/dark theme is not applied to native parts of the app [#916](https://github.com/nextcloud/talk-desktop/pull/916)
+- Fix parallel installations sharing common settings [#891](https://github.com/nextcloud/talk-desktop/pull/891)
+- Fix macOS tray icon not following system style [#887](https://github.com/nextcloud/talk-desktop/pull/887)
+- Fix screensharing on Flatpak distribution in Wayland [#877](https://github.com/nextcloud/talk-desktop/pull/877)
+
+### Changes
+
+- Built-in Talk in binaries is updated to v20.1.0-rc.2 [#920](https://github.com/nextcloud/talk-desktop/pull/920)
+- Distributions for macOS and Windows are now signed with a certificate [#908](https://github.com/nextcloud/talk-desktop/pull/908)
+- New MSI distribution is now provided for Windows in administrated environments with GPO deployment [#922](https://github.com/nextcloud/talk-desktop/pull/922)
+- ZIP distribution is now provided only for Linux [#904](https://github.com/nextcloud/talk-desktop/pull/904)
+- Distribution for macOS is now universal (support both Apple Silicon and Intel Macs) [#896](https://github.com/nextcloud/talk-desktop/pull/896)
+- Flatpak distribution runtime and platform have been updated [#892](https://github.com/nextcloud/talk-desktop/pull/892)
+- Update translations
+- Update dependencies
+
 ## v1.0.0-rc.1 - 2024-11-11
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,14 +11,13 @@
 
 - Add application settings [#835](https://github.com/nextcloud/talk-desktop/pull/835)
 - Add monochrome tray icon setting [#836](https://github.com/nextcloud/talk-desktop/pull/836)
-- Add download links handling with a new [#840](https://github.com/nextcloud/talk-desktop/pull/840)
+- Add download links handling with a new message menu item [#840](https://github.com/nextcloud/talk-desktop/pull/840)
 - Add zoom setting and fix a number of zoom-related issues [#853](https://github.com/nextcloud/talk-desktop/pull/853)
 
 ### Fixes
 
 - Fix error on launching app twice quickly before it initializes [#856](https://github.com/nextcloud/talk-desktop/pull/876)
-- Fix focusing a window on macOS when there is no window [#856](https://github.com/nextcloud/talk-desktop/pull/876)
-- Fix window Show the window on activate on macOS [#852](https://github.com/nextcloud/talk-desktop/pull/852)
+- Fix login window cannot be reopened after close on macOS [#852](https://github.com/nextcloud/talk-desktop/pull/852)
 - Fix Viewer close not handled during a call [#835](https://github.com/nextcloud/talk-desktop/pull/835)
 - Fix preview not shown for a supported mime-type [#831](https://github.com/nextcloud/talk-desktop/pull/831)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "talk-desktop",
-  "version": "1.0.0-rc.1",
+  "version": "1.0.0-rc.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "talk-desktop",
-      "version": "1.0.0-rc.1",
+      "version": "1.0.0-rc.2",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@mdi/svg": "^7.4.47",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "name": "talk-desktop",
   "productName": "Nextcloud Talk",
-  "version": "1.0.0-rc.1",
+  "version": "1.0.0-rc.2",
   "description": "Official Desktop client for Nextcloud Talk",
   "bugs": {
     "url": "https://github.com/nextcloud/talk-desktop/issues",


### PR DESCRIPTION
## v1.0.0-rc.2 - 2024-11-22

### Features

- Add new About window with an improved diagnosis report [#917](https://github.com/nextcloud/talk-desktop/pull/917)
- Add "Copy email address" to `mailto:` links context menu [#890](https://github.com/nextcloud/talk-desktop/pull/890)

### Fixes

- Fix light/dark theme is not applied to native parts of the app [#916](https://github.com/nextcloud/talk-desktop/pull/916)
- Fix parallel installations sharing common settings [#891](https://github.com/nextcloud/talk-desktop/pull/891)
- Fix macOS tray icon not following system style [#887](https://github.com/nextcloud/talk-desktop/pull/887)
- Fix screensharing on Flatpak distribution in Wayland [#877](https://github.com/nextcloud/talk-desktop/pull/877)

### Changes

- Built-in Talk in binaries is updated to v20.1.0-rc.2 [#920](https://github.com/nextcloud/talk-desktop/pull/920)
- Distributions for macOS and Windows are now signed with a certificate [#908](https://github.com/nextcloud/talk-desktop/pull/908)
- New MSI distribution is now provided for Windows in administrated environments with GPO deployment [#922](https://github.com/nextcloud/talk-desktop/pull/922)
- ZIP distribution is now provided only for Linux [#904](https://github.com/nextcloud/talk-desktop/pull/904)
- Distribution for macOS is now universal (support both Apple Silicon and Intel Macs) [#896](https://github.com/nextcloud/talk-desktop/pull/896)
- Flatpak distribution runtime and platform have been updated [#892](https://github.com/nextcloud/talk-desktop/pull/892)
- Update translations
- Update dependencies