### PR TITLE
fix(build): msi update installs as a new app

### DIFF
--- a/build/BuildConfig.types.ts
+++ b/build/BuildConfig.types.ts
@@ -148,6 +148,13 @@ export type BuildConfigInferred = {
 	winSquirrelAppId: string
 
 	/**
+	 * WiX MSI's UPGRADE_CODE, GUID.
+	 * Must persist between installations (versions) but be different for different branded versions.
+	 * See: https://docs.firegiant.com/wix3/xsd/wix/product/ (Attributes | UpgradeCode)
+	 */
+	winUpgradeCode: string
+
+	/**
 	 * Copyright string.
 	 * Used in metadata. Cannot be empty.
 	 * Copyright (c) {year} Nextcloud GmbH

--- a/build/UUIDv5.js
+++ b/build/UUIDv5.js
@@ -1,0 +1,43 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+const crypto = require('node:crypto')
+
+const DNS_NAMESPACE = '6ba7b810-9dad-11d1-80b4-00c04fd430c8'
+
+/**
+ * Generate UUID v5
+ *
+ * @param {string} name - Input string
+ * @param {string} namespace - Namespace UUID (e.g., '6ba7b810-9dad-11d1-80b4-00c04fd430c8')
+ * @return {string} UUIDv5
+ */
+function UUIDv5(name, namespace = DNS_NAMESPACE) {
+	const namespaceBytes = Buffer.from(namespace.replace(/-/g, ''), 'hex')
+
+	const hash = crypto.createHash('sha1')
+	hash.update(namespaceBytes)
+	hash.update(name, 'utf8')
+
+	const uuid = Array.from(hash.digest().slice(0, 16))
+
+	// Version byte (bits 4-7) - must be 5 (0b0101)
+	uuid[6] = (uuid[6] & 0b00001111) | 0b01010000
+	// Variant byte (bits 6-7) - must be 2 (0b10) for RFC 4122 compliance
+	uuid[8] = (uuid[8] & 0b00111111) | 0b10000000
+
+	const hex = uuid.map((byte) => byte.toString(16).padStart(2, '0')).join('')
+	return [
+		hex.slice(0, 8),
+		hex.slice(8, 12),
+		hex.slice(12, 16),
+		hex.slice(16, 20),
+		hex.slice(20, 32),
+	].join('-')
+}
+
+module.exports = {
+	UUIDv5,
+}

--- a/build/resolveBuildConfig.js
+++ b/build/resolveBuildConfig.js
@@ -6,6 +6,10 @@
 const path = require('node:path')
 const fs = require('node:fs')
 const defaultConfig = require('./config.json')
+const { UUIDv5 } = require('./UUIDv5.js')
+
+// DO NOT CHANGE
+const TALK_DESKTOP_UUID = '007a0d7d-9595-41d2-b5aa-740a5a63e38a'
 
 /**
  * Resolve the build configuration
@@ -55,6 +59,7 @@ function resolveBuildConfig(customConfigPath = process.env.CUSTOM_CONFIG) {
 		copyright: 'Copyright (c) {year} Nextcloud GmbH'.replace('{year}', new Date().getFullYear()),
 		applicationNameSanitized,
 		winSquirrelAppId: applicationNameSanitized, // Special case for Squirrel.Windows
+		winUpgradeCode: UUIDv5(`${appIdHost}.talk`, TALK_DESKTOP_UUID),
 	}
 }
 

--- a/forge.config.js
+++ b/forge.config.js
@@ -232,6 +232,7 @@ module.exports = {
 			manufacturer: CONFIG.companyName,
 			shortName: CONFIG.applicationNameSanitized,
 			arch: 'x64', // electron-wix-msi defaults to x86
+			upgradeCode: CONFIG.winUpgradeCode,
 			// Pass the version explicitly
 			// otherwise MakerWix makes versions with prerelease tags invalid semantic version
 			// which breaks app launch via stub executable


### PR DESCRIPTION
### ☑️ Resolves

- Fix: https://github.com/nextcloud/talk-desktop/issues/1305
- Set a specific Upgrade_Code => installing a new version 
- Generate UUIDv6 so it stays the same for the same app id
  - Branded clients have new app id => new upgrade code
