### PR TITLE
release: v1.2.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "talk-desktop",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "talk-desktop",
-      "version": "1.2.3",
+      "version": "1.2.4",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@mdi/svg": "^7.4.47",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "talk-desktop",
   "productName": "Nextcloud Talk",
   "desktopName": "com.nextcloud.talk.desktop",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "bugs": {
     "url": "https://github.com/nextcloud/talk-desktop/issues",
     "create": "https://github.com/nextcloud/talk-desktop/issues/new/choose"


### PR DESCRIPTION
## v1.2.4 - 2025-07-11

### Added

- Quit button in the user menu [#1356](https://github.com/nextcloud/talk-desktop/pull/1356)

### Fixes

- Re-opening application while running in background is broken on Linux in Flatpak [#1358](https://github.com/nextcloud/talk-desktop/pull/1358)
 
### Changes

- Built-in Talk in binaries is updated to v21.1.1 in both beta and stable release channels [#1365](https://github.com/nextcloud/talk-desktop/pull/1365)