### PR TITLE
fix(talk): hotfix for <a href=#> links breaking navigation

### DIFF
--- a/src/talk/renderer/talk.main.ts
+++ b/src/talk/renderer/talk.main.ts
@@ -16,3 +16,12 @@ import 'regenerator-runtime' // TODO: Why isn't it added on bundling
 await setupWebPage()
 
 await createTalkDesktopApp()
+
+// HOTFIX: prevent invalid links <a href="#"> used in NcListItem as a button from breaking routing in Vue Router 4 with Hash History
+// TODO: fix on NcListItem side and use real buttons instead of <a href="#">
+document.addEventListener('click', (event) => {
+	const emptyAnchorLink = (event.target as HTMLElement).closest('a[href="#"]')
+	if (emptyAnchorLink) {
+		event.preventDefault()
+	}
+})


### PR DESCRIPTION
### ☑️ Resolves

- Fix clicking on a participant in the participant list or room selector breaks navigation
- Root source of the issue: using `<a href="#">` links for buttons in `NcListItem` and other components
- In Vue 2 + VueRouter 3 it was ignored, in Vue 3 + VueRouter 4 triggers navigation to invalid route
- Hotfix: prevent default on such links
  - Is dirty? Yez.
- Proper fix: rework `NcListItem` in nextcloud-vue, release, bump in Talk, release.
  - WIP

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![before](https://github.com/user-attachments/assets/c8c00eb2-f752-4cfd-9b89-3f88dcc1358a) | ![after](https://github.com/user-attachments/assets/f68c3b45-d1f8-44c0-aed4-530c0ba2e578)
