### PR TITLE
release: v1.1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@
 
 # Changelog
 
+## v1.1.6 - 2025-04-10
+
+### Fixes
+
+- File picker does not work when user never set locale [#1164](https://github.com/nextcloud/talk-desktop/pull/1164)
+
+### Changes
+
+- Built-in Talk in binaries is updated to v21.0.2 in both beta and stable release channels [#1207](https://github.com/nextcloud/talk-desktop/pull/1207)
+- Update translations
+- Update dependencies
+
 ## v1.1.5 - 2025-02-24
 
 ### Fixes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "talk-desktop",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "talk-desktop",
-      "version": "1.1.5",
+      "version": "1.1.6",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@mdi/svg": "^7.4.47",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "name": "talk-desktop",
   "productName": "Nextcloud Talk",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "bugs": {
     "url": "https://github.com/nextcloud/talk-desktop/issues",
     "create": "https://github.com/nextcloud/talk-desktop/issues/new/choose"


### PR DESCRIPTION
## v1.1.6 - 2025-04-10

### Fixes

- File picker does not work when user never set locale [#1164](https://github.com/nextcloud/talk-desktop/pull/1164)

### Changes

- Built-in Talk in binaries is updated to v21.0.2 in both beta and stable release channels [#1207](https://github.com/nextcloud/talk-desktop/pull/1207)
- Update translations
- Update dependencies