### PR TITLE
build(windows): add Squirrel MSI

### DIFF
--- a/forge.config.js
+++ b/forge.config.js
@@ -71,7 +71,8 @@ function fixArtifactName(artifactPath, platform, arch) {
 	const artifactName = path.basename(artifactPath)
 	const ext = path.extname(artifactName)
 
-	if (platform === 'win32' && ext !== '.exe') {
+	// For Windows names are configurable in Squirrel distribution
+	if (platform === 'win32') {
 		return artifactPath
 	}
 

--- a/forge.config.js
+++ b/forge.config.js
@@ -175,7 +175,11 @@ module.exports = {
 			// App/Filenames
 			name: CONFIG.winAppId,
 			setupExe: generateDistName('win32', 'x64', '.exe'),
+			setupMsi: generateDistName('win32', 'x64', '.msi'),
 			exe: `${CONFIG.applicationName}.exe`,
+
+			// Add MSI for administrated environments
+			noMsi: false,
 
 			// Meta
 			title: CONFIG.applicationName,


### PR DESCRIPTION
### ☑️ Resolves

- Adds MSI installer with Deployment Tool for administrative environment (when the app is installed using Group Policies)
- Note: the installation is still per-user in the `%User%/AppData/Local`, not `C:/Program Files/`
- Alternative to the classic MSI installer

Details: https://github.com/Squirrel/Squirrel.Windows/blob/develop/docs/using/machine-wide-installs.md