### PR TITLE
fix(notifications): do not create native notification for old entries

### DIFF
--- a/src/talk/renderer/notifications/notifications.store.js
+++ b/src/talk/renderer/notifications/notifications.store.js
@@ -43,6 +43,7 @@ export function createNotificationStore() {
 		notifications: [],
 		lastETag: null,
 		lastTabId: null,
+		notificationThresholdId: 0,
 		userStatus: null,
 		tabId: null,
 		/** @type {number} */
@@ -224,8 +225,11 @@ export function createNotificationStore() {
 			state.lastETag = response.headers.etag
 			state.lastTabId = response.tabId
 			state.notifications = response.data.filter((notification) => notification.app === 'spreed')
-			const newNotifications = state.notifications.filter((notification) => !notificationsSet.has(notification.notificationId))
+			const newNotifications = state.notifications.filter((notification) => {
+				return !notificationsSet.has(notification.notificationId) && notification.notificationId > state.notificationThresholdId
+			})
 			notificationsSet = new Set(state.notifications.map((notification) => notification.notificationId))
+			state.notificationThresholdId = response.notificationThresholdId
 			if (state.backgroundFetching) {
 				for (const notification of newNotifications) {
 					await showNativeNotification(notification)


### PR DESCRIPTION
### ☑️ Resolves

* Fix #961
* Basic implementation of https://github.com/nextcloud/notifications/commit/6a543679b4de8af65cc82baa233ae17ffbbbc1af
* First fetch does not create notifications, so initial 0 should be fine


To test:
* create any Talk notification
* execute ` occ notification:test-push userid` 25 times to fill the server response
* start Desktop client
* dismiss one of dummy notifications
* wait for the next 200 response

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
Old notification | No notification

### 🚧 Tasks

- [ ] Test
