### PR TITLE
fix(macOS): microphone crash on screen sharing

### DIFF
--- a/src/talk/renderer/components/DesktopMediaSourceDialog.vue
+++ b/src/talk/renderer/components/DesktopMediaSourceDialog.vue
@@ -72,8 +72,11 @@ const requestDesktopCapturerSources = async () => {
 		name: screens.length > 1 ? t('talk_desktop', 'Audio + All screens') : t('talk_desktop', 'Audio + Screen'),
 	}
 
-	// On Wayland we don't manually provide the source stream. It is covered by Wayland and entire-desktop is not supported
-	sources.value = window.systemInfo.isWayland ? [...screens, ...windows] : [...screens, entireDesktop, ...windows]
+	// Wayland uses the system picker via PipeWire to select the source.
+	// Thus, only the selected source is available, and the custom entire-desktop option is neither supported nor needed.
+	// On macOS the entire-desktop captures only the primary screen and capturing system audio crashes audio (microphone).
+	// TODO: use the system picker on macOS Sonoma and later
+	sources.value = window.systemInfo.isWayland || window.systemInfo.isMac ? [...screens, ...windows] : [...screens, entireDesktop, ...windows]
 }
 
 const handleVideoSuspend = (source) => {


### PR DESCRIPTION
### ☑️ Resolves

* Fix: https://github.com/nextcloud/talk-desktop/issues/951

Requesting an entire desktop with a stream with audio is not actually supported in macOS. Somehow an attempt to request it results in losing audio devices access with

```
The AudioContext encountered an error from the audio device or the WebAudio renderer.
```

Current workaround is as simple as removing an unsupported option.

An alternative is to use experimental native screen sharing selector. But it is more complex, requires changes on the Talk side and loses an Entire desktop option for Windows and Linux.
- https://github.com/nextcloud/talk-desktop/pull/1022

## Screenshots

See mic icon. Before it is off and disabled due to an error.

Before | After
---|---
![Screenshot 2025-01-15 at 16 21 51](https://github.com/user-attachments/assets/381aa163-caa9-4c4e-9902-69f6756d154e) | ![Screenshot 2025-01-15 at 16 19 01](https://github.com/user-attachments/assets/63aeac8f-7204-4061-964d-a9f4ce3c5108)