### PR TITLE
perf(user-status): do not request backup status until user status form open

### DIFF
--- a/src/talk/renderer/TitleBar/components/UserMenu.vue
+++ b/src/talk/renderer/TitleBar/components/UserMenu.vue
@@ -86,6 +86,7 @@ function handleUserStatusChange(status: UserStatusStatusType) {
 					<NcAvatar
 						class="user-menu__avatar"
 						:user="user.id"
+						:preloaded-user-status="userStatus"
 						:display-name="user['display-name']"
 						:size="32"
 						disable-tooltip

--- a/src/talk/renderer/UserStatus/UserStatusDialog.vue
+++ b/src/talk/renderer/UserStatus/UserStatusDialog.vue
@@ -4,13 +4,16 @@
 -->
 
 <script setup lang="ts">
+import type { UserStatusBackup } from './userStatus.types.ts'
 import NcDialog from '@nextcloud/vue/components/NcDialog'
 import NcLoadingIcon from '@nextcloud/vue/components/NcLoadingIcon'
-import { translate as t } from '@nextcloud/l10n'
+import { getCurrentUser } from '@nextcloud/auth'
+import { t } from '@nextcloud/l10n'
 import { onBeforeMount, ref } from 'vue'
 import { useUserStatusStore } from './userStatus.store.ts'
 import UserStatusForm from './components/UserStatusForm.vue'
 import { usePredefinedStatusesStore } from './predefinedStatuses.store.ts'
+import { fetchBackupStatus } from './userStatus.service.ts'
 
 const emit = defineEmits<{
 	(event: 'close'): void
@@ -19,19 +22,28 @@ const emit = defineEmits<{
 const isReady = ref(false)
 const userStatusStore = useUserStatusStore()
 const predefinedStatusesStore = usePredefinedStatusesStore()
+const backupStatus = ref<UserStatusBackup | null>(null)
 
 onBeforeMount(async () => {
 	await Promise.all([
 		predefinedStatusesStore.initPromise,
 		userStatusStore.refreshUserStatus(),
+		loadBackupStatus(),
 	])
 	isReady.value = true
 })
+
+/**
+ * Load the backup status
+ */
+async function loadBackupStatus() {
+	backupStatus.value = await fetchBackupStatus(getCurrentUser()!.uid).catch(() => null)
+}
 </script>
 
 <template>
 	<NcDialog :name="t('talk_desktop', 'User status')" size="small" @closing="emit('close')">
-		<UserStatusForm v-if="isReady" @submit="emit('close')" />
+		<UserStatusForm v-if="isReady" :backup-status.sync="backupStatus" @submit="emit('close')" />
 		<NcLoadingIcon v-else :size="48" style="height: 480px /* Approx. size of the form */" />
 	</NcDialog>
 </template>

--- a/src/talk/renderer/UserStatus/UserStatusDialog.vue
+++ b/src/talk/renderer/UserStatus/UserStatusDialog.vue
@@ -5,19 +5,33 @@
 
 <script setup lang="ts">
 import NcDialog from '@nextcloud/vue/components/NcDialog'
+import NcLoadingIcon from '@nextcloud/vue/components/NcLoadingIcon'
 import { translate as t } from '@nextcloud/l10n'
+import { onBeforeMount, ref } from 'vue'
 import { useUserStatusStore } from './userStatus.store.ts'
 import UserStatusForm from './components/UserStatusForm.vue'
+import { usePredefinedStatusesStore } from './predefinedStatuses.store.ts'
 
 const emit = defineEmits<{
 	(event: 'close'): void
 }>()
 
+const isReady = ref(false)
 const userStatusStore = useUserStatusStore()
+const predefinedStatusesStore = usePredefinedStatusesStore()
+
+onBeforeMount(async () => {
+	await Promise.all([
+		predefinedStatusesStore.initPromise,
+		userStatusStore.refreshUserStatus(),
+	])
+	isReady.value = true
+})
 </script>
 
 <template>
 	<NcDialog :name="t('talk_desktop', 'User status')" size="small" @closing="emit('close')">
-		<UserStatusForm v-if="userStatusStore.userStatus" @submit="emit('close')" />
+		<UserStatusForm v-if="isReady" @submit="emit('close')" />
+		<NcLoadingIcon v-else :size="48" style="height: 480px /* Approx. size of the form */" />
 	</NcDialog>
 </template>

--- a/src/talk/renderer/UserStatus/components/UserStatusForm.vue
+++ b/src/talk/renderer/UserStatus/components/UserStatusForm.vue
@@ -9,9 +9,9 @@ import { computed, onBeforeMount, ref } from 'vue'
 import { toRef } from '@vueuse/core'
 import { getCurrentUser } from '@nextcloud/auth'
 import NcButton from '@nextcloud/vue/components/NcButton'
-import NcNoteCard from '@nextcloud/vue/components/NcNoteCard'
 import { translate as t } from '@nextcloud/l10n'
 import { useUserStatusStore } from '../userStatus.store.ts'
+import UserStatusFormBackup from './UserStatusFormBackup.vue'
 import UserStatusFormClearAt from './UserStatusFormClearAt.vue'
 import UserStatusFormCustomMessage from './UserStatusFormCustomMessage.vue'
 import UserStatusFormStatusType from './UserStatusFormStatusType.vue'
@@ -95,9 +95,11 @@ async function revertStatus() {
 	<div class="user-status-form">
 		<UserStatusFormStatusType class="user-status-form__row" :status="userStatus.status" @update:status="patchStatus({ status: $event })" />
 
-		<NcNoteCard v-if="backupStatus" type="info" class="user-status-form__row">
-			{{ t('talk_desktop', 'Your status was set automatically') }}
-		</NcNoteCard>
+		<UserStatusFormBackup
+			v-if="backupStatus"
+			class="user-status-form__row"
+			:user-status="backupStatus"
+			@revert="revertStatus" />
 
 		<UserStatusFormCustomMessage
 			class="user-status-form__row"
@@ -106,15 +108,6 @@ async function revertStatus() {
 			:icon="userStatus.icon"
 			@update:message="patchStatus({ message: $event })"
 			@update:icon="patchStatus({ icon: $event })" />
-
-		<template v-if="backupStatus">
-			<h4>{{ t('talk_desktop', 'Previously set status') }}</h4>
-			<UserStatusFormPredefinedOption key="previously-set" :user-status="backupStatus" @click="revertStatus" />
-		</template>
-
-		<h4 v-if="backupStatus">
-			{{ t('talk_desktop', 'Predefined statuses') }}
-		</h4>
 
 		<div class="user-status-form__predefined-statuses">
 			<UserStatusFormPredefinedOption

--- a/src/talk/renderer/UserStatus/components/UserStatusForm.vue
+++ b/src/talk/renderer/UserStatus/components/UserStatusForm.vue
@@ -4,9 +4,10 @@
 -->
 
 <script setup lang="ts">
-import type { PredefinedUserStatus, UserStatusPrivate } from '../userStatus.types.ts'
+import type { PredefinedUserStatus, UserStatusPrivate, UserStatusBackup } from '../userStatus.types.ts'
 import { computed, ref } from 'vue'
-import { storeToRefs } from 'pinia'
+import { toRef } from '@vueuse/core'
+import { getCurrentUser } from '@nextcloud/auth'
 import NcButton from '@nextcloud/vue/components/NcButton'
 import NcNoteCard from '@nextcloud/vue/components/NcNoteCard'
 import { translate as t } from '@nextcloud/l10n'
@@ -16,6 +17,7 @@ import UserStatusFormCustomMessage from './UserStatusFormCustomMessage.vue'
 import UserStatusFormStatusType from './UserStatusFormStatusType.vue'
 import UserStatusFormPredefinedOption from './UserStatusFormPredefinedOption.vue'
 import { convertPredefinedStatusToUserStatus } from '../userStatus.utils.ts'
+import { usePredefinedStatusesStore } from '../predefinedStatuses.store.ts'
 
 const emit = defineEmits<{
 	(event: 'submit'): void
@@ -27,7 +29,7 @@ const backupStatus = ref(userStatusStore.backupStatus ? { ...userStatusStore.bac
 
 const isDirty = ref(false)
 
-const { predefinedStatuses } = storeToRefs(userStatusStore)
+const predefinedStatuses = toRef(() => usePredefinedStatusesStore().predefinedStatuses)
 
 const statusIsUserDefined = computed(() => userStatus.value.icon || userStatus.value.message)
 const isClear = computed(() => userStatus.value.status === 'online' && !userStatus.value.icon && !userStatus.value.message)

--- a/src/talk/renderer/UserStatus/components/UserStatusFormBackup.vue
+++ b/src/talk/renderer/UserStatus/components/UserStatusFormBackup.vue
@@ -1,0 +1,80 @@
+<!--
+  - SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+  -->
+
+<script setup lang="ts">
+import type { UserStatusBackup } from '../userStatus.types.ts'
+import { t } from '@nextcloud/l10n'
+import NcButton from '@nextcloud/vue/components/NcButton'
+import NcNoteCard from '@nextcloud/vue/components/NcNoteCard'
+import NcUserStatusIcon from '@nextcloud/vue/components/NcUserStatusIcon'
+
+defineProps<{
+	userStatus: UserStatusBackup
+}>()
+
+const emit = defineEmits<{
+	(event: 'revert'): void
+}>()
+</script>
+
+<template>
+	<NcNoteCard type="info" class="user-status-form-backup">
+		<div class="user-status-form-backup__inner">
+			<span>{{ t('talk_desktop', 'Your status was set automatically') }}</span>
+			<span class="user-status-form-backup__reset">
+				<span class="user-status-form-backup__status">
+					<span>
+						<template v-if="userStatus.icon">
+							{{ userStatus.icon }}
+						</template>
+						<NcUserStatusIcon v-else-if="'status' in userStatus" :status="userStatus.status" />
+					</span>
+					<span>
+						{{ userStatus.message || t('talk_desktop', 'No status message') }}
+					</span>
+				</span>
+				<NcButton
+					class="user-status-form-backup__reset-button"
+					size="small"
+					variant="primary"
+					@click="emit('revert')">
+					{{ t('talk_desktop', 'Reset') }}
+				</NcButton>
+			</span>
+		</div>
+	</NcNoteCard>
+</template>
+
+<style scoped>
+/* TODO: fix upstream */
+.user-status-form-backup > :deep(div) {
+	flex: 1;
+}
+
+.user-status-form-backup__inner {
+	display: flex;
+	flex-direction: column;
+	gap: calc(2 * var(--default-grid-baseline));
+}
+
+.user-status-form-backup__status {
+	display: flex;
+	flex-direction: row;
+	align-items: center;
+	gap: calc(2 * var(--default-grid-baseline));
+}
+
+.user-status-form-backup__reset {
+	display: flex;
+	flex-direction: row;
+	align-items: flex-end;
+	justify-content: space-between;
+	gap: calc(2 * var(--default-grid-baseline));
+}
+
+.user-status-form-backup__reset-button {
+	flex: 0 0 auto;
+}
+</style>

--- a/src/talk/renderer/UserStatus/components/UserStatusFormCustomMessage.vue
+++ b/src/talk/renderer/UserStatus/components/UserStatusFormCustomMessage.vue
@@ -24,14 +24,11 @@ const emit = defineEmits<{
 	(event: 'update:icon', value: string | null): void
 	(event: 'update:message', value: string | null): void
 }>()
-
-// TODO: Vue 3 - replace with `useId`
-const id = Math.random().toString(36).slice(2, 8)
 </script>
 
 <template>
-	<div :id="id" class="user-status-form-custom-message">
-		<NcEmojiPicker :container="'#' + id" @select="emit('update:icon', $event)">
+	<div class="user-status-form-custom-message">
+		<NcEmojiPicker @select="emit('update:icon', $event)">
 			<NcButton :aria-label="t('talk_desktop', 'Emoji for your status message')" variant="tertiary" :disabled="disabled">
 				<template #icon>
 					<template v-if="icon">

--- a/src/talk/renderer/UserStatus/components/UserStatusFormPredefinedOption.vue
+++ b/src/talk/renderer/UserStatus/components/UserStatusFormPredefinedOption.vue
@@ -6,6 +6,7 @@
 <script setup lang="ts">
 import type { PredefinedUserStatus, UserStatusBackup } from '../userStatus.types.ts'
 import NcButton from '@nextcloud/vue/components/NcButton'
+import NcUserStatusIcon from '@nextcloud/vue/components/NcUserStatusIcon'
 import { clearAtToLabel } from '../userStatus.utils.ts'
 
 withDefaults(defineProps<{
@@ -28,8 +29,24 @@ const emit = defineEmits<{
 		:pressed="pressed"
 		@click="emit('click')">
 		<template #icon>
-			{{ userStatus.icon }}
+			<template v-if="userStatus.icon">
+				{{ userStatus.icon }}
+			</template>
+			<NcUserStatusIcon v-else-if="'status' in userStatus" :status="userStatus.status" />
 		</template>
-		{{ userStatus.message }} – {{ clearAtToLabel(userStatus.clearAt) }}
+		<span v-if="userStatus.message">
+			{{ userStatus.message }}
+		</span>
+		<span class="predefined-option__clear-at">
+			<span v-if="userStatus.message"> - </span>
+			{{ clearAtToLabel(userStatus.clearAt) }}
+		</span>
 	</NcButton>
 </template>
+
+<style scoped>
+.predefined-option__clear-at {
+	font-weight: normal;
+	color: var(--color-text-maxcontrast);
+}
+</style>

--- a/src/talk/renderer/UserStatus/predefinedStatuses.store.ts
+++ b/src/talk/renderer/UserStatus/predefinedStatuses.store.ts
@@ -12,11 +12,12 @@ import { browserStorage } from '../../../shared/browserStorage.service.ts'
 export const usePredefinedStatusesStore = defineStore('predefinedStatuses', () => {
 	const predefinedStatuses = useBrowserStorage<PredefinedUserStatus[] | null>(browserStorage, 'predefinedStatuses', null)
 
-	fetchAllPredefinedStatuses().then((statuses) => {
+	const initPromise = fetchAllPredefinedStatuses().then((statuses) => {
 		predefinedStatuses.value = statuses
 	})
 
 	return {
+		initPromise,
 		predefinedStatuses,
 	}
 })

--- a/src/talk/renderer/UserStatus/predefinedStatuses.store.ts
+++ b/src/talk/renderer/UserStatus/predefinedStatuses.store.ts
@@ -1,0 +1,22 @@
+/*!
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type { PredefinedUserStatus } from './userStatus.types.ts'
+import { defineStore } from 'pinia'
+import { fetchAllPredefinedStatuses } from './userStatus.service.ts'
+import { useBrowserStorage } from '../../../shared/useBrowserStorage.ts'
+import { browserStorage } from '../../../shared/browserStorage.service.ts'
+
+export const usePredefinedStatusesStore = defineStore('predefinedStatuses', () => {
+	const predefinedStatuses = useBrowserStorage<PredefinedUserStatus[] | null>(browserStorage, 'predefinedStatuses', null)
+
+	fetchAllPredefinedStatuses().then((statuses) => {
+		predefinedStatuses.value = statuses
+	})
+
+	return {
+		predefinedStatuses,
+	}
+})

--- a/src/talk/renderer/UserStatus/userStatus.store.ts
+++ b/src/talk/renderer/UserStatus/userStatus.store.ts
@@ -2,12 +2,9 @@
  * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
-import type {
-	UserStatusPrivate,
-	UserStatusPublic,
-} from './userStatus.types.ts'
+import type { UserStatusPrivate, UserStatusPublic } from './userStatus.types.ts'
 import { defineStore } from 'pinia'
-import { computed, ref, watch } from 'vue'
+import { computed } from 'vue'
 import { emit, subscribe } from '@nextcloud/event-bus'
 import { getCurrentUser } from '@nextcloud/auth'
 import {
@@ -16,28 +13,13 @@ import {
 	heartbeatUserStatus,
 	updateUserStatus,
 } from './userStatus.service.ts'
+import { useBrowserStorage } from '../../../shared/useBrowserStorage.ts'
+import { browserStorage } from '../../../shared/browserStorage.service.ts'
 
 declare module '@nextcloud/event-bus' {
 	interface NextcloudEvents {
 		'user_status:status.updated': UserStatusPublic
 	}
-}
-
-/**
- * Cache the user status in local storage
- *
- * @param userStatus - User status
- */
-function cacheUserStatus(userStatus: UserStatusPrivate) {
-	localStorage.setItem('TalkDesktop:userStatus', JSON.stringify(userStatus))
-}
-
-/**
- * Restore the user status from local storage
- */
-function restoreUserStatus(): UserStatusPrivate | null {
-	// @ts-expect-error - JSON parse type is invalid in lib.ts, `null` is a valid value to parse
-	return JSON.parse(localStorage.getItem('TalkDesktop:userStatus'))
 }
 
 /**
@@ -56,7 +38,7 @@ function emitUserStatusUpdated(userStatus: UserStatusPublic) {
 }
 
 export const useUserStatusStore = defineStore('userStatus', () => {
-	const userStatus = ref<UserStatusPrivate | null>(null)
+	const userStatus = useBrowserStorage<UserStatusPrivate | null>(browserStorage, 'userStatus', null)
 
 	const isDnd = computed(() => userStatus.value?.status === 'dnd')
 
@@ -66,16 +48,8 @@ export const useUserStatusStore = defineStore('userStatus', () => {
 		}
 	})
 
-	// Restore the user status from cache
-	const cachedStatus = restoreUserStatus()
-	if (cachedStatus) {
-		setUserStatus(cachedStatus, true)
-	}
-
-	watch(userStatus, (newUserStatus) => cacheUserStatus(newUserStatus!), { deep: true })
-
 	const initPromise = (async () => {
-		await updateUserStatusWithHeartbeat(false, true)
+		setUserStatus(await fetchCurrentUserStatus())
 	})()
 
 	/**
@@ -98,7 +72,7 @@ export const useUserStatusStore = defineStore('userStatus', () => {
 	 * @param withEmit - Whether to emit the update event
 	 */
 	function patchUserStatus(newUserStatus: Partial<UserStatusPrivate>, withEmit: boolean = true) {
-		Object.assign(userStatus.value!, newUserStatus)
+		userStatus.value = { ...userStatus.value, ...newUserStatus } as UserStatusPrivate
 		if (withEmit) {
 			emitUserStatusUpdated(userStatus.value!)
 		}
@@ -132,17 +106,11 @@ export const useUserStatusStore = defineStore('userStatus', () => {
 	 * Update the user status with a heartbeat
 	 *
 	 * @param isAway - Whether the user is away
-	 * @param forceFetchStatus - Whether to force fetch the current status
 	 */
-	async function updateUserStatusWithHeartbeat(isAway: boolean, forceFetchStatus: boolean = false) {
+	async function updateUserStatusWithHeartbeat(isAway: boolean) {
 		const status = await heartbeatUserStatus(isAway)
-
 		if (status) {
 			setUserStatus(status)
-		} else if (forceFetchStatus) {
-			// heartbeat returns the status only if it has changed
-			// Request explicitly if forced to fetch status
-			setUserStatus(await fetchCurrentUserStatus())
 		}
 	}
 

--- a/src/talk/renderer/UserStatus/userStatus.store.ts
+++ b/src/talk/renderer/UserStatus/userStatus.store.ts
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 import type {
-	PredefinedUserStatus,
 	UserStatusBackup,
 	UserStatusPrivate,
 	UserStatusPublic,
@@ -13,7 +12,6 @@ import { computed, ref, watch } from 'vue'
 import { emit, subscribe } from '@nextcloud/event-bus'
 import { getCurrentUser } from '@nextcloud/auth'
 import {
-	fetchAllPredefinedStatuses,
 	fetchCurrentUserStatus,
 	revertToBackupStatus,
 	heartbeatUserStatus,
@@ -45,23 +43,6 @@ function restoreUserStatus(): UserStatusPrivate | null {
 }
 
 /**
- * Cache the predefined statuses in local storage
- *
- * @param predefinedStatuses - Predefined statuses
- */
-function cachePredefinedStatuses(predefinedStatuses: PredefinedUserStatus[]) {
-	localStorage.setItem('TalkDesktop:predefinedStatuses', JSON.stringify(predefinedStatuses))
-}
-
-/**
- * Restore the predefined statuses from local storage
- */
-function restorePredefinedStatuses(): PredefinedUserStatus[] | null {
-	// @ts-expect-error - JSON parse type is invalid in lib.ts, `null` is a valid value to parse
-	return JSON.parse(localStorage.getItem('TalkDesktop:predefinedStatuses'))
-}
-
-/**
  * Emit the user status update event
  *
  * @param userStatus - User status
@@ -78,7 +59,6 @@ function emitUserStatusUpdated(userStatus: UserStatusPublic) {
 
 export const useUserStatusStore = defineStore('userStatus', () => {
 	const userStatus = ref<UserStatusPrivate | null>(null)
-	const predefinedStatuses = ref<PredefinedUserStatus[] | null>(restorePredefinedStatuses())
 	const backupStatus = ref<UserStatusBackup | null>(null)
 
 	const isDnd = computed(() => userStatus.value?.status === 'dnd')
@@ -99,9 +79,6 @@ export const useUserStatusStore = defineStore('userStatus', () => {
 
 	const initPromise = (async () => {
 		await updateUserStatusWithHeartbeat(false, true)
-
-		predefinedStatuses.value = await fetchAllPredefinedStatuses()
-		cachePredefinedStatuses(predefinedStatuses.value)
 	})()
 
 	/**
@@ -181,7 +158,6 @@ export const useUserStatusStore = defineStore('userStatus', () => {
 		initPromise,
 		userStatus,
 		isDnd,
-		predefinedStatuses,
 		backupStatus,
 		saveUserStatus,
 		revertUserStatusFromBackup,

--- a/src/talk/renderer/UserStatus/userStatus.store.ts
+++ b/src/talk/renderer/UserStatus/userStatus.store.ts
@@ -48,9 +48,14 @@ export const useUserStatusStore = defineStore('userStatus', () => {
 		}
 	})
 
-	const initPromise = (async () => {
+	refreshUserStatus()
+
+	/**
+	 * Fetch the current user status (Private)
+	 */
+	async function refreshUserStatus() {
 		setUserStatus(await fetchCurrentUserStatus())
-	})()
+	}
 
 	/**
 	 * Set the user status
@@ -115,9 +120,9 @@ export const useUserStatusStore = defineStore('userStatus', () => {
 	}
 
 	return {
-		initPromise,
 		userStatus,
 		isDnd,
+		refreshUserStatus,
 		saveUserStatus,
 		revertUserStatusFromBackup,
 		updateUserStatusWithHeartbeat,


### PR DESCRIPTION
### ☑️ Resolves

* Fix: https://github.com/nextcloud/talk-desktop/issues/1233
* Before backup status was requested on each heartbeat
* After it is requested only before opening the user status form
* Also:
  * Removed user status request from User Menu's avatar — use preload status
  * Fix the backup status design, as it is now more visible (I'm fine with dropping this commit)
  * Refactored a bit:
    * Decompose predefined statuses from the user status store
    * Use `useBrowserStorage` for LS caching

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![image](https://github.com/user-attachments/assets/5acc7efc-0330-4061-88b8-bb6bb66a4eca) | ![image](https://github.com/user-attachments/assets/ad09cf29-10c7-4be2-8e4c-e22a2de37fda)
![image](https://github.com/user-attachments/assets/da798d3a-cdf4-4db2-ada5-6d9e6b4c6089) | ![image](https://github.com/user-attachments/assets/ad09cf29-10c7-4be2-8e4c-e22a2de37fda)
![image](https://github.com/user-attachments/assets/b17e1f83-be12-4bfa-8249-4d2bf04f8069) | ![image](https://github.com/user-attachments/assets/5ec7b6de-511b-48d3-8f33-02544416fac5)

