### PR TITLE
release: v1.1.4 beta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,31 @@
 
 # Changelog
 
+## v1.1.4-beta - 2025-02-17
+
+### Notes
+
+**Squirrel Deployment Tool .msi → WiX v3 .msi**:\
+Experimental MSI installer with Squirrel Deployment Tool is removed
+and replaced with a new MSI installer based on WiX v3.
+You may remove the old installation. Your settings will be preserved.  
+
+### Features
+
+- Add a new MSI installer based on WiX v3 for Windows [#1103](https://github.com/nextcloud/talk-desktop/pull/1103)
+- Add an option to repeat call notification sound on a second output device [#772](https://github.com/nextcloud/talk-desktop/issues/772)
+
+### Fixes
+  
+- Fix call notification is still active when the call is joined [#1117](https://github.com/nextcloud/talk-desktop/issues/1117)
+
+### Changes
+
+- Built-in Talk in binaries is updated to v21.0.0-rc.4 in the beta release channel [#1119](https://github.com/nextcloud/talk-desktop/pull/1119)
+- Click five times on the logo in the about window to enable dev mode [#1105](https://github.com/nextcloud/talk-desktop/pull/1105)
+- Update translations
+- Update dependencies
+
 ## v1.1.3-beta - 2025-02-10
 
 ### Fixes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "talk-desktop",
-  "version": "1.1.3-beta",
+  "version": "1.1.4-beta",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "talk-desktop",
-      "version": "1.1.3-beta",
+      "version": "1.1.4-beta",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@mdi/svg": "^7.4.47",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "name": "talk-desktop",
   "productName": "Nextcloud Talk",
-  "version": "1.1.3-beta",
+  "version": "1.1.4-beta",
   "description": "Official Desktop client for Nextcloud Talk",
   "bugs": {
     "url": "https://github.com/nextcloud/talk-desktop/issues",


### PR DESCRIPTION
## v1.1.4-beta - 2025-02-17

### Notes

**Squirrel Deployment Tool .msi → WiX v3 .msi**:\
Experimental MSI installer with Squirrel Deployment Tool is removed
and replaced with a new MSI installer based on WiX v3.
You may remove the old installation. Your settings will be preserved.  

### Features

- Add a new MSI installer based on WiX v3 for Windows [#1103](https://github.com/nextcloud/talk-desktop/pull/1103)
- Add an option to repeat call notification sound on a second output device [#772](https://github.com/nextcloud/talk-desktop/issues/772)

### Fixes
  
- Fix call notification is still active when the call is joined [#1117](https://github.com/nextcloud/talk-desktop/issues/1117)

### Changes

- Built-in Talk in binaries is updated to v21.0.0-rc.4 in the beta release channel [#1119](https://github.com/nextcloud/talk-desktop/pull/1119)
- Click five times on the logo in the about window to enable dev mode [#1105](https://github.com/nextcloud/talk-desktop/pull/1105)
- Update translations
- Update dependencies