### PR TITLE
build: update built-in Talk versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   },
   "talk": {
     "stable": "v21.0.4",
-    "beta": "v21.1.0-rc.2",
+    "beta": "v21.1.0-rc.4",
     "dev": "main"
   },
   "dependencies": {


### PR DESCRIPTION
## Update Built-in Talk Version

Stable:
- Current: v21.0.4
- Latest: v20.1.7

Beta:
- Current: v21.1.0-rc.2
- Latest: v21.1.0-rc.4

Updating stable from v21.0.4 to v20.1.7
Updating beta from v21.1.0-rc.2 to v21.1.0-rc.4