### PR TITLE
fix(UserStatus): only allow to set available user status types

### DIFF
--- a/src/talk/renderer/TitleBar/components/UserMenu.vue
+++ b/src/talk/renderer/TitleBar/components/UserMenu.vue
@@ -4,6 +4,7 @@
   -->
 
 <script setup lang="ts">
+import type { UserStatusStatusType } from '../../UserStatus/userStatus.types.ts'
 import { computed, ref, watch } from 'vue'
 import { storeToRefs } from 'pinia'
 import { t } from '@nextcloud/l10n'
@@ -23,9 +24,8 @@ import UiMenuItem from './UiMenuItem.vue'
 import UiMenuSeparator from './UiMenuSeparator.vue'
 import UserStatusDialog from '../../UserStatus/UserStatusDialog.vue'
 import { useUserStatusStore } from '../../UserStatus/userStatus.store.ts'
-import { userStatusTranslations, userStatusStatusTypes } from '../../UserStatus/userStatus.utils.ts'
+import { userStatusTranslations, availableUserStatusStatusTypes } from '../../UserStatus/userStatus.utils.ts'
 import { appData } from '../../../../app/AppData.js'
-import type { UserStatusStatusType } from '../../UserStatus/userStatus.types.ts'
 
 const props = defineProps<{
 	// TODO: define a proper type for userMetadata
@@ -104,7 +104,7 @@ function handleUserStatusChange(status: UserStatusStatusType) {
 							</template>
 							{{ t('talk_desktop', 'Back') }}
 						</UiMenuItem>
-						<UiMenuItem v-for="status in userStatusStatusTypes"
+						<UiMenuItem v-for="status in availableUserStatusStatusTypes"
 							:key="status"
 							tag="button"
 							@click.native.stop="handleUserStatusChange(status)">

--- a/src/talk/renderer/UserStatus/components/UserStatusFormStatusType.vue
+++ b/src/talk/renderer/UserStatus/components/UserStatusFormStatusType.vue
@@ -6,7 +6,7 @@
 <script setup lang="ts">
 import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
 import NcUserStatusIcon from '@nextcloud/vue/dist/Components/NcUserStatusIcon.js'
-import { userStatusStatusTypes, userStatusTranslations } from '../userStatus.utils.ts'
+import { availableUserStatusStatusTypes, userStatusTranslations } from '../userStatus.utils.ts'
 import type { UserStatusStatusType } from '../userStatus.types.ts'
 
 defineProps<{
@@ -20,7 +20,7 @@ const emit = defineEmits<{
 
 <template>
 	<div class="user-status-form-status">
-		<NcButton v-for="option in userStatusStatusTypes"
+		<NcButton v-for="option in availableUserStatusStatusTypes"
 			:key="option"
 			type="tertiary"
 			alignment="start"

--- a/src/talk/renderer/UserStatus/userStatus.utils.ts
+++ b/src/talk/renderer/UserStatus/userStatus.utils.ts
@@ -7,7 +7,10 @@ import type { ClearAtPredefinedConfig, PredefinedUserStatus, UserStatus, UserSta
 import moment from '@nextcloud/moment'
 import { translate as t } from '@nextcloud/l10n'
 
-export const userStatusStatusTypes: UserStatusStatusType[] = ['online', 'away', 'busy', 'dnd', 'invisible', 'offline'] as const
+/**
+ * List of user status types that user can set
+ */
+export const availableUserStatusStatusTypes: UserStatusStatusType[] = ['online', 'away', 'dnd', 'invisible']
 
 export const userStatusTranslations: Record<UserStatusStatusType, string> = {
 	online: t('talk_desktop', 'Online'),


### PR DESCRIPTION
### Resolves

- Not all user status status types should be available for manual setting

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![image](https://github.com/user-attachments/assets/8c4eda34-d297-4b31-adaa-50d3c6d412b9) | ![image](https://github.com/user-attachments/assets/b1a822fc-c856-49af-a06e-65cb898e589f)
![image](https://github.com/user-attachments/assets/723804d9-83f2-4969-b08d-c81896028731) | ![image](https://github.com/user-attachments/assets/a446a534-5389-47da-b582-8d6250ed4bf6)
