### PR TITLE
fix(meta): add meta tag for light/dark color scheme support

### DIFF
--- a/src/authentication/renderer/authentication.html
+++ b/src/authentication/renderer/authentication.html
@@ -7,6 +7,7 @@
 <html>
 <head>
 	<meta charset="UTF-8" />
+	<meta name="color-scheme" content="light dark">
 	<title>Nextcloud Talk</title>
 </head>
 <body>

--- a/src/talk/renderer/talk.html
+++ b/src/talk/renderer/talk.html
@@ -7,6 +7,7 @@
 <html>
 <head>
 	<meta charset="UTF-8" />
+	<meta name="color-scheme" content="light dark">
 	<title>Nextcloud Talk</title>
 </head>
 <body>


### PR DESCRIPTION
### ☑️ Resolves

* Issue with incorrect color scheme inheritance
* Nextcloud uses system/light/dark themes, but support them via body data-attributes
* Without specifying `<meta name="color-scheme" content="light dark">` browser/Desktop is unaware of supported color schemes at all and defaults to base theme (light)

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![image](https://github.com/user-attachments/assets/478203f1-69cc-4c98-ab04-0f1f7424cd53) | ![image](https://github.com/user-attachments/assets/c0cc71fa-603c-45cb-bfbc-272b1983e21c)

### 🚧 Tasks

- [ ] Server follow-up
