### PR TITLE
build(dev): make NEXTCLOUD_DEV_SERVER_HOSTS optional

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,9 +1,10 @@
-# SPDX-FileCopyrightText: 2022 Nextcloud GmbH and Nextcloud contributors
-# SPDX-License-Identifier: CC0-1.0
-
-# Path to talk repository
+# Path to the Nextcloud Talk source (https://github.com/nextcloud/spreed)
+# Set it to reuse a specific locally cloned Talk
+# Defaults to "spreed" folder in the repository root
+# Example: /var/www/nextcloud/apps-extra/spreed
 TALK_PATH=spreed
 
-# List of Nextcloud development server hosts separetad by space (incl. signaling WS server host)
-# Example: https://nextcloud.local https://stable26.local
-NEXTCLOUD_DEV_SERVER_HOSTS=https://nextcloud.local https://stable26.local
+# List of hosts allowed in the Content Security Policy for `default-src` in the development server
+# Defaults to "*" which might be unsafe during development - you can set it to allow only your hosts
+# Example: https://nextcloud.local wss://signaling.nextcloud.local wss://notify_push.nextcloud.local
+NEXTCLOUD_DEV_SERVER_HOSTS=*

--- a/README.md
+++ b/README.md
@@ -60,42 +60,28 @@ However, using portable `zip` distribution, you can have several Nextcloud Talk 
 
 ## 🛠️ Development Setup
 
-### Initial setup
-
-```bash
-# Install dependencies
-npm ci
-
-# Make .env file
-cp .env.example .env
-
-# Don't forget to configure ENV variables! 
-```
-
-Nextcloud Talk Desktop requires [Nextcloud Talk source code](https://github.com/nextcloud/spreed).
-
-#### No `nextcloud/spreed` is cloned?
-
-Clone `nextcloud/spreed` and install dependencies:
-
-```bash
-# Clone in the repository root
-git clone https://github.com/nextcloud/spreed
-
-# Install dependencies
-cd ./spreed/
-npm ci
-
-# Don't forget to return back
-cd ../
-```
-
-#### `nextcloud/spreed` is already cloned?
-
-Set `TALK_PATH` ENV variable or edit `.env` file:
- ```dotenv
-TALK_PATH=/path/to/nextcloud-dev/apps/spreed/
- ```
+1. Install dependencies
+	 ```bash
+	 npm ci 
+	 ```
+2. Nextcloud Talk Desktop requires [Nextcloud Talk source code](https://github.com/nextcloud/spreed).
+   - **No `nextcloud/spreed` is cloned?**\
+     Clone it and install dependencies:
+	   ```sh
+	   # Clone Talk to the repository root
+	   git clone https://github.com/nextcloud/spreed
+     
+	   # Install dependencies
+	   npm ci --prefix=spreed
+	   ```
+   - **You want to reuse existing `nextcloud/spreed`, for instance, in a server setup?**\
+     Set `TALK_PATH` ENV variable or edit `.env` file:
+     ```sh
+     cp .env.example .env
+     # Edit .env and set TALK_PATH
+     TALK_PATH=/path/to/nextcloud/server/apps-extra/spreed/
+     ```
+3. Check `.env.example` for any additional configuration if needed.
 
 ## 🧑‍💻 Development
 

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -24,6 +24,12 @@ SPDX-FileCopyrightText = "none"
 SPDX-License-Identifier = "CC0-1.0"
 
 [[annotations]]
+path = [".env.example"]
+precedence = "aggregate"
+SPDX-FileCopyrightText = "2022 Nextcloud GmbH and Nextcloud contributors"
+SPDX-License-Identifier = "CC0-1.0"
+
+[[annotations]]
 path = ["img/dmg-background.png", "img/dmg-background@2x.png"]
 precedence = "aggregate"
 SPDX-FileCopyrightText = "2024 Nextcloud GmbH"

--- a/forge.config.js
+++ b/forge.config.js
@@ -113,7 +113,7 @@ module.exports = {
 			}
 
 			if (!fs.existsSync(path.join(TALK_PATH, 'node_modules'))) {
-				throw new Error(`No Nextcloud Talk (spreed repository) dependencies are installed.\nTry to execute \`cd ${TALK_PATH} && npm ci\``)
+				throw new Error(`No Nextcloud Talk (spreed repository) dependencies are installed.\nTry to execute \`npm ci --prefix="${TALK_PATH}"\``)
 			}
 		},
 
@@ -291,7 +291,7 @@ module.exports = {
 			name: '@electron-forge/plugin-webpack',
 			config: {
 				mainConfig: './webpack.main.config.js',
-				devContentSecurityPolicy: `default-src 'self' 'unsafe-inline' data: blob: ${process.env.NEXTCLOUD_DEV_SERVER_HOSTS}; script-src 'self' 'unsafe-eval' 'unsafe-inline' data: blob:`,
+				devContentSecurityPolicy: `default-src 'self' 'unsafe-inline' data: blob: ${process.env.NEXTCLOUD_DEV_SERVER_HOSTS || '*'}; script-src 'self' 'unsafe-eval' 'unsafe-inline' data: blob:`,
 				port: 3000, // The default for this plugin
 				loggerPort: 9005, // The default is 9000, but it conflicts with Talk API
 				devServer: {

--- a/src/authentication/renderer/AuthenticationApp.vue
+++ b/src/authentication/renderer/AuthenticationApp.vue
@@ -16,7 +16,7 @@ import { MIN_REQUIRED_NEXTCLOUD_VERSION, MIN_REQUIRED_TALK_VERSION } from '../..
 import { refetchAppData } from '../../app/appData.service.js'
 
 const version = window.TALK_DESKTOP.packageInfo.version
-const rawServerUrl = ref(process.env.NODE_ENV !== 'production' ? process.env.NEXTCLOUD_DEV_SERVER_HOSTS?.split?.(' ')?.[0] : '')
+const rawServerUrl = ref('')
 
 const serverUrl = computed(() => {
 	const addHTTPS = (url) => url.startsWith('http') ? url : `https://${url}`


### PR DESCRIPTION
### ☑️ Resolves

* Make `NEXTCLOUD_DEV_SERVER_HOSTS` which sets hosts for CSP in the dev server **optional**
  * Allows starting development without touching ENV variables or `.env` file
  * No more `.env` required during development, unless non-default values needed
* Adjust `.env.example`
* Update "Development Setup" in the `README` according to the new change