### PR TITLE
fix: use outline icons

### DIFF
--- a/src/callbox/renderer/CallboxApp.vue
+++ b/src/callbox/renderer/CallboxApp.vue
@@ -9,8 +9,8 @@ import { useEventListener } from '@vueuse/core'
 import NcAvatar from '@nextcloud/vue/components/NcAvatar'
 import NcButton from '@nextcloud/vue/components/NcButton'
 import IconClose from 'vue-material-design-icons/Close.vue'
-import IconPhone from 'vue-material-design-icons/Phone.vue'
-import IconPhoneHangup from 'vue-material-design-icons/PhoneHangup.vue'
+import IconPhoneHangupOutline from 'vue-material-design-icons/PhoneHangupOutline.vue'
+import IconPhoneOutline from 'vue-material-design-icons/PhoneOutline.vue'
 import { postBroadcast } from '../../shared/broadcast.service.ts'
 import { waitCurrentUserHasJoinedCall } from './callbox.service.ts'
 import { playRingtone } from './callbox.utils.ts'
@@ -95,7 +95,7 @@ function dismiss() {
 				wide
 				@click="dismiss">
 				<template #icon>
-					<IconPhoneHangup :size="20" />
+					<IconPhoneHangupOutline :size="20" />
 				</template>
 				{{ t('talk_desktop', 'Dismiss') }}
 			</NcButton>
@@ -105,7 +105,7 @@ function dismiss() {
 				wide
 				@click="join">
 				<template #icon>
-					<IconPhone :size="20" />
+					<IconPhoneOutline :size="20" />
 				</template>
 				{{ t('talk_desktop', 'Join call') }}
 			</NcButton>

--- a/src/talk/renderer/TitleBar/components/MainMenu.vue
+++ b/src/talk/renderer/TitleBar/components/MainMenu.vue
@@ -13,8 +13,8 @@ import NcActionButton from '@nextcloud/vue/components/NcActionButton'
 import NcActionLink from '@nextcloud/vue/components/NcActionLink'
 import NcActions from '@nextcloud/vue/components/NcActions'
 import NcActionSeparator from '@nextcloud/vue/components/NcActionSeparator'
-import IconBug from 'vue-material-design-icons/Bug.vue'
-import IconCog from 'vue-material-design-icons/Cog.vue'
+import IconBugOutline from 'vue-material-design-icons/BugOutline.vue'
+import IconCogOutline from 'vue-material-design-icons/CogOutline.vue'
 import IconInformationOutline from 'vue-material-design-icons/InformationOutline.vue'
 import IconMenu from 'vue-material-design-icons/Menu.vue'
 import IconReload from 'vue-material-design-icons/Reload.vue'
@@ -60,7 +60,7 @@ const openInWeb = () => window.open(generateUrl(getCurrentTalkRoutePath()), '_bl
 		</NcActionButton>
 		<NcActionLink v-if="!BUILD_CONFIG.isBranded" :href="packageInfo.bugs.create || packageInfo.bugs.url" target="_blank">
 			<template #icon>
-				<IconBug :size="20" />
+				<IconBugOutline :size="20" />
 			</template>
 			{{ t('talk_desktop', 'Report a bug') }}
 		</NcActionLink>
@@ -69,7 +69,7 @@ const openInWeb = () => window.open(generateUrl(getCurrentTalkRoutePath()), '_bl
 
 		<NcActionButton close-after-click @click="openSettings">
 			<template #icon>
-				<IconCog :size="20" />
+				<IconCogOutline :size="20" />
 			</template>
 			{{ t('talk_desktop', 'Settings') }}
 		</NcActionButton>

--- a/src/talk/renderer/TitleBar/components/UserMenu.vue
+++ b/src/talk/renderer/TitleBar/components/UserMenu.vue
@@ -18,7 +18,7 @@ import IconChevronLeft from 'vue-material-design-icons/ChevronLeft.vue'
 import IconChevronRight from 'vue-material-design-icons/ChevronRight.vue'
 import IconEmoticonOutline from 'vue-material-design-icons/EmoticonOutline.vue'
 import IconLogout from 'vue-material-design-icons/Logout.vue'
-import IconPencil from 'vue-material-design-icons/Pencil.vue'
+import IconPencilOutline from 'vue-material-design-icons/PencilOutline.vue'
 import IconPower from 'vue-material-design-icons/Power.vue'
 import UserStatusDialog from '../../UserStatus/UserStatusDialog.vue'
 import ThemeLogo from './ThemeLogo.vue'
@@ -163,7 +163,7 @@ function handleUserStatusChange(status: UserStatusStatusType) {
 								</template>
 								{{ userStatus.message || t('talk_desktop', 'Set custom status') }}
 								<template v-if="userStatus.message" #action-icon>
-									<IconPencil :size="20" />
+									<IconPencilOutline :size="20" />
 								</template>
 							</UiMenuItem>
 

--- a/src/upgrade/renderer/UpgradeApp.vue
+++ b/src/upgrade/renderer/UpgradeApp.vue
@@ -7,7 +7,7 @@
 import { t } from '@nextcloud/l10n'
 import { generateUrl } from '@nextcloud/router'
 import NcButton from '@nextcloud/vue/components/NcButton'
-import IconCloudDownload from 'vue-material-design-icons/CloudDownload.vue'
+import IconCloudDownloadOutline from 'vue-material-design-icons/CloudDownloadOutline.vue'
 import IconWeb from 'vue-material-design-icons/Web.vue'
 
 const packageInfo = window.TALK_DESKTOP.packageInfo
@@ -32,7 +32,7 @@ const browserLink = generateUrl('/apps/spreed')
 				variant="primary"
 				wide>
 				<template #icon>
-					<IconCloudDownload :size="20" />
+					<IconCloudDownloadOutline :size="20" />
 				</template>
 				{{ t('talk_desktop', 'Update Talk Desktop') }} ↗
 			</NcButton>


### PR DESCRIPTION
### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![image](https://github.com/user-attachments/assets/b69b42f7-e0fd-4f78-a46e-bc9b61c5aa13) | ![image](https://github.com/user-attachments/assets/f10936f0-e022-43d9-904e-3946c7e406d1)
![image](https://github.com/user-attachments/assets/85c1e3a1-9e07-4ecb-9130-42cfc4f06ab8) | ![image](https://github.com/user-attachments/assets/98a957c2-f8ef-4c99-98f3-de3d279f7c7c)
![image](https://github.com/user-attachments/assets/df25b830-3c26-48b9-994d-44e6b63ec8ec) | ![image](https://github.com/user-attachments/assets/3251a4c9-938e-4161-89e3-ba2db6db2e7c)
![image](https://github.com/user-attachments/assets/deae3e2b-c5bc-4eb4-92bb-61e8cc8fbf03) | ![image](https://github.com/user-attachments/assets/457cda29-cc2e-4265-8734-9d769f6ffc75)
