### PR TITLE
[stable1] build: update built-in Talk versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,8 +42,8 @@
     "typecheck": "vue-tsc --noEmit"
   },
   "talk": {
-    "stable": "v21.1.0",
-    "beta": "v21.1.0",
+    "stable": "v21.1.1",
+    "beta": "v21.1.1",
     "dev": "main"
   },
   "dependencies": {


### PR DESCRIPTION
## Update Built-in Talk Version

Stable:
- Current: v21.1.0
- Latest: v21.1.1

Beta:
- Current: v21.1.0
- Latest: v21.1.1

Updating stable from v21.1.0 to v21.1.1
Updating beta from v21.1.0 to v21.1.1