### PR TITLE
fix: substitute empty locale from server with system locale

### DIFF
--- a/src/shared/setupWebPage.js
+++ b/src/shared/setupWebPage.js
@@ -55,7 +55,8 @@ async function loadAndRegisterL10n(app, lang, resolver) {
  * @return {Promise<void>}
  */
 async function applyL10n() {
-	const { language, locale } = appData.userMetadata ?? await window.TALK_DESKTOP.getSystemL10n()
+	const language = appData.userMetadata?.language || (await window.TALK_DESKTOP.getSystemL10n()).language
+	const locale = appData.userMetadata?.locale || (await window.TALK_DESKTOP.getSystemL10n()).locale
 
 	document.documentElement.lang = language
 	document.documentElement.dataset.locale = locale


### PR DESCRIPTION
### ☑️ Resolves

* Issue #985
* appData.userMetadata might have a locale as `" "` empty string (which means user has never changed it in Personal settings), but it won't be replaced with system value and handled by system as empty string
  <img width="174" alt="image" src="https://github.com/user-attachments/assets/198f4a90-6b8f-4f3f-9a2c-bae4b5a18e31" />
* `Intl.*` constructors do not accept empty string as a locale:
![image](https://github.com/user-attachments/assets/c1f40f64-aa80-4e9e-ab71-c9b8cb090771)


### 🖼️ Screenshots

<img width="375" alt="image" src="https://github.com/user-attachments/assets/7fd5ac66-4fc9-40b4-9b65-ad0c76d47ff2" />

### 🚧 Tasks

- [ ] ...
