### PR TITLE
release: v1.1.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@
 
 # Changelog
 
+## v1.1.9 - 2025-05-12
+
+### Fixes
+
+- Regression breaking connection to Nextcloud server with non-empty base URL [#1263](https://github.com/nextcloud/talk-desktop/issues/1263)
+
+### Changes
+
+- Update translations
+- Update dependencies
+
 ## v1.1.8 - 2025-05-05
 
 ### Fixes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "talk-desktop",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "talk-desktop",
-      "version": "1.1.8",
+      "version": "1.1.9",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@mdi/svg": "^7.4.47",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "name": "talk-desktop",
   "productName": "Nextcloud Talk",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "bugs": {
     "url": "https://github.com/nextcloud/talk-desktop/issues",
     "create": "https://github.com/nextcloud/talk-desktop/issues/new/choose"


### PR DESCRIPTION
## v1.1.9 - 2025-05-12

### Fixes

- Regression breaking connection to Nextcloud server with non-empty base URL [#1263](https://github.com/nextcloud/talk-desktop/issues/1263)

### Changes

- Update translations
- Update dependencies