### PR TITLE
feat(user_status): add 'Busy' status support

### DIFF
--- a/src/talk/renderer/TitleBar/components/UserMenu.vue
+++ b/src/talk/renderer/TitleBar/components/UserMenu.vue
@@ -84,6 +84,7 @@ function handleUserStatusChange(status: UserStatusStatusType) {
 						:preloaded-user-status="userStatus"
 						:display-name="user['display-name']"
 						:size="32"
+						disable-menu
 						disable-tooltip
 						v-bind="attrs"
 						tabindex="0"

--- a/src/talk/renderer/UserStatus/userStatus.utils.ts
+++ b/src/talk/renderer/UserStatus/userStatus.utils.ts
@@ -6,17 +6,20 @@
 import type { ClearAtPredefinedConfig, PredefinedUserStatus, UserStatus, UserStatusStatusType } from './userStatus.types.ts'
 
 import { getFirstDay, t } from '@nextcloud/l10n'
+import { appData } from '../../../app/AppData.js'
 import { formatDuration, formatDurationFromNow } from '../../../shared/datetime.utils.ts'
 
 /**
  * List of user status types that user can set
  */
-export const availableUserStatusStatusTypes: UserStatusStatusType[] = ['online', 'away', 'dnd', 'invisible']
+export const availableUserStatusStatusTypes: UserStatusStatusType[] = (appData.capabilities as unknown)?.user_status?.supports_busy
+	? ['online', 'away', 'busy', 'dnd', 'invisible']
+	: ['online', 'away', 'dnd', 'invisible']
 
 export const userStatusTranslations: Record<UserStatusStatusType, string> = {
 	online: t('talk_desktop', 'Online'),
 	away: t('talk_desktop', 'Away'),
-	busy: t('talk_desktop', 'Away'),
+	busy: t('talk_desktop', 'Busy'),
 	dnd: t('talk_desktop', 'Do not disturb'),
 	invisible: t('talk_desktop', 'Invisible'),
 	offline: t('talk_desktop', 'Offline'),


### PR DESCRIPTION
### ☑️ Resolves

I'm lasy, it's the same screenshot

### 🖼️ Screenshots

<img width="93" height="151" alt="image" src="https://github.com/user-attachments/assets/7133b394-5093-4232-8dc6-e2c891030e8f" />
