### PR TITLE
fix(linux): critical error with C (POSIX) system language

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -69,8 +69,9 @@ ipcMain.on('app:quit', () => app.quit())
 ipcMain.handle('app:getSystemInfo', () => systemInfo)
 ipcMain.handle('app:getTitle', (event) => BrowserWindow.fromWebContents(event.sender).title || app.getName())
 ipcMain.handle('app:getSystemL10n', () => ({
-	locale: app.getLocale().replace('-', '_'),
-	language: app.getPreferredSystemLanguages()[0].replace('-', '_'),
+	locale: app.getLocale().replace('-', '_') ?? 'en',
+	// Note: Linux may have C (POSIX) locale, which results in an empty preferred languages list
+	language: app.getPreferredSystemLanguages()[0]?.replace('-', '_') ?? 'en-US',
 }))
 ipcMain.handle('app:enableWebRequestInterceptor', (event, ...args) => enableWebRequestInterceptor(...args))
 ipcMain.handle('app:disableWebRequestInterceptor', (event, ...args) => disableWebRequestInterceptor(...args))


### PR DESCRIPTION
### ☑️ Resolves

* Fix: https://github.com/nextcloud/talk-desktop/issues/984

On Linux there is a rare case when C (posix) is set as the system language in desktop environment. This leads to having an empty list of `getPreferredSystemLanguages` and crashes app init.

Fallback to `'en-US'`.

Just in case (although, not expected), adding a fallback for `getLocale()`