### PR TITLE
fix(app): always re-fetch capabilities and user data on launch

### DIFF
--- a/src/app/appData.service.js
+++ b/src/app/appData.service.js
@@ -33,18 +33,12 @@ export async function refetchAppData(appData, persist = false) {
 }
 
 /**
- * If talk hash is dirty, re-fetch capabilities and userMetadata and update appData
+ * Re-fetch capabilities and userMetadata with retry and update appData
  *
  * @param {import('./AppData.js').appData} appData appData
  * @return {Promise<void>}
- * @throws {Error}
  */
-export async function refetchAppDataIfDirty(appData) {
-	// Re-fetch on dirty Talk hash and any desktop client upgrade
-	if (!appData.talkHashDirty && packageJson.version === appData.version.desktop) {
-		return
-	}
-
+export async function refetchAppDataWithRetry(appData) {
 	await new Promise((resolve) => {
 		/**
 		 * Try to re-fetch appData

--- a/src/welcome/welcome.js
+++ b/src/welcome/welcome.js
@@ -4,7 +4,7 @@
  */
 
 import { appData } from '../app/AppData.js'
-import { refetchAppDataIfDirty } from '../app/appData.service.js'
+import { refetchAppDataWithRetry } from '../app/appData.service.js'
 import { initGlobals } from '../shared/globals/globals.js'
 import { applyAxiosInterceptors } from '../shared/setupWebPage.js'
 
@@ -31,7 +31,7 @@ applyAxiosInterceptors()
 
 if (appData.credentials) {
 	await window.TALK_DESKTOP.enableWebRequestInterceptor(appData.serverUrl, { credentials: appData.credentials })
-	await refetchAppDataIfDirty(appData)
+	await refetchAppDataWithRetry(appData)
 }
 
 window.TALK_DESKTOP.sendAppData(appData.toJSON())


### PR DESCRIPTION
### ☑️ Resolves

- Fix: https://github.com/nextcloud/talk-desktop/issues/1167
- Always re-fetch capabilities and user metadata on application launch
- Before it was only refetched on dirty hash and talk desktop update

