### PR TITLE
fix: avoid preflight (OPTIONS) request by using internal reverse proxy

### DIFF
--- a/src/app/webRequestInterceptor.js
+++ b/src/app/webRequestInterceptor.js
@@ -6,7 +6,7 @@
 const { session } = require('electron')
 const { osTitle } = require('./system.utils.ts')
 const packageJson = require('../../package.json')
-const { APP_ORIGIN } = require('../constants.js')
+const { APP_PROTOCOL } = require('../constants.js')
 
 const USER_AGENT = `Mozilla/5.0 (${osTitle}) Nextcloud-Talk v${packageJson.version}`
 
@@ -15,16 +15,11 @@ const USER_AGENT = `Mozilla/5.0 (${osTitle}) Nextcloud-Talk v${packageJson.versi
  *
  * @param {string} serverUrl - Nextcloud server URL
  * @param {object} [options] - Patching options
- * @param {boolean} [options.enableCors] - Enable CORS for OCS and other APIs
- * @param {boolean} [options.enableCookies] - Enable aka cross-origin cookie without setting SameSate=None.
- *                                                  Some Talk and Files API requests require cookie session.
  * @param {import('../accounts/login.service.js').Credentials} [options.credentials] - User credentials for the Authentication header
  */
 function enableWebRequestInterceptor(serverUrl, {
-	enableCors = false,
-	enableCookies = false,
 	credentials = null,
-}) {
+} = {}) {
 	/**
 	 * Note: this function affects ALL requests. Performance is important here.
 	 */
@@ -32,138 +27,36 @@ function enableWebRequestInterceptor(serverUrl, {
 	// Cleanup because Electron doesn't support an interceptor update...
 	disableWebRequestInterceptor()
 
-	/**
-	 * CookieStorage. There are not many cookies (2-3). POJO is faster, than a Map.
-	 *
-	 * @type {{[cookieName: string]: string}}
-	 */
-	const cookiesStorage = {}
-
-	/**
-	 * @param {import('electron').OnBeforeSendHeadersListenerDetails} details - OnBeforeSendHeadersListenerDetails
-	 */
-	function includeCookies(details) {
-		details.requestHeaders.Cookie = Object.entries(cookiesStorage).map(([cookieName, cookieValue]) => `${cookieName}=${cookieValue}`).join('; ')
-	}
-
-	/**
-	 * @param {import('electron').OnHeadersReceivedListenerDetails} details - OnHeadersReceivedListenerDetails
-	 */
-	function persistCookies(details) {
-		// OPTIONS will have new session - ignore
-		if (details.method === 'OPTIONS') {
-			return
-		}
-
-		// Set-Cookie header may have any casing
-		const setCookieRE = /set-cookie/i
-		const setCookieHeaders = Object.keys(details.responseHeaders).filter((header) => setCookieRE.test(header))
-		// Persist all cookies
-		for (const setCookieHeader of setCookieHeaders) {
-			for (const cookie of details.responseHeaders[setCookieHeader]) {
-				const [name, value] = cookie.split('=')
-				cookiesStorage[name] = value.split(';')[0]
-			}
-			delete details.responseHeaders[setCookieHeader]
-		}
-	}
-
-	const ALLOWED_ORIGIN = [APP_ORIGIN]
-	const ALLOWED_METHODS = ['GET, POST, PUT, PATCH, DELETE, PROPFIND, MKCOL, SEARCH, REPORT'] // Includes WebDAV
-	const ALLOWED_CREDENTIALS_TRUE = ['true']
-	const ALLOWED_HEADERS = [
-		[
-			// Common
-			'Authorization',
-			'Content-Type',
-			'If-None-Match',
-			// WebDAV
-			'Depth',
-			// Nextcloud
-			'requesttoken',
-			'OCS-APIRequest',
-			'X-OC-MTIME',
-			'X-Requested-With',
-		].join(', '),
-	]
-	const EXPOSED_HEADERS = [
-		[
-		// Common headers
-			'ETag',
-			// Nextcloud Talk custom Response Headers
-			'x-nextcloud-talk-modified-before',
-			'x-nextcloud-talk-hash',
-			'x-nextcloud-has-user-statuses',
-			'x-chat-last-given',
-			'x-chat-last-common-read',
-		// TODO: should we add any WebDAV headers?
-		].join(', '),
-	]
-
-	/**
-	 * @param {import('electron').OnHeadersReceivedListenerDetails} details - OnHeadersReceivedListenerDetails
-	 */
-	function addCorsHeaders(details) {
-		if (details.method === 'OPTIONS') {
-			if (details.statusCode >= 400) {
-				// OPTIONS request may not be successful for many reasons, but it is not related to actual error.
-				// For example:
-				// - 405 Method Not Allowed -> 200 OK
-				//   OPTIONS method for CORS on OCS and API is not allowed at all.
-				//   Emulate allowed CORS.
-				// - 401 Unauthorized -> 200 OK
-				//   There is an authentication issue.
-				//   But if OPTIONS request fails, an actual request will fail with general Network error.
-				//   ClientRequest sender will not be able to detect the reason.
-				// - 500 Server error -> 200 OK
-				//   Same as 401 on some requests
-				//
-				// Replacing status is safe here, because it is only used for OPTIONS request.
-				// The following actual request will return the actual status anyway
-				details.statusCode = 200
-				// eslint-disable-next-line no-unused-vars
-				const [httpVersion, statusCode, optionalReason] = details.statusLine.split(' ')
-				details.statusLine = [httpVersion, '200', optionalReason].join(' ')
-			}
-		}
-
-		// Emulate CORS
-		details.responseHeaders['Access-Control-Allow-Origin'] = ALLOWED_ORIGIN
-		details.responseHeaders['Access-Control-Allow-Methods'] = ALLOWED_METHODS
-		details.responseHeaders['Access-Control-Allow-Credentials'] = ALLOWED_CREDENTIALS_TRUE
-		details.responseHeaders['Access-Control-Allow-Headers'] = ALLOWED_HEADERS
-		details.responseHeaders['Access-Control-Expose-Headers'] = EXPOSED_HEADERS
-	}
-
 	/** @type {import('electron').WebRequestFilter} */
 	const filter = {
 		urls: [`${serverUrl}/*`],
 	}
 
-	// TODO: should use concrete window session instead of defaultSession ?
+	session.defaultSession.webRequest.onBeforeRequest({
+		urls: [`${serverUrl}/*`, `${APP_PROTOCOL}://api/*`],
+	}, (details, callback) => {
+		// Make sure redirect request is to the current server
+		if (details.url.startsWith(`${APP_PROTOCOL}://api/`)) {
+			const redirectUrl = details.url.slice(`${APP_PROTOCOL}://api/`.length)
+			return callback({ cancel: !redirectUrl.startsWith(serverUrl) })
+		}
+
+		// Redirect to the internal reverse proxy
+		if (details.webContents) {
+			return callback({ redirectURL: APP_PROTOCOL + '://api/' + details.url })
+		}
+
+		callback({})
+	})
 
 	session.defaultSession.webRequest.onBeforeSendHeaders(
 		filter,
 		(details, callback) => {
+			details.requestHeaders.Origin = new URL(serverUrl).origin
 			details.requestHeaders['User-Agent'] = USER_AGENT
+			details.requestHeaders['OCS-APIRequest'] = 'true'
 			if (credentials) {
 				details.requestHeaders.Authorization = `Basic ${btoa(`${credentials.user}:${credentials.password}`)}`
-			}
-			if (enableCookies) {
-				includeCookies(details)
-			}
-			callback(details)
-		},
-	)
-
-	session.defaultSession.webRequest.onHeadersReceived(
-		filter,
-		(details, callback) => {
-			if (enableCookies) {
-				persistCookies(details)
-			}
-			if (enableCors) {
-				addCorsHeaders(details)
 			}
 			callback(details)
 		},
@@ -175,7 +68,6 @@ function enableWebRequestInterceptor(serverUrl, {
  */
 function disableWebRequestInterceptor() {
 	session.defaultSession.webRequest.onBeforeSendHeaders(null)
-	session.defaultSession.webRequest.onHeadersReceived(null)
 }
 
 module.exports = {

--- a/src/authentication/renderer/AuthenticationApp.vue
+++ b/src/authentication/renderer/AuthenticationApp.vue
@@ -74,7 +74,6 @@ async function login() {
 	// Check if valid URL
 	try {
 		// new URL will throw an exception on invalid URL
-
 		new URL(serverUrl.value)
 	} catch {
 		return setError(t('talk_desktop', 'Invalid server address'))
@@ -82,7 +81,7 @@ async function login() {
 
 	// Prepare to request the server
 	window.TALK_DESKTOP.disableWebRequestInterceptor()
-	window.TALK_DESKTOP.enableWebRequestInterceptor(serverUrl.value, { enableCors: true })
+	window.TALK_DESKTOP.enableWebRequestInterceptor(serverUrl.value)
 	appData.reset()
 	appData.serverUrl = serverUrl.value
 
@@ -128,7 +127,7 @@ async function login() {
 	}
 
 	// Add credentials to the request
-	window.TALK_DESKTOP.enableWebRequestInterceptor(serverUrl.value, { enableCors: true, enableCookies: true, credentials })
+	window.TALK_DESKTOP.enableWebRequestInterceptor(serverUrl.value, { credentials })
 	// Save credentials
 	appData.credentials = credentials
 

--- a/src/main.js
+++ b/src/main.js
@@ -298,8 +298,6 @@ app.whenReady().then(async () => {
 		if (appData.credentials) {
 			// User is authenticated - setup and start main window
 			enableWebRequestInterceptor(appData.serverUrl, {
-				enableCors: true,
-				enableCookies: true,
 				credentials: appData.credentials,
 			})
 			mainWindow = createTalkWindow()

--- a/src/shared/setupWebPage.js
+++ b/src/shared/setupWebPage.js
@@ -102,14 +102,6 @@ async function applyUserData() {
  * @return {void}
  */
 export function applyAxiosInterceptors() {
-	axios.interceptors.request.use((config) => {
-		// For CORS requests
-		config.withCredentials = true
-		// For OCS requests using Authentication headers
-		config.headers['OCS-APIRequest'] = 'true'
-		return config
-	}, (error) => Promise.reject(error))
-
 	// Handle 401 Unauthorized and 426 Upgrade Required responses
 	let upgradeInterceptorHasBeenTriggeredOnce = false
 	axios.interceptors.response.use((response) => response, (error) => {

--- a/src/welcome/welcome.js
+++ b/src/welcome/welcome.js
@@ -30,7 +30,7 @@ initGlobals()
 applyAxiosInterceptors()
 
 if (appData.credentials) {
-	await window.TALK_DESKTOP.enableWebRequestInterceptor(appData.serverUrl, { enableCors: true, enableCookies: true, credentials: appData.credentials })
+	await window.TALK_DESKTOP.enableWebRequestInterceptor(appData.serverUrl, { credentials: appData.credentials })
 	await refetchAppDataIfDirty(appData)
 }
 


### PR DESCRIPTION
### ☑️ Resolves

* Fix: https://github.com/nextcloud/talk-desktop/issues/1234
* The app is on `nctalk://app` host
* The server is on `https://some.nextcloud.ltd`
* Request from the app to the server is a cross-origin request (forbidden)
* In the past was "allowed" by changing the server response
  * This still makes an unnecessary server request
* Now it redirects to internal `ncapp://api/https://some.nextcloud.ltd` and proxies the request
  * It still has an ugly redirect
  * But no `OPTIONS` requests to the server

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![image](https://github.com/user-attachments/assets/87b89869-db50-4dd0-ac33-e5d44dbc8969) | ![image](https://github.com/user-attachments/assets/bf8acd20-bec5-4404-8ce4-1b5332c6e945)
