### PR TITLE
feat: add simple taskbar badge counter

### DIFF
--- a/forge.config.js
+++ b/forge.config.js
@@ -349,6 +349,8 @@ module.exports = {
 					'--share=network',
 					// System notifications with libnotify
 					'--talk-name=org.freedesktop.Notifications',
+					// Ubuntu integration (dock badge counter - LauncherEntry)
+					'--talk-name=com.canonical.Unity',
 
 					/**
 					 * Additional args

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "private": true,
   "name": "talk-desktop",
   "productName": "Nextcloud Talk",
+  "desktopName": "com.nextcloud.talk.desktop",
   "version": "1.2.2-beta",
   "bugs": {
     "url": "https://github.com/nextcloud/talk-desktop/issues",

--- a/src/main.js
+++ b/src/main.js
@@ -318,6 +318,7 @@ app.whenReady().then(async () => {
 		if (createMainWindow === createTalkWindow) {
 			appData.reset()
 			await mainWindow.webContents.session.clearStorageData()
+			app.setBadgeCount(0)
 			const authenticationWindow = createAuthenticationWindow()
 			createMainWindow = createAuthenticationWindow
 			authenticationWindow.once('ready-to-show', () => authenticationWindow.show())

--- a/src/talk/renderer/TalkWrapper/TalkWrapper.vue
+++ b/src/talk/renderer/TalkWrapper/TalkWrapper.vue
@@ -9,6 +9,7 @@ import { appData } from '../../../app/AppData.js'
 import { subscribeBroadcast } from '../../../shared/broadcast.service.ts'
 import { registerTalkDesktopSettingsSection } from '../Settings/index.ts'
 import { onTalkHashDirty, onTalkHashUpdate, openConversation, setTalkHash } from './talk.service.ts'
+import { useBadgeCountIntegration } from './useBadgeCountIntegration.ts'
 
 const emit = defineEmits<{
 	(event: 'ready'): void
@@ -21,6 +22,7 @@ onMounted(async () => {
 	// Additional integrations
 	registerTalkDesktopSettingsSection()
 	subscribeBroadcast('talk:conversation:open', ({ token, directCall }) => openConversation(token, { directCall }))
+	useBadgeCountIntegration()
 
 	// If there is a talkHash - set it initially
 	if (appData.talkHash) {

--- a/src/talk/renderer/TalkWrapper/useBadgeCountIntegration.ts
+++ b/src/talk/renderer/TalkWrapper/useBadgeCountIntegration.ts
@@ -1,0 +1,57 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { ref, watchEffect } from 'vue'
+
+/**
+ * Set badge counter according to Talk unread counts
+ */
+export function useBadgeCountIntegration() {
+	const count = ref(0)
+
+	window.OCA.Talk.instance.$store.watch(countUnreadConversations, (newValue: number) => {
+		count.value = newValue
+	}, { immediate: true })
+
+	watchEffect(() => {
+		window.TALK_DESKTOP.setBadgeCount(count.value)
+	})
+}
+
+/**
+ * Count conversations with unread notifications
+ * HOTFIX: provide Talk API instead
+ */
+function countUnreadConversations() {
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	return window.OCA.Talk.instance.$store.getters.conversationsList.reduce((count: number, conversation: any) => {
+		// Filter out archived conversations
+		if (conversation.isArchived) {
+			return count
+		}
+
+		// Muted with "Never notify"
+		if (conversation.notificationLevel === 3) {
+			return count
+		}
+
+		// ONE_TO_ONE || ONE_TO_ONE_FORMER
+		if ((conversation.type === 1 || conversation.type === 5) && conversation.unreadMessages) {
+			return count + 1
+		}
+
+		// Any other group conversation
+		if (
+			// Always notify && any unread message
+			(conversation.notificationLevel === 1 && conversation.unreadMessages)
+			// Mentioned
+			|| conversation.unreadMention
+		) {
+			return count + 1
+		}
+
+		return count
+	}, 0)
+}

--- a/src/talk/renderer/TitleBar/components/DevMenu.vue
+++ b/src/talk/renderer/TitleBar/components/DevMenu.vue
@@ -34,7 +34,6 @@ async function triggerScreenSharing() {
 }
 
 async function triggerNotification() {
-	window.TALK_DESKTOP.setBadgeCount()
 	window.TALK_DESKTOP.flashAppIcon(true)
 
 	const n = new Notification('Notification title', {

--- a/src/talk/renderer/notifications/notifications.store.js
+++ b/src/talk/renderer/notifications/notifications.store.js
@@ -94,7 +94,6 @@ export function createNotificationStore() {
 		if (notifications.length > _oldcount) {
 			_oldcount = notifications.length
 			if (state.backgroundFetching && document.hidden) {
-				window.TALK_DESKTOP.setBadgeCount()
 				window.TALK_DESKTOP.flashAppIcon(true)
 				// If we didn't already highlight, store the title so we can restore on tab-view
 				if (!document.title.startsWith('* ')) {
@@ -110,7 +109,6 @@ export function createNotificationStore() {
 	 * the Talk might have altered it.
 	 */
 	function _restoreTitle() {
-		window.TALK_DESKTOP.setBadgeCount(0)
 		window.TALK_DESKTOP.flashAppIcon(false)
 		if (document.title.startsWith('* ')) {
 			document.title = document.title.substring(2)


### PR DESCRIPTION
### ☑️ Resolves

- Fix: https://github.com/nextcloud/talk-desktop/issues/1020
- Fix: https://github.com/nextcloud/talk-desktop/issues/85
- Fix (but only on Ubuntu): https://github.com/nextcloud/talk-desktop/issues/976

- Only Taskbar icon for now
  - No system tray icon badge
- Supports:
  - Windows
  - macOS
  - Ubuntu (and some other distributions with Unity compatible extensions for dock icon badges)
- `talk:unread:updated` event is not used
  - It doesn't check notification levels
  - It doesn't count conversation types
  - 💩 dirty hotfix: manually watch the store and calc
- No settings until there are mo options:
  - System tray icon
  - Different counts
  - Different styles

### 🖼️ Screenshots

OS | Example
---|---
Windows | ![image](https://github.com/user-attachments/assets/024ca6a0-ee0b-4d89-beaf-edca451290bf)
macOS | ![image](https://github.com/user-attachments/assets/f26a5b66-1225-4ce7-af41-eb7328544fd4)
Ubuntu | ![image](https://github.com/user-attachments/assets/4e7c83e0-bc4f-4df3-ad4b-e9db00603c0a)

