### PR TITLE
build: use dot in sanitized dist name

### DIFF
--- a/forge.config.js
+++ b/forge.config.js
@@ -49,8 +49,9 @@ function generateDistName(platform, arch, ext) {
 	const archTitle = archTitles[arch] ?? arch
 	const CHANNEL = process.env.CHANNEL ?? 'stable'
 	const channel = CHANNEL !== 'stable' ? CHANNEL : ''
+	const name = CONFIG.applicationName.replace(/[^a-z0-9]/gi, '.')
 
-	return [CONFIG.applicationNameSanitized, channel, platformTitle, archTitle].filter(Boolean).join('-') + ext
+	return [name, channel, platformTitle, archTitle].filter(Boolean).join('-') + ext
 }
 
 /**


### PR DESCRIPTION
### ☑️ Resolves

* Fix https://github.com/nextcloud/talk-desktop/issues/1209
  * It was fixed because I renamed files manually after the build 🙈
* Regression from https://github.com/nextcloud/talk-desktop/pull/1193
* There were different sanitized name formats...
  * In dist files we used `.` as a replacement of non-alphanumeric characters
  * In other places - non-alphanumeric characters are just removed
