### PR TITLE
release: v.1.2.2 beta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@
 
 # Changelog
 
+## v1.2.2-beta - 2025-05-30
+
+### Added
+
+- Online/Away status update on system level activity change and locked screen [#1222](https://github.com/nextcloud/talk-desktop/pull/1222)
+
+### Fixes
+
+- Untrusted certificate support on all platforms [#1308](https://github.com/nextcloud/talk-desktop/pull/1308)
+- Some settings and user data are only updated after re-login [#1312](https://github.com/nextcloud/talk-desktop/pull/1312)
+
+### Changes
+
+- Built-in Talk in binaries is updated to v21.1.0-rc.4 in the beta release channel [#1316](https://github.com/nextcloud/talk-desktop/pull/1316)
+
 ## v1.2.1-beta - 2025-05-16
 
 ### Fixes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "talk-desktop",
-  "version": "1.2.1-beta",
+  "version": "1.2.2-beta",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "talk-desktop",
-      "version": "1.2.1-beta",
+      "version": "1.2.2-beta",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@mdi/svg": "^7.4.47",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "name": "talk-desktop",
   "productName": "Nextcloud Talk",
-  "version": "1.2.1-beta",
+  "version": "1.2.2-beta",
   "bugs": {
     "url": "https://github.com/nextcloud/talk-desktop/issues",
     "create": "https://github.com/nextcloud/talk-desktop/issues/new/choose"


### PR DESCRIPTION
## v1.2.2-beta - 2025-05-30

### Added

- Online/Away status update on system level activity change and locked screen [#1222](https://github.com/nextcloud/talk-desktop/pull/1222)

### Fixes

- Untrusted certificate support on all platforms [#1308](https://github.com/nextcloud/talk-desktop/pull/1308)
- Some settings and user data are only updated after re-login [#1312](https://github.com/nextcloud/talk-desktop/pull/1312)

### Changes

- Built-in Talk in binaries is updated to v21.1.0-rc.4 in the beta release channel [#1316](https://github.com/nextcloud/talk-desktop/pull/1316)