### PR TITLE
chore: add internal app protocol

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -20,17 +20,11 @@ export default [
 		languageOptions: {
 			globals: {
 				// Electron Forge build vars
-				AUTHENTICATION_WINDOW_WEBPACK_ENTRY: 'readonly',
 				AUTHENTICATION_WINDOW_PRELOAD_WEBPACK_ENTRY: 'readonly',
 				CALLBOX_WINDOW_PRELOAD_WEBPACK_ENTRY: 'readonly',
-				CALLBOX_WINDOW_WEBPACK_ENTRY: 'readonly',
-				TALK_WINDOW_WEBPACK_ENTRY: 'readonly',
 				TALK_WINDOW_PRELOAD_WEBPACK_ENTRY: 'readonly',
-				HELP_WINDOW_WEBPACK_ENTRY: 'readonly',
 				HELP_WINDOW_PRELOAD_WEBPACK_ENTRY: 'readonly',
-				UPGRADE_WINDOW_WEBPACK_ENTRY: 'readonly',
 				UPGRADE_WINDOW_PRELOAD_WEBPACK_ENTRY: 'readonly',
-				WELCOME_WINDOW_WEBPACK_ENTRY: 'readonly',
 				WELCOME_WINDOW_PRELOAD_WEBPACK_ENTRY: 'readonly',
 				// Build constants
 				IS_DESKTOP: 'readonly',

--- a/forge.config.js
+++ b/forge.config.js
@@ -373,8 +373,15 @@ module.exports = {
 				port: 3000, // The default for this plugin
 				loggerPort: 9005, // The default is 9000, but it conflicts with Talk API
 				devServer: {
+					// Allow using app protocol
+					allowedHosts: 'all',
 					client: {
 						overlay: false,
+						// When serving a page from a custom protocol://host
+						// WS hostname must be set explicitly
+						webSocketURL: {
+							hostname: 'localhost',
+						},
 					},
 				},
 				renderer: {

--- a/src/app/appProtocol.ts
+++ b/src/app/appProtocol.ts
@@ -1,0 +1,89 @@
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import path from 'node:path'
+import { pathToFileURL } from 'node:url'
+import { app, protocol, net } from 'electron'
+import { APP_PROTOCOL, APP_HOST, DEV_SERVER_ORIGIN } from '../constants.js'
+
+protocol.registerSchemesAsPrivileged([
+	{
+		scheme: APP_PROTOCOL,
+		privileges: {
+			standard: true,
+			secure: true,
+			allowServiceWorkers: true,
+			supportFetchAPI: true,
+		},
+	},
+])
+
+/**
+ * Register app protocol handler
+ */
+export function registerAppProtocolHandler() {
+	protocol.handle(APP_PROTOCOL, async (request) => {
+		const url = new URL(request.url)
+
+		// Redirect nctalk://call/{token} links to the app
+		if (url.host === 'call') {
+			return new Response(null, {
+				status: 302,
+				headers: {
+					Location: `${APP_PROTOCOL}://${APP_HOST}/talk_window/index.html#/call${url.pathname + url.search + url.hash}`,
+				},
+			})
+		}
+
+		// Handle in-app links
+		if (url.host === APP_HOST) {
+			// In development mode proxy requests to the dev server
+			if (process.env.NODE_ENV === 'development') {
+				const urlOnDevServer = new URL(url.pathname + url.search + url.hash, DEV_SERVER_ORIGIN)
+				return await fetch(urlOnDevServer)
+			}
+
+			const distPath = getDistPath()
+
+			const requestPath = path.join(distPath, decodeURIComponent(url.pathname))
+
+			// Prevent accessing external files via nctalk://app/../../path/to/external/file
+			// Note: it is not supposed to happen with asar package but still better to check
+			const relativePath = path.relative(distPath, requestPath)
+			if (!relativePath || relativePath.startsWith('..') || path.isAbsolute(relativePath)) {
+				console.warn(`Unsafe path requested: ${requestPath}`)
+				return new Response(`Cannot GET ${request.url}`, { status: 404 })
+			}
+
+			// Generate file://path/to/app/file?query URL
+			const urlToFile = pathToFileURL(requestPath)
+			return net.fetch(urlToFile.toString() + url.search + url.hash)
+		}
+
+		// Unknown host
+		console.warn('Unknown application host:', url.host)
+		return new Response(`Cannot GET ${request.url}`, { status: 404 })
+	})
+}
+
+let distPath: string
+/**
+ * Get cached path to the app dist
+ */
+function getDistPath() {
+	if (!distPath) {
+		if (process.env.NODE_ENV === 'development') {
+			// In dev mode with Electron Forge + Webpack, static files might be in a different location
+			// This could be the webpack output directory or the original static folder
+			distPath = path.join(__dirname, '../../.webpack/renderer')
+		} else {
+			distPath = app.isPackaged
+				? path.join(process.resourcesPath, 'app.asar', '.webpack/renderer')
+				: path.join(__dirname, '.webpack/renderer')
+		}
+	}
+
+	return distPath
+}

--- a/src/app/externalLinkHandlers.ts
+++ b/src/app/externalLinkHandlers.ts
@@ -13,7 +13,7 @@ import type {
 } from 'electron'
 import { shell } from 'electron'
 import { appData } from './AppData.js'
-import { DEV_SERVER_ORIGIN } from '../constants.js'
+import { APP_ORIGIN } from '../constants.js'
 
 /**
  * Check if a link is an internal application link
@@ -21,7 +21,7 @@ import { DEV_SERVER_ORIGIN } from '../constants.js'
  * @param url - URL
  */
 export function isInternalLink(url: string) {
-	return url.startsWith('file') || (process.env.NODE_ENV !== 'production' && url.startsWith(DEV_SERVER_ORIGIN))
+	return url.startsWith(APP_ORIGIN + '/')
 }
 
 /**

--- a/src/app/utils.ts
+++ b/src/app/utils.ts
@@ -7,6 +7,7 @@ import type { BrowserWindow } from 'electron'
 import { screen } from 'electron'
 import { getAppConfig } from './AppConfig.ts'
 import { BUILD_CONFIG } from '../shared/build.config.ts'
+import { APP_ORIGIN } from '../constants.js'
 
 /**
  * Get the scaled window size based on the current zoom factor
@@ -80,4 +81,15 @@ export function buildTitle(title?: string) {
 	const BASE_TITLE = BUILD_CONFIG.applicationName
 	const base = __CHANNEL__ !== 'stable' ? `${BASE_TITLE} ${capitalize(__CHANNEL__)}` : BASE_TITLE
 	return title ? `${title} - ${base}` : base
+}
+
+type WindowName = 'authentication_window' | 'callbox_window' | 'help_window' | 'talk_window' | 'upgrade_window' | 'welcome_window'
+
+/**
+ * Get the URL for a window to load
+ *
+ * @param windowName - Window name
+ */
+export function getWindowUrl(windowName: WindowName) {
+	return `${APP_ORIGIN}/${windowName}/index.html`
 }

--- a/src/app/webRequestInterceptor.js
+++ b/src/app/webRequestInterceptor.js
@@ -4,9 +4,9 @@
  */
 
 const { session } = require('electron')
-const { DEV_SERVER_ORIGIN } = require('../constants.js')
 const { osTitle } = require('./system.utils.ts')
 const packageJson = require('../../package.json')
+const { APP_ORIGIN } = require('../constants.js')
 
 const USER_AGENT = `Mozilla/5.0 (${osTitle}) Nextcloud-Talk v${packageJson.version}`
 
@@ -68,12 +68,12 @@ function enableWebRequestInterceptor(serverUrl, {
 		}
 	}
 
-	const ALLOWED_ORIGIN = [process.env.NODE_ENV === 'production' ? 'file://' : `${DEV_SERVER_ORIGIN}`]
+	const ALLOWED_ORIGIN = [APP_ORIGIN]
 	const ALLOWED_METHODS = ['GET, POST, PUT, PATCH, DELETE, PROPFIND, MKCOL, SEARCH, REPORT'] // Includes WebDAV
 	const ALLOWED_CREDENTIALS_TRUE = ['true']
 	const ALLOWED_HEADERS = [
 		[
-		// Common
+			// Common
 			'Authorization',
 			'Content-Type',
 			'If-None-Match',

--- a/src/authentication/authentication.window.js
+++ b/src/authentication/authentication.window.js
@@ -8,7 +8,7 @@ const { TITLE_BAR_HEIGHT } = require('../constants.js')
 const { applyContextMenu } = require('../app/applyContextMenu.js')
 const { getBrowserWindowIcon } = require('../shared/icons.utils.js')
 const { getAppConfig } = require('../app/AppConfig.ts')
-const { getScaledWindowSize, applyZoom, buildTitle } = require('../app/utils.ts')
+const { getScaledWindowSize, applyZoom, buildTitle, getWindowUrl } = require('../app/utils.ts')
 
 /**
  * @return {import('electron').BrowserWindow}
@@ -51,7 +51,7 @@ function createAuthenticationWindow() {
 	applyContextMenu(window)
 	applyZoom(window)
 
-	window.loadURL(AUTHENTICATION_WINDOW_WEBPACK_ENTRY)
+	window.loadURL(getWindowUrl('authentication_window'))
 
 	return window
 }

--- a/src/callbox/callbox.window.ts
+++ b/src/callbox/callbox.window.ts
@@ -4,7 +4,7 @@
  */
 
 import { BrowserWindow, screen } from 'electron'
-import { applyZoom, getScaledWindowSize } from '../app/utils.ts'
+import { applyZoom, getScaledWindowSize, getWindowUrl } from '../app/utils.ts'
 import { getBrowserWindowIcon } from '../shared/icons.utils.js'
 import { isMac, isWindows } from '../app/system.utils.ts'
 import { getAppConfig } from '../app/AppConfig.ts'
@@ -67,7 +67,7 @@ export function createCallboxWindow(params: CallboxParams) {
 
 	applyZoom(window)
 
-	window.loadURL(CALLBOX_WINDOW_WEBPACK_ENTRY + '?' + new URLSearchParams(params))
+	window.loadURL(getWindowUrl('callbox_window') + '?' + new URLSearchParams(params))
 
 	window.once('ready-to-show', () => window.showInactive())
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -3,6 +3,9 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+const APP_PROTOCOL = 'nctalk'
+const APP_HOST = 'app'
+const APP_ORIGIN = `${APP_PROTOCOL}://${APP_HOST}`
 const DEV_SERVER_ORIGIN = 'http://localhost:3000'
 const MIN_REQUIRED_NEXTCLOUD_VERSION = 27
 const MIN_REQUIRED_TALK_VERSION = 17
@@ -12,6 +15,9 @@ const ZOOM_MIN = 0.55
 const ZOOM_MAX = 5
 
 module.exports = {
+	APP_PROTOCOL,
+	APP_HOST,
+	APP_ORIGIN,
 	DEV_SERVER_ORIGIN,
 	MIN_REQUIRED_NEXTCLOUD_VERSION,
 	MIN_REQUIRED_TALK_VERSION,

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -78,17 +78,11 @@ declare interface Window {
  */
 
 // Electron Forge built constants
-declare const AUTHENTICATION_WINDOW_WEBPACK_ENTRY: string
 declare const AUTHENTICATION_WINDOW_PRELOAD_WEBPACK_ENTRY: string
 declare const CALLBOX_WINDOW_PRELOAD_WEBPACK_ENTRY: string
-declare const CALLBOX_WINDOW_WEBPACK_ENTRY: string
-declare const TALK_WINDOW_WEBPACK_ENTRY: string
 declare const TALK_WINDOW_PRELOAD_WEBPACK_ENTRY: string
-declare const HELP_WINDOW_WEBPACK_ENTRY: string
 declare const HELP_WINDOW_PRELOAD_WEBPACK_ENTRY: string
-declare const UPGRADE_WINDOW_WEBPACK_ENTRY: string
 declare const UPGRADE_WINDOW_PRELOAD_WEBPACK_ENTRY: string
-declare const WELCOME_WINDOW_WEBPACK_ENTRY: string
 declare const WELCOME_WINDOW_PRELOAD_WEBPACK_ENTRY: string
 
 declare global {

--- a/src/help/help.window.js
+++ b/src/help/help.window.js
@@ -6,7 +6,7 @@
 const { BrowserWindow } = require('electron')
 const { applyExternalLinkHandler } = require('../app/externalLinkHandlers.ts')
 const { getBrowserWindowIcon } = require('../shared/icons.utils.js')
-const { getScaledWindowSize, applyZoom, buildTitle } = require('../app/utils.ts')
+const { getScaledWindowSize, applyZoom, buildTitle, getWindowUrl } = require('../app/utils.ts')
 const { applyContextMenu } = require('../app/applyContextMenu.js')
 
 /**
@@ -38,7 +38,7 @@ function createHelpWindow(parentWindow) {
 
 	window.removeMenu()
 
-	window.loadURL(HELP_WINDOW_WEBPACK_ENTRY)
+	window.loadURL(getWindowUrl('help_window'))
 
 	applyExternalLinkHandler(window)
 	applyContextMenu(window)

--- a/src/main.js
+++ b/src/main.js
@@ -25,6 +25,7 @@ const { applyTheme } = require('./app/theme.config.ts')
 const { initLaunchAtStartupListener } = require('./app/launchAtStartup.config.ts')
 const { createCallboxWindow } = require('./callbox/callbox.window.ts')
 const { openChromeWebRtcInternals } = require('./app/dev.utils.ts')
+const { registerAppProtocolHandler } = require('./app/appProtocol.ts')
 const { BUILD_CONFIG } = require('./shared/build.config.ts')
 
 /**
@@ -135,6 +136,7 @@ app.whenReady().then(async () => {
 	await loadAppConfig()
 	applyTheme()
 	initLaunchAtStartupListener()
+	registerAppProtocolHandler()
 
 	// Open in the background if it is explicitly set, or the app was open at login on macOS
 	const openInBackground = ARGUMENTS.openInBackground || app.getLoginItemSettings().wasOpenedAtLogin

--- a/src/talk/renderer/talk.main.ts
+++ b/src/talk/renderer/talk.main.ts
@@ -13,6 +13,6 @@ import { setupWebPage } from '../../shared/setupWebPage.js'
 import { createTalkDesktopApp } from './TalkDesktop.app.ts'
 
 // Initially open the Welcome page, if not specified
-await setupWebPage({ routeHash: '#/apps/spreed' })
+await setupWebPage()
 
 await createTalkDesktopApp()

--- a/src/talk/talk.window.js
+++ b/src/talk/talk.window.js
@@ -12,7 +12,7 @@ const { setupTray } = require('../app/app.tray.js')
 const { getBrowserWindowIcon } = require('../shared/icons.utils.js')
 const { TITLE_BAR_HEIGHT } = require('../constants.js')
 const { getAppConfig } = require('../app/AppConfig.ts')
-const { getScaledWindowMinSize, getScaledWindowSize, applyZoom, buildTitle } = require('../app/utils.ts')
+const { getScaledWindowMinSize, getScaledWindowSize, applyZoom, buildTitle, getWindowUrl } = require('../app/utils.ts')
 
 /**
  * @return {import('electron').BrowserWindow}
@@ -77,7 +77,7 @@ function createTalkWindow() {
 
 	setupTray(window)
 
-	window.loadURL(TALK_WINDOW_WEBPACK_ENTRY + '#/apps/spreed')
+	window.loadURL(getWindowUrl('talk_window') + '#/apps/spreed')
 
 	return window
 }

--- a/src/upgrade/upgrade.window.ts
+++ b/src/upgrade/upgrade.window.ts
@@ -6,7 +6,7 @@
 import { BrowserWindow } from 'electron'
 import { applyExternalLinkHandler } from '../app/externalLinkHandlers.ts'
 import { getBrowserWindowIcon } from '../shared/icons.utils.js'
-import { getScaledWindowSize, applyZoom, buildTitle } from '../app/utils.ts'
+import { getScaledWindowSize, applyZoom, buildTitle, getWindowUrl } from '../app/utils.ts'
 import { applyContextMenu } from '../app/applyContextMenu.js'
 
 /**
@@ -34,7 +34,7 @@ export function createUpgradeWindow() {
 
 	window.removeMenu()
 
-	window.loadURL(UPGRADE_WINDOW_WEBPACK_ENTRY)
+	window.loadURL(getWindowUrl('upgrade_window'))
 
 	applyContextMenu(window)
 	applyExternalLinkHandler(window)

--- a/src/welcome/welcome.window.js
+++ b/src/welcome/welcome.window.js
@@ -6,7 +6,7 @@
 const { BrowserWindow } = require('electron')
 const { getBrowserWindowIcon } = require('../shared/icons.utils.js')
 const { isMac } = require('../app/system.utils.ts')
-const { getScaledWindowSize, applyZoom } = require('../app/utils.ts')
+const { getScaledWindowSize, applyZoom, getWindowUrl } = require('../app/utils.ts')
 const { getAppConfig } = require('../app/AppConfig.ts')
 
 /**
@@ -40,7 +40,7 @@ function createWelcomeWindow() {
 
 	applyZoom(window)
 
-	window.loadURL(WELCOME_WINDOW_WEBPACK_ENTRY)
+	window.loadURL(getWindowUrl('welcome_window'))
 
 	return window
 }


### PR DESCRIPTION
## ☑️ Resolves

* For https://github.com/nextcloud/talk-desktop/issues/9
  * 18: https://www.electronjs.org/docs/latest/tutorial/security#18-avoid-usage-of-the-file-protocol-and-prefer-usage-of-custom-protocols
* Base for:
  * Some other improvements
  * https://github.com/nextcloud/talk-desktop/issues/387

Note, it's only an internal protocol. It is not exposed to the system (yet).

### Before

Resources where loaded via `file://` protocol and absolute file path.

### After

There is an internal application protocol with the following URLs:
- `nctalk://app/` - Application files
  - `nctalk://app/welcome_window/index.html` - welcome page
  - `nctalk://app/talk_window/index.html` - Talk
  - `nctalk://app/talk_window/index.js` - static file
  - etc.
- `nctalk://call/{token}/` - Link to a specific conversation
  - Redirects to `nctalk://app/talk_window/index.html#/call/{token}/`