### PR TITLE
fix: apply selected theme also to native parts of the app

### DIFF
--- a/src/app/theme.config.ts
+++ b/src/app/theme.config.ts
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { nativeTheme } from 'electron'
+import { getAppConfig, onAppConfigChange } from './AppConfig.ts'
+
+onAppConfigChange('theme', applyTheme)
+
+/**
+ * Apply the application theme based on the AppConfig
+ */
+export function applyTheme() {
+	const theme = getAppConfig('theme')
+
+	// TODO: add high-contrast themes
+	const configToNativeTheme = {
+		default: 'system',
+		dark: 'dark',
+		light: 'light',
+	} as const
+
+	nativeTheme.themeSource = configToNativeTheme[theme]
+}

--- a/src/main.js
+++ b/src/main.js
@@ -19,6 +19,7 @@ const { createWelcomeWindow } = require('./welcome/welcome.window.js')
 const { installVueDevtools } = require('./install-vue-devtools.js')
 const { loadAppConfig, getAppConfig, setAppConfig } = require('./app/AppConfig.ts')
 const { triggerDownloadUrl } = require('./app/downloads.ts')
+const { applyTheme } = require('./app/theme.config.ts')
 
 /**
  * Parse command line arguments
@@ -115,6 +116,7 @@ let isInWindowRelaunch = false
 
 app.whenReady().then(async () => {
 	await loadAppConfig()
+	applyTheme()
 
 	try {
 		await installVueDevtools()

--- a/src/shared/setupWebPage.js
+++ b/src/shared/setupWebPage.js
@@ -6,11 +6,10 @@
 import { register } from '@nextcloud/l10n'
 import axios from '@nextcloud/axios'
 
-import { applyBodyThemeAttrs } from './theme.utils.js'
 import { appData } from '../app/AppData.js'
 import { initGlobals } from './globals/globals.js'
 import { setupInitialState } from './initialState.service.js'
-import { getAppConfigValue, initAppConfig } from './appConfig.service.ts' // eslint-disable-line import/namespace
+import { initAppConfig } from './appConfig.service.ts' // eslint-disable-line import/namespace
 import { TITLE_BAR_HEIGHT } from '../constants.js'
 
 /**
@@ -223,7 +222,6 @@ export async function setupWebPage() {
 	initGlobals()
 	window.OS = await window.TALK_DESKTOP.getOs()
 	applyUserData()
-	applyBodyThemeAttrs(getAppConfigValue('theme'))
 	applyHeaderHeight()
 	applyAxiosInterceptors()
 	await applyL10n()

--- a/src/talk/renderer/Settings/appConfig.store.ts
+++ b/src/talk/renderer/Settings/appConfig.store.ts
@@ -8,7 +8,6 @@ import type { AppConfig, AppConfigKey } from '../../../app/AppConfig.ts'
 import { readonly, ref, set, watch, watchEffect } from 'vue'
 import { defineStore } from 'pinia'
 import { getAppConfig } from '../../../shared/appConfig.service.ts'
-import { applyBodyThemeAttrs } from '../../../shared/theme.utils.js'
 import { setInitialState } from '../../../shared/initialState.service.js'
 import { useUserStatusStore } from '../UserStatus/userStatus.store.js'
 
@@ -28,8 +27,6 @@ export const useAppConfigStore = defineStore('appConfig', () => {
 			unwatchRelaunch()
 		},
 	)
-
-	watch(() => appConfig.value.theme, (newTheme) => applyBodyThemeAttrs(newTheme))
 
 	const userStatusStore = useUserStatusStore()
 	watchEffect(() => {


### PR DESCRIPTION
### ☑️ Resolves

A minor change in theming. Simplifying pages setup and respects selected theme in all parts of the app.

* Before we used Nextcloud theme via `[data-theme-*]`. It has 2 drawbacks:
  * Requires setting attrs initially on every window
  * Native parts of the app have a system theme
* Now using a native theme:
  * Requires settings only once on app init
  * Works on all the parts

### 🖼️ Screenshots

Example - a Light theme on a Dark system

🏚️ Before | 🏡 After
---|---
![image](https://github.com/user-attachments/assets/8ef7f660-6df5-4569-99bd-29822caedc98) | ![image](https://github.com/user-attachments/assets/11fea6ae-c5b2-4f8e-812d-e2c3a1d2c180)