### PR TITLE
fix: adjust mimetype icon for directories

### DIFF
--- a/src/shared/globals/OC/mimetype.js
+++ b/src/shared/globals/OC/mimetype.js
@@ -94,7 +94,7 @@ export const MimeTypeList = {
 		'application/yaml': 'text/code',
 		'application/zip': 'package/x-generic',
 		database: 'file',
-		'httpd/unix-directory': 'dir',
+		'httpd/unix-directory': 'folder',
 		'text/css': 'text/code',
 		'text/csv': 'x-office/spreadsheet',
 		'text/html': 'text/code',


### PR DESCRIPTION
### ☑️ Resolves

* Issue #1253
* 'dir' is not listed anywhere, but 'folder' exists

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
<img width="144" alt="2025-04-30_12h36_52" src="https://github.com/user-attachments/assets/06f194b8-b5ff-4701-b9bc-caf6472cf486" /> | <img width="143" alt="image" src="https://github.com/user-attachments/assets/a2c2fbb4-8565-4e37-acf2-1083439016c6" />
