### PR TITLE
fix(user-status): emoji picker cannot be focused

### DIFF
--- a/src/talk/renderer/UserStatus/components/UserStatusFormCustomMessage.vue
+++ b/src/talk/renderer/UserStatus/components/UserStatusFormCustomMessage.vue
@@ -24,11 +24,14 @@ const emit = defineEmits<{
 	(event: 'update:icon', value: string | null): void,
 	(event: 'update:message', value: string | null): void,
 }>()
+
+// TODO: Vue 3 - replace with `useId`
+const id = Math.random().toString(36).slice(2, 8)
 </script>
 
 <template>
-	<div class="user-status-form-custom-message">
-		<NcEmojiPicker @select="emit('update:icon', $event)">
+	<div :id="id" class="user-status-form-custom-message">
+		<NcEmojiPicker :container="'#' + id" @select="emit('update:icon', $event)">
 			<NcButton :aria-label="t('talk_desktop', 'Emoji for your status message')" type="tertiary" :disabled="disabled">
 				<template #icon>
 					<template v-if="icon">


### PR DESCRIPTION
### ☑️ Resolves

* Hotfix for emoji picker focus trap
* Regression from https://github.com/nextcloud-libraries/nextcloud-vue/pull/6466
* A proper solution on the nextcloud-vue side is in progress

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![before](https://github.com/user-attachments/assets/b8571f29-a387-46c9-8d82-95d0c62ea784) | ![after](https://github.com/user-attachments/assets/9a6a6c76-f1e6-43eb-86b8-4d687151037e)