### PR TITLE
fix(user-status): heartbeat is not sent when (in)activity doesn't change

### DIFF
--- a/src/talk/renderer/UserStatus/useHeartbeat.ts
+++ b/src/talk/renderer/UserStatus/useHeartbeat.ts
@@ -54,7 +54,7 @@ export const useHeartbeat = createSharedComposable(() => {
 		}
 		await heartbeat()
 		// TODO: fix when main and renderer process have separate tsconfig
-		heartbeatTimeout = setTimeout(heartbeat, HEARTBEAT_INTERVAL) as unknown as number
+		heartbeatTimeout = setTimeout(restartHeartbeat, HEARTBEAT_INTERVAL) as unknown as number
 	}
 
 	// Restart heartbeat to immediately notify server on state change

--- a/src/talk/renderer/UserStatus/useHeartbeat.ts
+++ b/src/talk/renderer/UserStatus/useHeartbeat.ts
@@ -37,7 +37,7 @@ export const useHeartbeat = createSharedComposable(() => {
 	/**
 	 * Send a heartbeat
 	 */
-	async function heartbeat() {
+	async function sendHeartbeat() {
 		try {
 			await userStatusStore.updateUserStatusWithHeartbeat(isAway.value)
 		} catch (error) {
@@ -46,13 +46,13 @@ export const useHeartbeat = createSharedComposable(() => {
 	}
 
 	/**
-	 * Start heartbeat interval
+	 * (Re)start heartbeat interval
 	 */
 	async function restartHeartbeat() {
 		if (heartbeatTimeout) {
 			clearTimeout(heartbeatTimeout)
 		}
-		await heartbeat()
+		await sendHeartbeat()
 		// TODO: fix when main and renderer process have separate tsconfig
 		heartbeatTimeout = setTimeout(restartHeartbeat, HEARTBEAT_INTERVAL) as unknown as number
 	}


### PR DESCRIPTION
### ☑️ Resolves

- Fix: https://github.com/nextcloud/talk-desktop/issues/1402
- Instead of recursively schedule heartbeating, only a single heartbeat sending was scheduled
- Rename a function to clarify it