### PR TITLE
build: fix universal arch title is missing in output

### DIFF
--- a/forge.config.js
+++ b/forge.config.js
@@ -54,10 +54,12 @@ function generateDistName(platform, arch, ext, includeVersion = false) {
 		x64: 'x64',
 		arm64: 'arm',
 	}
+	const platformTitle = platformTitles[platform] ?? platform
+	const archTitle = archTitles[arch] ?? arch
 	const version = packageJSON.version
 	return includeVersion
-		? `${CONFIG.applicationNameSanitized}-v${version}-${platformTitles[platform]}-${archTitles[arch]}${ext}`
-		: `${CONFIG.applicationNameSanitized}-${platformTitles[platform]}-${archTitles[arch]}${ext}`
+		? `${CONFIG.applicationNameSanitized}-v${version}-${platformTitle}-${archTitle}${ext}`
+		: `${CONFIG.applicationNameSanitized}-${platformTitle}-${archTitle}${ext}`
 }
 
 /**


### PR DESCRIPTION
### ☑️ Resolves

* Before: `Nextcloud.Talk-macos-undefined.dmg`
* After: `Nextcloud.Talk-macos-universal.dmg`