### PR TITLE
fix: get app version for initial state from app data

### DIFF
--- a/src/shared/setupWebPage.js
+++ b/src/shared/setupWebPage.js
@@ -168,8 +168,8 @@ function getInitialStateFromCapabilities(capabilities, userMetadata) {
 		core: {
 			capabilities,
 			config: {
-				version: '25.0.2.3', // TODO: Find in Capabilities
-				versionstring: '25.0.2', // TODO: Find in Capabilities
+				version: appData.version.nextcloud?.string ?? '25.0.2.3',
+				versionstring: appData.version.nextcloud?.string ?? '25.0.2',
 				modRewriteWorking: false, // Forced to false. Is it used?
 			},
 		},


### PR DESCRIPTION
### ☑️ Resolves

- Found from checking https://github.com/nextcloud/spreed/pull/15533
- appData has the required information, so should be fine to put it into initial state

### 🖼️ Screenshots

<img width="696" height="61" alt="image" src="https://github.com/user-attachments/assets/346a6cef-594f-4b01-af11-e80317e33a40" />
