### PR TITLE
build: update built-in Talk versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,8 +42,8 @@
     "typecheck": "vue-tsc --noEmit"
   },
   "talk": {
-    "stable": "22.0.0-beta.1",
-    "beta": "22.0.0-beta.1",
+    "stable": "v22.0.0-rc.1",
+    "beta": "v22.0.0-rc.1",
     "dev": "main"
   },
   "dependencies": {


### PR DESCRIPTION
## Update Built-in Talk Version

Stable:
- Current: 22.0.0-beta.1
- Latest: v21.1.4

Beta:
- Current: 22.0.0-beta.1
- Latest: v22.0.0-rc.1

Updating stable from 22.0.0-beta.1 to v22.0.0-rc.1
Updating beta from 22.0.0-beta.1 to v22.0.0-rc.1