### PR TITLE
release: v2.0.0-beta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@
 
 # Changelog
 
+## v2.0.0-beta - 2025-09-04
+
+### Changes
+
+- Built-in Talk in binaries is updated to v22.0.0-rc.1 in the beta release channel [#1452](https://github.com/nextcloud/talk-desktop/pull/1452)
+- Built-in styles were updated to Nextcloud v32.0.0rc1 styles [#1451](https://github.com/nextcloud/talk-desktop/pull/1451)
+- Talk Desktop is migrated Vue 3 and can no longer use built-in Talk below v22 with Vue 2 [#680](https://github.com/nextcloud/talk-desktop/pull/680), [#1422](https://github.com/nextcloud/talk-desktop/pull/1422)
+
 ## v1.2.6 - 2025-09-02
 
 ### Fixes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "talk-desktop",
-  "version": "2.0.0-rc.0",
+  "version": "2.0.0-beta",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "talk-desktop",
-      "version": "2.0.0-rc.0",
+      "version": "2.0.0-beta",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@mdi/svg": "^7.4.47",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "talk-desktop",
   "productName": "Nextcloud Talk",
   "desktopName": "com.nextcloud.talk.desktop",
-  "version": "2.0.0-rc.0",
+  "version": "2.0.0-beta",
   "bugs": {
     "url": "https://github.com/nextcloud/talk-desktop/issues",
     "create": "https://github.com/nextcloud/talk-desktop/issues/new/choose"


### PR DESCRIPTION
## v2.0.0-beta - 2025-09-04

### Changes

- Built-in Talk in binaries is updated to v22.0.0-rc.1 in the beta release channel [#1452](https://github.com/nextcloud/talk-desktop/pull/1452)
- Built-in styles were updated to Nextcloud v32.0.0rc1 styles [#1451](https://github.com/nextcloud/talk-desktop/pull/1451)
- Talk Desktop is migrated Vue 3 and can no longer use built-in Talk below v22 with Vue 2 [#680](https://github.com/nextcloud/talk-desktop/pull/680), [#1422](https://github.com/nextcloud/talk-desktop/pull/1422)
