### PR TITLE
build: update built-in Talk versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,8 +42,8 @@
     "typecheck": "vue-tsc --noEmit"
   },
   "talk": {
-    "stable": "v21.1.3",
-    "beta": "v21.1.3",
+    "stable": "v21.1.4",
+    "beta": "v21.1.4",
     "dev": "main"
   },
   "dependencies": {


### PR DESCRIPTION
## Update Built-in Talk Version

Stable:
- Current: v21.1.3
- Latest: v21.1.4

Beta:
- Current: v21.1.3
- Latest: v22.0.0-beta.2

Updating stable from v21.1.3 to v21.1.4