### PR TITLE
fix(app): window title is untranslated and may duplicate on reload

### DIFF
--- a/src/authentication/authentication.window.js
+++ b/src/authentication/authentication.window.js
@@ -16,7 +16,7 @@ const { getBrowserWindowIcon } = require('../shared/icons.utils.js')
 function createAuthenticationWindow() {
 	const zoomFactor = getAppConfig('zoomFactor')
 	const window = new BrowserWindow({
-		title: buildTitle('Authentication'),
+		title: buildTitle(),
 		...getScaledWindowSize({
 			width: 450,
 			height: 500,

--- a/src/authentication/login.window.js
+++ b/src/authentication/login.window.js
@@ -8,7 +8,7 @@ const os = require('node:os')
 const { getAppConfig } = require('../app/AppConfig.ts')
 const { applyContextMenu } = require('../app/applyContextMenu.js')
 const { osTitle } = require('../app/system.utils.ts')
-const { getScaledWindowMinSize, getScaledWindowSize, applyZoom, buildTitle } = require('../app/utils.ts')
+const { getScaledWindowMinSize, getScaledWindowSize, applyZoom } = require('../app/utils.ts')
 const { getBrowserWindowIcon } = require('../shared/icons.utils.js')
 const { parseLoginRedirectUrl } = require('./login.service.js')
 
@@ -25,12 +25,10 @@ function openLoginWebView(parentWindow, serverUrl) {
 	return new Promise((resolve) => {
 		const WIDTH = 750
 		const HEIGHT = 750
-		const TITLE = buildTitle('Login')
 
 		const zoomFactor = getAppConfig('zoomFactor')
 
 		const window = new BrowserWindow({
-			title: TITLE,
 			...getScaledWindowSize({
 				width: WIDTH,
 				height: HEIGHT,
@@ -66,12 +64,11 @@ function openLoginWebView(parentWindow, serverUrl) {
 		})
 
 		window.webContents.on('did-start-loading', () => {
-			window.setTitle(`${TITLE} [Loading...]`)
+			window.setTitle('[Loading...]')
 			window.setProgressBar(2, { mode: 'indeterminate' })
 		})
 
 		window.webContents.on('did-stop-loading', () => {
-			window.setTitle(TITLE)
 			window.setProgressBar(-1)
 		})
 

--- a/src/authentication/renderer/authentication.main.js
+++ b/src/authentication/renderer/authentication.main.js
@@ -3,12 +3,15 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+import { t } from '@nextcloud/l10n'
 import { createApp } from 'vue'
 import { setupWebPage } from '../../shared/setupWebPage.js'
 
 import '../../shared/assets/global.styles.css'
 
-await setupWebPage()
+await setupWebPage({
+	title: () => t('talk_desktop', 'Authentication'),
+})
 
 const { default: AuthenticationApp } = await import('./AuthenticationApp.vue')
 

--- a/src/certificate/certificate.window.ts
+++ b/src/certificate/certificate.window.ts
@@ -19,9 +19,8 @@ import { getBrowserWindowIcon } from '../shared/icons.utils.js'
  * @return Whether user accept the certificate
  */
 export function showCertificateTrustDialog(parentWindow: BrowserWindow, details: UntrustedCertificateDetails) {
-	const TITLE = buildTitle('Security warning')
 	const window = new BrowserWindow({
-		title: TITLE,
+		title: buildTitle(),
 		...getScaledWindowSize({
 			width: 600,
 			height: 600,

--- a/src/certificate/renderer/certificate.main.ts
+++ b/src/certificate/renderer/certificate.main.ts
@@ -3,12 +3,15 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+import { t } from '@nextcloud/l10n'
 import { createApp } from 'vue'
 import { setupWebPage } from '../../shared/setupWebPage.js'
 
 import '../../shared/assets/global.styles.css'
 
-await setupWebPage()
+await setupWebPage({
+	title: () => t('talk_desktop', 'Security warning'),
+})
 
 const { default: CertificateApp } = await import('./CertificateApp.vue')
 

--- a/src/help/help.window.js
+++ b/src/help/help.window.js
@@ -15,9 +15,8 @@ const { getBrowserWindowIcon } = require('../shared/icons.utils.js')
  * @return {import('electron').BrowserWindow}
  */
 function createHelpWindow(parentWindow) {
-	const TITLE = buildTitle('About')
 	const window = new BrowserWindow({
-		title: TITLE,
+		title: buildTitle(),
 		...getScaledWindowSize({
 			width: 1024,
 			height: 720,

--- a/src/help/renderer/help.app.js
+++ b/src/help/renderer/help.app.js
@@ -3,13 +3,16 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+import { t } from '@nextcloud/l10n'
 import { createApp } from 'vue'
 import { setupWebPage } from '../../shared/setupWebPage.js'
 
 import '../../shared/assets/global.styles.css'
 import './help.styles.css'
 
-await setupWebPage()
+await setupWebPage({
+	title: () => t('talk_desktop', 'About'),
+})
 
 const { default: HelpApp } = await import('./HelpApp.vue')
 

--- a/src/main.js
+++ b/src/main.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-const { app, ipcMain, desktopCapturer, systemPreferences, shell, BrowserWindow, session } = require('electron')
+const { app, ipcMain, desktopCapturer, systemPreferences, shell, session } = require('electron')
 const { spawn } = require('node:child_process')
 const fs = require('node:fs')
 const path = require('node:path')
@@ -18,6 +18,7 @@ const { setupReleaseNotificationScheduler } = require('./app/githubReleaseNotifi
 const { initLaunchAtStartupListener } = require('./app/launchAtStartup.config.ts')
 const { systemInfo, isLinux, isMac, isWindows, isSameExecution } = require('./app/system.utils.ts')
 const { applyTheme } = require('./app/theme.config.ts')
+const { buildTitle } = require('./app/utils.ts')
 const { enableWebRequestInterceptor, disableWebRequestInterceptor } = require('./app/webRequestInterceptor.js')
 const { createAuthenticationWindow } = require('./authentication/authentication.window.js')
 const { openLoginWebView } = require('./authentication/login.window.js')
@@ -88,7 +89,7 @@ if (process.env.NODE_ENV === 'production' && !BUILD_CONFIG.isBranded) {
 
 ipcMain.on('app:quit', () => app.quit())
 ipcMain.handle('app:getSystemInfo', () => systemInfo)
-ipcMain.handle('app:getTitle', (event) => BrowserWindow.fromWebContents(event.sender).title || app.getName())
+ipcMain.handle('app:buildTitle', (event, title) => buildTitle(title))
 ipcMain.handle('app:getSystemL10n', () => ({
 	locale: app.getLocale().replace('-', '_') ?? 'en',
 	// Note: Linux may have C (POSIX) locale, which results in an empty preferred languages list

--- a/src/preload.js
+++ b/src/preload.js
@@ -27,11 +27,12 @@ const TALK_DESKTOP = {
 	 */
 	packageInfo,
 	/**
-	 * Get the current window title
+	 * Build a title for the window from base (product name) and release channel
 	 *
-	 * @return {Promise<string>}
+	 * @param {string} [title] - Window title if any
+	 * @return {Promise<string>} - Full window title with base and release channel
 	 */
-	getTitle: () => ipcRenderer.invoke('app:getTitle'),
+	buildTitle: (title) => ipcRenderer.invoke('app:buildTitle', title),
 	/**
 	 * Quit the application
 	 */

--- a/src/shared/setupWebPage.js
+++ b/src/shared/setupWebPage.js
@@ -213,18 +213,21 @@ function applyDownloadLinkHandler() {
 
 /**
  * Make all required initial setup for the web page for authorized user: server-rendered data, globals and ect.
+ *
+ * @param {() => string} [title] - Getter for a custom title
  */
-export async function setupWebPage() {
-	document.title = await window.TALK_DESKTOP.getTitle()
+export async function setupWebPage({
+	title,
+} = {}) {
 	appData.fromJSON(await window.TALK_DESKTOP.getAppData())
 	await initAppConfig()
+	await applyL10n()
+	document.title = await window.TALK_DESKTOP.buildTitle(title?.())
 	applyInitialState()
 	initGlobals()
-	window.systemInfo = await window.TALK_DESKTOP.getSystemInfo()
 	applyUserData()
 	applyHeaderHeight()
 	applyAxiosInterceptors()
-	await applyL10n()
 	applyDownloadLinkHandler()
 
 	// Re-fetch appData if dirty
@@ -239,4 +242,6 @@ export async function setupWebPage() {
 		// Re-apply initial state after re-fetch
 		applyInitialState()
 	}
+
+	window.systemInfo = await window.TALK_DESKTOP.getSystemInfo()
 }

--- a/src/upgrade/renderer/upgrade.main.ts
+++ b/src/upgrade/renderer/upgrade.main.ts
@@ -3,12 +3,15 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+import { t } from '@nextcloud/l10n'
 import { createApp } from 'vue'
 import { setupWebPage } from '../../shared/setupWebPage.js'
 
 import '../../shared/assets/global.styles.css'
 
-await setupWebPage()
+await setupWebPage({
+	title: () => t('talk_desktop', 'Upgrade required'),
+})
 
 const { default: UpgradeApp } = await import('./UpgradeApp.vue')
 

--- a/src/upgrade/upgrade.window.ts
+++ b/src/upgrade/upgrade.window.ts
@@ -13,9 +13,8 @@ import { getBrowserWindowIcon } from '../shared/icons.utils.js'
  * Create the upgrade window
  */
 export function createUpgradeWindow() {
-	const TITLE = buildTitle('Upgrade required')
 	const window = new BrowserWindow({
-		title: TITLE,
+		title: buildTitle(),
 		...getScaledWindowSize({
 			width: 350,
 			height: 300,


### PR DESCRIPTION
### ☑️ Resolves

- Fix: https://github.com/nextcloud/talk-desktop/issues/1373

Electron keeps the window title on reload instead of using the initial title from Window options.
As a result, using the current window title as the base title on reload results in a duplicated title on reload.

There is no way to get the original title from window options. Instead - move the title setting to the renderer side.

It also allows translating the title.
