### PR TITLE
release: v1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@
 
 # Changelog
 
+## v1.0.1 - 2024-12-19
+
+### Fixes
+
+- Fix crash on the second instance run on Linux [#993](https://github.com/nextcloud/talk-desktop/pull/993)
+- Fix native elements have incorrect theme [#974](https://github.com/nextcloud/talk-desktop/pull/974)
+- Fix notifications are shown for too old entries [#967](https://github.com/nextcloud/talk-desktop/pull/967)
+- Improve call state check in the call notification popup with new call state api [#965](https://github.com/nextcloud/talk-desktop/pull/965)
+- Fix call notification popup is shown when the call has already ended [#964](https://github.com/nextcloud/talk-desktop/pull/964)
+
+### Changes
+
+- Built-in Talk in binaries is updated to v20.1.1 [#995](https://github.com/nextcloud/talk-desktop/pull/995)
+- Update translations
+- Update dependencies
+
 ## v1.0.0 - 2024-12-03
 
 ### Features

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "talk-desktop",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "talk-desktop",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@mdi/svg": "^7.4.47",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "name": "talk-desktop",
   "productName": "Nextcloud Talk",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Official Desktop client for Nextcloud Talk",
   "bugs": {
     "url": "https://github.com/nextcloud/talk-desktop/issues",


### PR DESCRIPTION
- waiting for: https://github.com/nextcloud/talk-desktop/pull/996

## v1.0.1 - 2024-12-19

### Fixes

- Fix crash on the second instance run on Linux [#993](https://github.com/nextcloud/talk-desktop/pull/993)
- Fix native elements have incorrect theme [#974](https://github.com/nextcloud/talk-desktop/pull/974)
- Fix notifications are shown for too old entries [#967](https://github.com/nextcloud/talk-desktop/pull/967)
- Improve call state check in the call notification popup with new call state api [#965](https://github.com/nextcloud/talk-desktop/pull/965)
- Fix call notification popup is shown when the call has already ended [#964](https://github.com/nextcloud/talk-desktop/pull/964)

### Changes

- Built-in Talk in binaries is updated to v20.1.1 [#995](https://github.com/nextcloud/talk-desktop/pull/995)
- Update translations
- Update dependencies