### PR TITLE
build: update built-in Talk versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,8 +42,8 @@
     "typecheck": "vue-tsc --noEmit"
   },
   "talk": {
-    "stable": "v22.0.0-rc.2",
-    "beta": "v22.0.0-rc.2",
+    "stable": "v22.0.0",
+    "beta": "v22.0.0",
     "dev": "main"
   },
   "dependencies": {


### PR DESCRIPTION
## Update Built-in Talk Version

Stable:
- Current: v22.0.0-rc.2
- Latest: v22.0.0

Beta:
- Current: v22.0.0-rc.2
- Latest: v22.0.0

Updating stable from v22.0.0-rc.2 to v22.0.0
Updating beta from v22.0.0-rc.2 to v22.0.0