### PR TITLE
chore: migrate to Electron 36 `session.extensions`

### DIFF
--- a/src/install-vue-devtools.js
+++ b/src/install-vue-devtools.js
@@ -34,7 +34,7 @@ async function isDirectoryExists(path) {
  * @return {Promise<void>}
  */
 async function installVueDevtools() {
-	if (session.defaultSession.getExtension(VUE_DEVTOOLS_EXTENSION_ID)) {
+	if (session.defaultSession.extensions.getExtension(VUE_DEVTOOLS_EXTENSION_ID)) {
 		console.log('Vue Devtools extension has already been installed')
 		return
 	}
@@ -48,7 +48,7 @@ async function installVueDevtools() {
 		console.log('Vue Devtools extension is unpacked')
 	}
 
-	await session.defaultSession.loadExtension(extensionDir)
+	await session.defaultSession.extensions.loadExtension(extensionDir)
 
 	console.log('Vue Devtools extension is installed')
 }


### PR DESCRIPTION
### ☑️ Resolves

* Follow-up: https://github.com/nextcloud/talk-desktop/pull/1272
* Fix deprecation:
  > Moved Session extension APIs to Session.extensions. [#45597](https://redirect.github.com/electron/electron/pull/45597)
