### PR TITLE
chore: help redirect spreed issues to another repo

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -19,6 +19,11 @@ labels: 0. Needs triage, bug
 2.
 3.
 
+<!---
+Have you tried to reproduce the issue in Talk web-page as well?
+If that is the case, open an issue in app repository instead: https://github.com/nextcloud/spreed/issues/new/choose
+-->
+
 ### Expected behaviour
 Tell us what should happen
 


### PR DESCRIPTION
### ☑️ Resolves

Push users to check issue in web as well and open issue in correct repo

### 🖼️ Screenshots

```md
<!--
Have you tried to reproduce the issue in Talk web-page as well?
If that is the case, open an issue in app repository instead: https://github.com/nextcloud/spreed/issues/new/choose
-->
```
