### PR TITLE
fix(app): errors due to incorrect language format

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -83,7 +83,7 @@ ipcMain.handle('app:getTitle', (event) => BrowserWindow.fromWebContents(event.se
 ipcMain.handle('app:getSystemL10n', () => ({
 	locale: app.getLocale().replace('-', '_') ?? 'en',
 	// Note: Linux may have C (POSIX) locale, which results in an empty preferred languages list
-	language: app.getPreferredSystemLanguages()[0]?.replace('-', '_') ?? 'en-US',
+	language: app.getPreferredSystemLanguages()[0]?.replace('-', '_') ?? 'en_US',
 }))
 ipcMain.handle('app:enableWebRequestInterceptor', (event, ...args) => enableWebRequestInterceptor(...args))
 ipcMain.handle('app:disableWebRequestInterceptor', (event, ...args) => disableWebRequestInterceptor(...args))

--- a/src/shared/setupWebPage.js
+++ b/src/shared/setupWebPage.js
@@ -55,13 +55,16 @@ async function loadAndRegisterL10n(app, lang, resolver) {
  * @return {Promise<void>}
  */
 async function applyL10n() {
-	const language = appData.userMetadata?.language || (await window.TALK_DESKTOP.getSystemL10n()).language
-	const locale = appData.userMetadata?.locale || (await window.TALK_DESKTOP.getSystemL10n()).locale
+	const { language: systemLanguage, locale: systemLocale } = await window.TALK_DESKTOP.getSystemL10n()
+	const language = appData.userMetadata?.language || systemLanguage
+	const locale = appData.userMetadata?.locale || systemLocale
 
-	document.documentElement.lang = language
+	const canonicalLanguage = language.replaceAll('_', '-')
+
+	document.documentElement.lang = canonicalLanguage
 	document.documentElement.dataset.locale = locale
 
-	console.log(`Using locale "${locale}" for language "${language}"`)
+	console.info(`Using locale "${locale}" for language "${language}"`)
 
 	if (language !== 'en') {
 		await Promise.all([
@@ -70,7 +73,7 @@ async function applyL10n() {
 		])
 	}
 
-	document.body.dir = isRTL(language) ? 'rtl' : 'ltr'
+	document.body.dir = isRTL(canonicalLanguage) ? 'rtl' : 'ltr'
 }
 
 /**


### PR DESCRIPTION
### ☑️ Resolves

* In Nextcloud we use the posix format (e.g. `en_US`) while HTML expects IETF (`en-US`)
* This results in errors in `Intl`
* Fix: https://github.com/nextcloud/talk-desktop/issues/985
