### PR TITLE
chore(ts): fix error in getDesktopMediaSource.ts

### DIFF
--- a/src/talk/renderer/screensharing/getDesktopMediaSource.ts
+++ b/src/talk/renderer/screensharing/getDesktopMediaSource.ts
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+import type AppGetDesktopMediaSource from './AppGetDesktopMediaSource.vue'
+
 import { createApp } from 'vue'
 
 let appGetDesktopMediaSourceInstance: InstanceType<typeof AppGetDesktopMediaSource> | null = null


### PR DESCRIPTION
The type wasn't defined and used in
```ts
let appGetDesktopMediaSourceInstance: InstanceType<typeof AppGetDesktopMediaSource> | null = null
```