### PR TITLE
fix: defer Vue app import until webpage setup is done

### DIFF
--- a/src/shared/globals/OC/dialogs.js
+++ b/src/shared/globals/OC/dialogs.js
@@ -7,7 +7,7 @@ import { createApp } from 'vue'
 
 let ocDialogsAdapter = null
 
-document.addEventListener('DOMContentLoaded', async () => {
+document.addEventListener('TalkWebPageSetupDone', async () => {
 	const { default: OcDialogsAdapter } = await import('./OcDialogsAdapter.vue')
 
 	const container = document.body.appendChild(document.createElement('div'))

--- a/src/shared/setupWebPage.js
+++ b/src/shared/setupWebPage.js
@@ -239,4 +239,7 @@ export async function setupWebPage() {
 	}
 
 	window.systemInfo = await window.TALK_DESKTOP.getSystemInfo()
+
+	// Notify that the webpage setup is finished
+	document.dispatchEvent(new CustomEvent('TalkWebPageSetupDone'))
 }

--- a/src/talk/renderer/screensharing/getDesktopMediaSource.ts
+++ b/src/talk/renderer/screensharing/getDesktopMediaSource.ts
@@ -4,7 +4,6 @@
  */
 
 import { createApp } from 'vue'
-import AppGetDesktopMediaSource from './AppGetDesktopMediaSource.vue'
 
 let appGetDesktopMediaSourceInstance: InstanceType<typeof AppGetDesktopMediaSource> | null = null
 
@@ -15,6 +14,7 @@ let appGetDesktopMediaSourceInstance: InstanceType<typeof AppGetDesktopMediaSour
  */
 export async function getDesktopMediaSource() {
 	if (!appGetDesktopMediaSourceInstance) {
+		const { default: AppGetDesktopMediaSource } = await import('./AppGetDesktopMediaSource.vue')
 		const container = document.body.appendChild(document.createElement('div'))
 		appGetDesktopMediaSourceInstance = createApp(AppGetDesktopMediaSource).mount(container) as InstanceType<typeof AppGetDesktopMediaSource>
 	}


### PR DESCRIPTION
### ☑️ Resolves

- Fix interface errors caused by early import

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
<img width="345" height="66" alt="image" src="https://github.com/user-attachments/assets/65daa0ed-d8ca-4301-a61c-eb5661557cbc" /> | <img width="422" height="67" alt="image" src="https://github.com/user-attachments/assets/1d8d770b-0dad-44d5-b223-9af2d3bbfc43" />

- [x] Checked stable1, no backport needed
