### PR TITLE
fix(certificate): warning is not full-height in vue 3 container

### DIFF
--- a/src/certificate/renderer/CertificateApp.vue
+++ b/src/certificate/renderer/CertificateApp.vue
@@ -100,7 +100,7 @@ const isAdvanced = ref(false)
 	flex-direction: column;
 	align-items: stretch;
 	gap: calc(4 * var(--default-grid-baseline));
-	height: 100%;
+	height: 100vh;
 	padding: calc(4 * var(--default-grid-baseline));
 	background: var(--color-main-background);
 }


### PR DESCRIPTION
### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
<img width="586" height="593" alt="image" src="https://github.com/user-attachments/assets/9a8a2bba-a2bc-4d78-8a60-aeb8f12aa9d9" /> | <img width="586" height="593" alt="image" src="https://github.com/user-attachments/assets/4452623c-37c2-4001-be9c-e9a208d7c287" />
