### PR TITLE
build: allow running `release:package` without `npm ci` and without uncommitted changes check

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "package:mac:x64": "electron-forge make --skip-package --platform=darwin --arch=x64",
     "package:mac:arm64": "electron-forge make --skip-package --platform=darwin --arch=arm64",
     "package:windows": "electron-forge make --skip-package --platform=win32",
-    "release:package": "zx ./scripts/prepare-release-packages.mjs",
+    "release:package": "npx -y zx ./scripts/prepare-release-packages.mjs",
     "generate-icons": "node ./scripts/generate-icons.js",
     "download-vue-devtools": "node ./scripts/download-vue-devtools.mjs",
     "lint": "eslint --ext .js,.vue src/ --fix",

--- a/scripts/prepare-release-packages.mjs
+++ b/scripts/prepare-release-packages.mjs
@@ -3,8 +3,9 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import { $, echo, spinner, argv, fs, os, usePwsh } from 'zx'
-// eslint-disable-next-line no-undef
+/// <reference types="zx" />
+/* eslint-disable no-undef */
+
 const packageJson = require('../package.json')
 
 const TALK_PATH = './out/.temp/spreed/'


### PR DESCRIPTION
- Add `--skip-check` option to skip uncommitted changes checking
  - Allows script development without removing the check
- Run the script via `npx zx`
  - Allows running `release:package` without installing all the dependencies
- Minor texts changes