### PR TITLE
fix: set circles_enabled in initial state from server capabilities

### DIFF
--- a/src/shared/setupWebPage.js
+++ b/src/shared/setupWebPage.js
@@ -141,7 +141,7 @@ function getInitialStateFromCapabilities(capabilities, userMetadata) {
 			grid_videos_limit_enforced: false, // TODO: Missed in Capabilities. Is it a problem?
 			federation_enabled: capabilities?.spreed?.config?.federation?.enabled,
 			start_conversations: capabilities?.spreed?.config?.conversations?.['can-create'],
-			circles_enabled: false, // TODO: Missed in Capabilities. Is it a problem?
+			circles_enabled: capabilities?.circles !== undefined,
 			guests_accounts_enabled: true, // TODO: Missed in Capabilities. It is a problem
 			read_status_privacy: capabilities?.spreed?.config?.chat?.['read-privacy'],
 			typing_privacy: capabilities?.spreed?.config?.chat?.['typing-privacy'],


### PR DESCRIPTION
### ☑️ Resolves

* Follow-up to https://github.com/nextcloud/spreed/pull/14447

### 🖼️ Screenshots

🏡 After
 ![image](https://github.com/user-attachments/assets/f7258986-2bd4-43a7-a796-68cd50ffb188)

### 🚧 Tasks

- [ ] Require refetch AppData - is it a problem?
