### PR TITLE
release: v1.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@
 
 # Changelog
 
+## v1.1.5 - 2025-02-24
+
+### Fixes
+
+- Loop ringtone on incoming call [#1123](https://github.com/nextcloud/talk-desktop/pull/1123)
+- Teams (Circles) support [#1121](https://github.com/nextcloud/talk-desktop/pull/1121)
+
+### Changes
+
+- Built-in Talk in binaries is updated to v21.0.0 in both beta and stable release channels [#1137](https://github.com/nextcloud/talk-desktop/pull/1137)
+- Update translations
+- Update dependencies
+
 ## v1.1.4-beta - 2025-02-17
 
 ### Notes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "talk-desktop",
-  "version": "1.1.4-beta",
+  "version": "1.1.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "talk-desktop",
-      "version": "1.1.4-beta",
+      "version": "1.1.5",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@mdi/svg": "^7.4.47",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "name": "talk-desktop",
   "productName": "Nextcloud Talk",
-  "version": "1.1.4-beta",
+  "version": "1.1.5",
   "description": "Official Desktop client for Nextcloud Talk",
   "bugs": {
     "url": "https://github.com/nextcloud/talk-desktop/issues",


### PR DESCRIPTION
## v1.1.5 - 2025-02-24

### Fixes

- Loop ringtone on incoming call [#1123](https://github.com/nextcloud/talk-desktop/pull/1123)
- Teams (Circles) support [#1121](https://github.com/nextcloud/talk-desktop/pull/1121)

### Changes

- Built-in Talk in binaries is updated to v21.0.0 in both beta and stable release channels [#1137](https://github.com/nextcloud/talk-desktop/pull/1137)
- Update translations
- Update dependencies