### PR TITLE
release: v1.1.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@
 
 # Changelog
 
+## v1.1.7 - 2025-04-18
+
+### Features
+
+- Add untrusted SSL certificate support on Linux [#1200](https://github.com/nextcloud/talk-desktop/pull/1200)
+
+### Changes
+
+- Built-in Talk in binaries is updated to v21.0.2 in both beta and stable release channels [#1224](https://github.com/nextcloud/talk-desktop/pull/1224)
+- Update translations
+- Update dependencies
+
 ## v1.1.6 - 2025-04-10
 
 ### Fixes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "talk-desktop",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "talk-desktop",
-      "version": "1.1.6",
+      "version": "1.1.7",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@mdi/svg": "^7.4.47",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "name": "talk-desktop",
   "productName": "Nextcloud Talk",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "bugs": {
     "url": "https://github.com/nextcloud/talk-desktop/issues",
     "create": "https://github.com/nextcloud/talk-desktop/issues/new/choose"


### PR DESCRIPTION
## v1.1.7 - 2025-04-18

### Features

- Add untrusted SSL certificate support on Linux [#1200](https://github.com/nextcloud/talk-desktop/pull/1200)

### Changes

- Built-in Talk in binaries is updated to v21.0.2 in both beta and stable release channels [#1224](https://github.com/nextcloud/talk-desktop/pull/1224)
- Update translations
- Update dependencies