### PR TITLE
release: v1.2.0-beta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@
 
 # Changelog
 
+## v1.2.0-beta - 2025-05-12
+
+### Changes
+
+- Built-in Talk in binaries is updated to v21.1.0-rc.1 in the beta release channel [#1286](https://github.com/nextcloud/talk-desktop/pull/1286)
+
 ## v1.1.9 - 2025-05-12
 
 ### Fixes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "talk-desktop",
-  "version": "1.1.9",
+  "version": "1.2.0-beta",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "talk-desktop",
-      "version": "1.1.9",
+      "version": "1.2.0-beta",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@mdi/svg": "^7.4.47",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "name": "talk-desktop",
   "productName": "Nextcloud Talk",
-  "version": "1.1.9",
+  "version": "1.2.0-beta",
   "bugs": {
     "url": "https://github.com/nextcloud/talk-desktop/issues",
     "create": "https://github.com/nextcloud/talk-desktop/issues/new/choose"


### PR DESCRIPTION
## v1.2.0-beta - 2025-05-12

### Changes

- Built-in Talk in binaries is updated to v21.1.0-rc.1 in the beta release channel [#1286](https://github.com/nextcloud/talk-desktop/pull/1286)