### PR TITLE
fix: temporary remove buggy theme change handling for tray icon

### DIFF
--- a/src/talk/talk.window.js
+++ b/src/talk/talk.window.js
@@ -3,14 +3,13 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-const { BrowserWindow, nativeTheme } = require('electron')
+const { BrowserWindow } = require('electron')
 const { applyExternalLinkHandler } = require('../app/externalLinkHandlers.js')
 const { applyContextMenu } = require('../app/applyContextMenu.js')
 const { applyDownloadHandler } = require('../app/downloads.ts')
 const { applyWheelZoom } = require('../app/zoom.service.ts')
 const { setupTray } = require('../app/app.tray.js')
-const { getBrowserWindowIcon, getTrayIcon } = require('../shared/icons.utils.js')
-const { isMac } = require('../app/system.utils.ts')
+const { getBrowserWindowIcon } = require('../shared/icons.utils.js')
 const { TITLE_BAR_HEIGHT } = require('../constants.js')
 const { getAppConfig } = require('../app/AppConfig.ts')
 const { getScaledWindowMinSize, getScaledWindowSize } = require('../app/utils.ts')
@@ -74,14 +73,7 @@ function createTalkWindow() {
 	applyDownloadHandler(window)
 	applyWheelZoom(window)
 
-	const tray = setupTray(window)
-
-	// macOS automatically adjust the tray using a template icon
-	if (!isMac) {
-		nativeTheme.on('updated', () => {
-			tray.setImage(getTrayIcon())
-		})
-	}
+	setupTray(window)
 
 	window.loadURL(TALK_WINDOW_WEBPACK_ENTRY)
 


### PR DESCRIPTION
### ☑️ Resolves

* Fix: https://github.com/nextcloud/talk-desktop/issues/927
* Fix: https://github.com/nextcloud/talk-desktop/issues/878

For unknown reasons:
- `NativeTheme.on('updated')` is triggered without theme change, for example, on external monitor connected/disconnected, or background image is changed on Windows
- When it happens, it says that the tray is destroyed (even if it works afterwards)
- And it cannot find an image for the icon (even if it worked on init and if you explicitly trigger a change in settings)

Also, this is only reproducible with the production build (`npm run build`).

This feature is very nit. But the bug is very annoying.

Until we found a solution - remove this feature to avoid errors.

To test (on non-macOS):
1. Make a production build `npm run build`
2. Run. Just in case, select the monochrome tray icon.
3. Change system theme
