### PR TITLE
release: v1.1.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 
 ### Changes
 
-- Built-in Talk in binaries is updated to v21.0.2 in both beta and stable release channels [#1224](https://github.com/nextcloud/talk-desktop/pull/1224)
+- Built-in Talk in binaries is updated to v21.0.3 in both beta and stable release channels [#1224](https://github.com/nextcloud/talk-desktop/pull/1224)
 - Update translations
 - Update dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@
 
 # Changelog
 
+## v1.1.8 - 2025-04-29
+
+### Fixes
+
+- Reduce the number of user status requests by half [#1237](https://github.com/nextcloud/talk-desktop/pull/1237)
+- Regression from the previous release causing unnecessary OPTIONS request to the server [#1236](https://github.com/nextcloud/talk-desktop/pull/1236)
+- File picker does not work in some locales [#1235](https://github.com/nextcloud/talk-desktop/pull/1235)
+
+### Changes
+
+- Built-in Talk in binaries is updated to v21.0.4 in both beta and stable release channels [#1246](https://github.com/nextcloud/talk-desktop/pull/1246)
+- Talk Desktop can now be installed on Windows via community supported Chocolatey package: `choco install nextcloud-talk` [#1247](https://github.com/nextcloud/talk-desktop/pull/1247)
+
 ## v1.1.7 - 2025-04-18
 
 ### Features

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "talk-desktop",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "talk-desktop",
-      "version": "1.1.7",
+      "version": "1.1.8",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@mdi/svg": "^7.4.47",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "name": "talk-desktop",
   "productName": "Nextcloud Talk",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "bugs": {
     "url": "https://github.com/nextcloud/talk-desktop/issues",
     "create": "https://github.com/nextcloud/talk-desktop/issues/new/choose"


### PR DESCRIPTION
## v1.1.8 - 2025-04-29

### Fixes

- Reduce the number of user status requests by half [#1237](https://github.com/nextcloud/talk-desktop/pull/1237)
- Regression from the previous release causing unnecessary OPTIONS request to the server [#1236](https://github.com/nextcloud/talk-desktop/pull/1236)
- File picker does not work in some locales [#1235](https://github.com/nextcloud/talk-desktop/pull/1235)

### Changes

- Built-in Talk in binaries is updated to v21.0.4 in both beta and stable release channels [#1246](https://github.com/nextcloud/talk-desktop/pull/1246)
- Talk Desktop can now be installed on Windows via community supported Chocolatey package: `choco install nextcloud-talk` [#1247](https://github.com/nextcloud/talk-desktop/pull/1247)