### PR TITLE
build: update built-in Talk versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   },
   "talk": {
     "stable": "v21.0.4",
-    "beta": "v21.1.0-rc.1",
+    "beta": "v21.1.0-rc.2",
     "dev": "main"
   },
   "dependencies": {


### PR DESCRIPTION
## Update Built-in Talk Version

Stable:
- Current: v21.0.4
- Latest: v21.0.4

Beta:
- Current: v21.1.0-rc.1
- Latest: v21.1.0-rc.2

Updating beta from v21.1.0-rc.1 to v21.1.0-rc.2