### PR TITLE
chore: bump dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -54,7 +54,7 @@
         "node-loader": "^2.1.0",
         "regenerator-runtime": "^0.14.1",
         "typescript": "^5.9.2",
-        "vue-tsc": "^3.0.6",
+        "vue-tsc": "^3.0.8",
         "webpack": "^5.101.3",
         "webpack-merge": "^6.0.1",
         "worker-loader": "^3.0.8",
@@ -5903,9 +5903,9 @@
       "license": "MIT"
     },
     "node_modules/@vue/language-core": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-3.0.6.tgz",
-      "integrity": "sha512-e2RRzYWm+qGm8apUHW1wA5RQxzNhkqbbKdbKhiDUcmMrNAZGyM8aTiL3UrTqkaFI5s7wJRGGrp4u3jgusuBp2A==",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-3.0.8.tgz",
+      "integrity": "sha512-eYs6PF7bxoPYvek9qxceo1BCwFbJZYqJll+WaYC8o8ec60exqj+n+QRGGiJHSeUfYp0hDxARbMdxMq/fbPgU5g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6514,9 +6514,9 @@
       }
     },
     "node_modules/alien-signals": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/alien-signals/-/alien-signals-2.0.7.tgz",
-      "integrity": "sha512-wE7y3jmYeb0+h6mr5BOovuqhFv22O/MV9j5p0ndJsa7z1zJNPGQ4ph5pQk/kTTCWRC3xsA4SmtwmkzQO+7NCNg==",
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/alien-signals/-/alien-signals-2.0.8.tgz",
+      "integrity": "sha512-844G1VLkk0Pe2SJjY0J8vp8ADI73IM4KliNu2OGlYzWpO28NexEUvjHTcFjFX3VXoiUtwTbHxLNI9ImkcoBqzA==",
       "dev": true,
       "license": "MIT"
     },
@@ -18106,14 +18106,14 @@
       }
     },
     "node_modules/vue-tsc": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-3.0.6.tgz",
-      "integrity": "sha512-Tbs8Whd43R2e2nxez4WXPvvdjGbW24rOSgRhLOHXzWiT4pcP4G7KeWh0YCn18rF4bVwv7tggLLZ6MJnO6jXPBg==",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-3.0.8.tgz",
+      "integrity": "sha512-H9yg/m6ywykmWS+pIAEs65v2FrVm5uOA0a0dHkX6Sx8dNg1a1m4iudt/6eGa9fAenmNHGlLFN9XpWQb8i5sU1w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@volar/typescript": "2.4.23",
-        "@vue/language-core": "3.0.6"
+        "@vue/language-core": "3.0.8"
       },
       "bin": {
         "vue-tsc": "bin/vue-tsc.js"
@@ -22843,9 +22843,9 @@
       "integrity": "sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g=="
     },
     "@vue/language-core": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-3.0.6.tgz",
-      "integrity": "sha512-e2RRzYWm+qGm8apUHW1wA5RQxzNhkqbbKdbKhiDUcmMrNAZGyM8aTiL3UrTqkaFI5s7wJRGGrp4u3jgusuBp2A==",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-3.0.8.tgz",
+      "integrity": "sha512-eYs6PF7bxoPYvek9qxceo1BCwFbJZYqJll+WaYC8o8ec60exqj+n+QRGGiJHSeUfYp0hDxARbMdxMq/fbPgU5g==",
       "dev": true,
       "requires": {
         "@volar/language-core": "2.4.23",
@@ -23294,9 +23294,9 @@
       "requires": {}
     },
     "alien-signals": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/alien-signals/-/alien-signals-2.0.7.tgz",
-      "integrity": "sha512-wE7y3jmYeb0+h6mr5BOovuqhFv22O/MV9j5p0ndJsa7z1zJNPGQ4ph5pQk/kTTCWRC3xsA4SmtwmkzQO+7NCNg==",
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/alien-signals/-/alien-signals-2.0.8.tgz",
+      "integrity": "sha512-844G1VLkk0Pe2SJjY0J8vp8ADI73IM4KliNu2OGlYzWpO28NexEUvjHTcFjFX3VXoiUtwTbHxLNI9ImkcoBqzA==",
       "dev": true
     },
     "ansi-escapes": {
@@ -31213,13 +31213,13 @@
       "requires": {}
     },
     "vue-tsc": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-3.0.6.tgz",
-      "integrity": "sha512-Tbs8Whd43R2e2nxez4WXPvvdjGbW24rOSgRhLOHXzWiT4pcP4G7KeWh0YCn18rF4bVwv7tggLLZ6MJnO6jXPBg==",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-3.0.8.tgz",
+      "integrity": "sha512-H9yg/m6ywykmWS+pIAEs65v2FrVm5uOA0a0dHkX6Sx8dNg1a1m4iudt/6eGa9fAenmNHGlLFN9XpWQb8i5sU1w==",
       "dev": true,
       "requires": {
         "@volar/typescript": "2.4.23",
-        "@vue/language-core": "3.0.6"
+        "@vue/language-core": "3.0.8"
       }
     },
     "watchpack": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@mdi/svg": "^7.4.47",
-        "@nextcloud/axios": "^2.5.1",
+        "@nextcloud/axios": "^2.5.2",
         "@nextcloud/browser-storage": "^0.4.0",
         "@nextcloud/capabilities": "^1.2.0",
         "@nextcloud/event-bus": "^3.3.2",
@@ -4159,17 +4159,17 @@
       }
     },
     "node_modules/@nextcloud/axios": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@nextcloud/axios/-/axios-2.5.1.tgz",
-      "integrity": "sha512-AA7BPF/rsOZWAiVxqlobGSdD67AEwjOnymZCKUIwEIBArKxYK7OQEqcILDjQwgj6G0e/Vg9Y8zTVsPZp+mlvwA==",
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@nextcloud/axios/-/axios-2.5.2.tgz",
+      "integrity": "sha512-8frJb77jNMbz00TjsSqs1PymY0nIEbNM4mVmwen2tXY7wNgRai6uXilIlXKOYB9jR/F/HKRj6B4vUwVwZbhdbw==",
+      "license": "GPL-3.0-or-later",
       "dependencies": {
-        "@nextcloud/auth": "^2.3.0",
+        "@nextcloud/auth": "^2.5.1",
         "@nextcloud/router": "^3.0.1",
-        "axios": "^1.6.8"
+        "axios": "^1.12.2"
       },
       "engines": {
-        "node": "^20.0.0",
-        "npm": "^10.0.0"
+        "node": "^20.0.0 || ^22.0.0 || ^24.0.0"
       }
     },
     "node_modules/@nextcloud/browser-storage": {
@@ -6772,9 +6772,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.11.0.tgz",
-      "integrity": "sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.2.tgz",
+      "integrity": "sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",
@@ -15238,7 +15238,8 @@
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
     },
     "node_modules/public-encrypt": {
       "version": "4.0.3",
@@ -21722,13 +21723,13 @@
       }
     },
     "@nextcloud/axios": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@nextcloud/axios/-/axios-2.5.1.tgz",
-      "integrity": "sha512-AA7BPF/rsOZWAiVxqlobGSdD67AEwjOnymZCKUIwEIBArKxYK7OQEqcILDjQwgj6G0e/Vg9Y8zTVsPZp+mlvwA==",
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@nextcloud/axios/-/axios-2.5.2.tgz",
+      "integrity": "sha512-8frJb77jNMbz00TjsSqs1PymY0nIEbNM4mVmwen2tXY7wNgRai6uXilIlXKOYB9jR/F/HKRj6B4vUwVwZbhdbw==",
       "requires": {
-        "@nextcloud/auth": "^2.3.0",
+        "@nextcloud/auth": "^2.5.1",
         "@nextcloud/router": "^3.0.1",
-        "axios": "^1.6.8"
+        "axios": "^1.12.2"
       }
     },
     "@nextcloud/browser-storage": {
@@ -23571,9 +23572,9 @@
       }
     },
     "axios": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.11.0.tgz",
-      "integrity": "sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.2.tgz",
+      "integrity": "sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==",
       "requires": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@nextcloud/l10n": "^3.4.0",
         "@nextcloud/notify_push": "^1.3.0",
         "@nextcloud/router": "^3.0.1",
-        "@nextcloud/vue": "^9.0.0-rc.9",
+        "@nextcloud/vue": "^9.0.0",
         "@vueuse/core": "^13.7.0",
         "core-js": "^3.45.1",
         "electron-squirrel-startup": "^1.0.1",
@@ -4381,18 +4381,6 @@
         "node": "^20.0.0 || ^22.0.0 || ^24.0.0"
       }
     },
-    "node_modules/@nextcloud/timezones": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@nextcloud/timezones/-/timezones-1.0.0.tgz",
-      "integrity": "sha512-9b7Wms2mzB4RAltf8s9dY40PcU5ova5QjQJw1Gty35e54alKyx33BqUOy4gEbkzmYSrW4aZcLcMrOO5Bj2eIzg==",
-      "license": "AGPL-3.0-or-later",
-      "dependencies": {
-        "ical.js": "^2.1.0"
-      },
-      "engines": {
-        "node": "^20 || ^22"
-      }
-    },
     "node_modules/@nextcloud/typings": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/@nextcloud/typings/-/typings-1.9.1.tgz",
@@ -4407,14 +4395,15 @@
       }
     },
     "node_modules/@nextcloud/vue": {
-      "version": "9.0.0-rc.9",
-      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-9.0.0-rc.9.tgz",
-      "integrity": "sha512-rrM0KmRMGK2u1y9VZNJwVA7IzzU1OMnPkqU5ii9j07F5uOjy4J97/Bu71maQ19nfZA8tFe6INKHuX5AgOPYkbg==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-9.0.0.tgz",
+      "integrity": "sha512-zEz1NObKuMuWBCSbDxGtfkM6ZYKpYyFGCStuBF+/N4Wh4LBp2Z6QY14A311nuMOwSM2W2i16MMpYvIYGguUTkA==",
+      "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@ckpack/vue-color": "^1.6.0",
         "@floating-ui/dom": "^1.7.4",
         "@nextcloud/auth": "^2.5.2",
-        "@nextcloud/axios": "^2.5.1",
+        "@nextcloud/axios": "^2.5.2",
         "@nextcloud/browser-storage": "^0.4.0",
         "@nextcloud/capabilities": "^1.2.0",
         "@nextcloud/event-bus": "^3.3.2",
@@ -4423,7 +4412,6 @@
         "@nextcloud/logger": "^3.0.2",
         "@nextcloud/router": "^3.0.1",
         "@nextcloud/sharing": "^0.3.0",
-        "@nextcloud/timezones": "^1.0.0",
         "@vuepic/vue-datepicker": "^11.0.2",
         "@vueuse/components": "^13.9.0",
         "@vueuse/core": "^13.9.0",
@@ -4431,7 +4419,7 @@
         "clone": "^2.1.2",
         "crypto-browserify": "^3.12.1",
         "debounce": "^2.2.0",
-        "dompurify": "^3.2.6",
+        "dompurify": "^3.2.7",
         "emoji-mart-vue-fast": "^15.0.5",
         "escape-html": "^1.0.3",
         "floating-vue": "^5.2.2",
@@ -8687,9 +8675,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.6.tgz",
-      "integrity": "sha512-/2GogDQlohXPZe6D6NOgQvXLPSYBqIWMnZ8zzOhn09REE4eyAzb+Hed3jhoM9OkuaJ8P6ZGTTVWQKAi8ieIzfQ==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.7.tgz",
+      "integrity": "sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -11386,12 +11374,6 @@
       "engines": {
         "node": ">=10.18"
       }
-    },
-    "node_modules/ical.js": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/ical.js/-/ical.js-2.2.1.tgz",
-      "integrity": "sha512-yK/UlPbEs316igb/tjRgbFA8ZV75rCsBJp/hWOatpyaPNlgw0dGDmU+FoicOcwX4xXkeXOkYiOmCqNPFpNPkQg==",
-      "license": "MPL-2.0"
     },
     "node_modules/icon-gen": {
       "version": "5.0.0",
@@ -21876,14 +21858,6 @@
         "@nextcloud/initial-state": "^2.2.0"
       }
     },
-    "@nextcloud/timezones": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@nextcloud/timezones/-/timezones-1.0.0.tgz",
-      "integrity": "sha512-9b7Wms2mzB4RAltf8s9dY40PcU5ova5QjQJw1Gty35e54alKyx33BqUOy4gEbkzmYSrW4aZcLcMrOO5Bj2eIzg==",
-      "requires": {
-        "ical.js": "^2.1.0"
-      }
-    },
     "@nextcloud/typings": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/@nextcloud/typings/-/typings-1.9.1.tgz",
@@ -21893,14 +21867,14 @@
       }
     },
     "@nextcloud/vue": {
-      "version": "9.0.0-rc.9",
-      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-9.0.0-rc.9.tgz",
-      "integrity": "sha512-rrM0KmRMGK2u1y9VZNJwVA7IzzU1OMnPkqU5ii9j07F5uOjy4J97/Bu71maQ19nfZA8tFe6INKHuX5AgOPYkbg==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-9.0.0.tgz",
+      "integrity": "sha512-zEz1NObKuMuWBCSbDxGtfkM6ZYKpYyFGCStuBF+/N4Wh4LBp2Z6QY14A311nuMOwSM2W2i16MMpYvIYGguUTkA==",
       "requires": {
         "@ckpack/vue-color": "^1.6.0",
         "@floating-ui/dom": "^1.7.4",
         "@nextcloud/auth": "^2.5.2",
-        "@nextcloud/axios": "^2.5.1",
+        "@nextcloud/axios": "^2.5.2",
         "@nextcloud/browser-storage": "^0.4.0",
         "@nextcloud/capabilities": "^1.2.0",
         "@nextcloud/event-bus": "^3.3.2",
@@ -21909,7 +21883,6 @@
         "@nextcloud/logger": "^3.0.2",
         "@nextcloud/router": "^3.0.1",
         "@nextcloud/sharing": "^0.3.0",
-        "@nextcloud/timezones": "^1.0.0",
         "@vuepic/vue-datepicker": "^11.0.2",
         "@vueuse/components": "^13.9.0",
         "@vueuse/core": "^13.9.0",
@@ -21917,7 +21890,7 @@
         "clone": "^2.1.2",
         "crypto-browserify": "^3.12.1",
         "debounce": "^2.2.0",
-        "dompurify": "^3.2.6",
+        "dompurify": "^3.2.7",
         "emoji-mart-vue-fast": "^15.0.5",
         "escape-html": "^1.0.3",
         "floating-vue": "^5.2.2",
@@ -24884,9 +24857,9 @@
       }
     },
     "dompurify": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.6.tgz",
-      "integrity": "sha512-/2GogDQlohXPZe6D6NOgQvXLPSYBqIWMnZ8zzOhn09REE4eyAzb+Hed3jhoM9OkuaJ8P6ZGTTVWQKAi8ieIzfQ==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.7.tgz",
+      "integrity": "sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==",
       "requires": {
         "@types/trusted-types": "^2.0.7"
       }
@@ -26803,11 +26776,6 @@
       "integrity": "sha512-Y93lCzHYgGWdrJ66yIktxiaGULYc6oGiABxhcO5AufBeOyoIdZF7bIfLaOrbM0iGIOXQQgxxRrFEnb+Y6w1n4A==",
       "dev": true,
       "peer": true
-    },
-    "ical.js": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/ical.js/-/ical.js-2.2.1.tgz",
-      "integrity": "sha512-yK/UlPbEs316igb/tjRgbFA8ZV75rCsBJp/hWOatpyaPNlgw0dGDmU+FoicOcwX4xXkeXOkYiOmCqNPFpNPkQg=="
     },
     "icon-gen": {
       "version": "5.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,7 @@
         "dotenv": "^17.2.2",
         "electron": "^37.4.0",
         "esbuild-loader": "^4.3.0",
-        "eslint": "^9.35.0",
+        "eslint": "^9.36.0",
         "globals": "^16.4.0",
         "icon-gen": "^5.0.0",
         "mini-css-extract-plugin": "^2.9.4",
@@ -3096,10 +3096,11 @@
       "license": "MIT"
     },
     "node_modules/@eslint/js": {
-      "version": "9.35.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.35.0.tgz",
-      "integrity": "sha512-30iXE9whjlILfWobBkNerJo+TXYsgVM5ERQwMcMKCHckHflCmf7wXDAHlARoWnh0s1U72WqlbeyE7iAcCzuCPw==",
+      "version": "9.36.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.36.0.tgz",
+      "integrity": "sha512-uhCbYtYynH30iZErszX78U+nR3pJU3RHGQ57NXy5QupD4SBVwDeU8TNBy+MjMngc1UyIW9noKqsRqfjQTBU2dw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
@@ -9738,10 +9739,11 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.35.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.35.0.tgz",
-      "integrity": "sha512-QePbBFMJFjgmlE+cXAlbHZbHpdFVS2E/6vzCy7aKlebddvl1vadiC4JFV5u/wqTkNUwEV8WrQi257jf5f06hrg==",
+      "version": "9.36.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.36.0.tgz",
+      "integrity": "sha512-hB4FIzXovouYzwzECDcUkJ4OcfOEkXTv2zRY6B9bkwjx/cprAq0uvm1nl7zvQ0/TsUk0zQiN4uPfJpB9m+rPMQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -9749,7 +9751,7 @@
         "@eslint/config-helpers": "^0.3.1",
         "@eslint/core": "^0.15.2",
         "@eslint/eslintrc": "^3.3.1",
-        "@eslint/js": "9.35.0",
+        "@eslint/js": "9.36.0",
         "@eslint/plugin-kit": "^0.3.5",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
@@ -21521,9 +21523,9 @@
       }
     },
     "@eslint/js": {
-      "version": "9.35.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.35.0.tgz",
-      "integrity": "sha512-30iXE9whjlILfWobBkNerJo+TXYsgVM5ERQwMcMKCHckHflCmf7wXDAHlARoWnh0s1U72WqlbeyE7iAcCzuCPw==",
+      "version": "9.36.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.36.0.tgz",
+      "integrity": "sha512-uhCbYtYynH30iZErszX78U+nR3pJU3RHGQ57NXy5QupD4SBVwDeU8TNBy+MjMngc1UyIW9noKqsRqfjQTBU2dw==",
       "dev": true
     },
     "@eslint/json": {
@@ -26050,9 +26052,9 @@
       "dev": true
     },
     "eslint": {
-      "version": "9.35.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.35.0.tgz",
-      "integrity": "sha512-QePbBFMJFjgmlE+cXAlbHZbHpdFVS2E/6vzCy7aKlebddvl1vadiC4JFV5u/wqTkNUwEV8WrQi257jf5f06hrg==",
+      "version": "9.36.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.36.0.tgz",
+      "integrity": "sha512-hB4FIzXovouYzwzECDcUkJ4OcfOEkXTv2zRY6B9bkwjx/cprAq0uvm1nl7zvQ0/TsUk0zQiN4uPfJpB9m+rPMQ==",
       "dev": true,
       "requires": {
         "@eslint-community/eslint-utils": "^4.8.0",
@@ -26061,7 +26063,7 @@
         "@eslint/config-helpers": "^0.3.1",
         "@eslint/core": "^0.15.2",
         "@eslint/eslintrc": "^3.3.1",
-        "@eslint/js": "9.35.0",
+        "@eslint/js": "9.36.0",
         "@eslint/plugin-kit": "^0.3.5",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,7 @@
         "@vercel/webpack-asset-relocator-loader": "^1.10.0",
         "@vue/tsconfig": "^0.8.1",
         "dotenv": "^17.2.2",
-        "electron": "^37.4.0",
+        "electron": "^38.1.2",
         "esbuild-loader": "^4.3.0",
         "eslint": "^9.36.0",
         "globals": "^16.4.0",
@@ -8770,11 +8770,12 @@
       "dev": true
     },
     "node_modules/electron": {
-      "version": "37.4.0",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-37.4.0.tgz",
-      "integrity": "sha512-HhsSdWowE5ODOeWNc/323Ug2C52mq/TqNBG+4uMeOA3G2dMXNc/nfyi0RYu1rJEgiaJLEjtHveeZZaYRYFsFCQ==",
+      "version": "38.1.2",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-38.1.2.tgz",
+      "integrity": "sha512-WXUcN3W8h8NTTZViA3KNX0rV2YBU0X0mEUM3ubupXTDY4QtIN7tmiqYVOKSKpR2LckTmBWGuEeY4D6xVoffwKQ==",
       "dev": true,
       "hasInstallScript": true,
+      "license": "MIT",
       "dependencies": {
         "@electron/get": "^2.0.0",
         "@types/node": "^22.7.7",
@@ -24952,9 +24953,9 @@
       "dev": true
     },
     "electron": {
-      "version": "37.4.0",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-37.4.0.tgz",
-      "integrity": "sha512-HhsSdWowE5ODOeWNc/323Ug2C52mq/TqNBG+4uMeOA3G2dMXNc/nfyi0RYu1rJEgiaJLEjtHveeZZaYRYFsFCQ==",
+      "version": "38.1.2",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-38.1.2.tgz",
+      "integrity": "sha512-WXUcN3W8h8NTTZViA3KNX0rV2YBU0X0mEUM3ubupXTDY4QtIN7tmiqYVOKSKpR2LckTmBWGuEeY4D6xVoffwKQ==",
       "dev": true,
       "requires": {
         "@electron/get": "^2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "pinia": "^2.3.1",
         "semver": "^7.7.2",
         "unzip-crx-3": "^0.2.0",
-        "vue": "^3.5.21",
+        "vue": "^3.5.22",
         "vue-material-design-icons": "^5.3.1"
       },
       "devDependencies": {
@@ -322,12 +322,12 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.28.3",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.3.tgz",
-      "integrity": "sha512-7+Ey1mAgYqFAx2h0RuoxcQT5+MlG3GTV0TQrgr7/ZliKsm/MNDxVVutlWaziMq7wJNAz8MTqz55XLpWvva6StA==",
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.4.tgz",
+      "integrity": "sha512-yZbBqeM6TkpP9du/I2pUZnJsRMGGvOuIrhjzC1AwHwW+6he4mni6Bp/m8ijn0iOuZuPI2BfkCoSRunpyjnrQKg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.28.2"
+        "@babel/types": "^7.28.4"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -419,9 +419,9 @@
       "peer": true
     },
     "node_modules/@babel/types": {
-      "version": "7.28.2",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.2.tgz",
-      "integrity": "sha512-ruv7Ae4J5dUYULmeXw1gmb7rYRz57OWCPM57pHojnLq/3Z1CK2lNSLTCVjxVk1F/TZHwOZZrOWi0ur95BbLxNQ==",
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.4.tgz",
+      "integrity": "sha512-bkFqkLhh3pMBUQQkpVgWDWq/lqzc2678eUyDlTBhRqhCHFguYYGM0Efga7tYk4TogG/3x0EEl66/OQ+WGbWB/Q==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.27.1",
@@ -5829,12 +5829,13 @@
       "dev": true
     },
     "node_modules/@vue/compiler-core": {
-      "version": "3.5.21",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.21.tgz",
-      "integrity": "sha512-8i+LZ0vf6ZgII5Z9XmUvrCyEzocvWT+TeR2VBUVlzIH6Tyv57E20mPZ1bCS+tbejgUgmjrEh7q/0F0bibskAmw==",
+      "version": "3.5.22",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.22.tgz",
+      "integrity": "sha512-jQ0pFPmZwTEiRNSb+i9Ow/I/cHv2tXYqsnHKKyCQ08irI2kdF5qmYedmF8si8mA7zepUFmJ2hqzS8CQmNOWOkQ==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.28.3",
-        "@vue/shared": "3.5.21",
+        "@babel/parser": "^7.28.4",
+        "@vue/shared": "3.5.22",
         "entities": "^4.5.0",
         "estree-walker": "^2.0.2",
         "source-map-js": "^1.2.1"
@@ -5844,6 +5845,7 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
       "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"
       },
@@ -5852,37 +5854,40 @@
       }
     },
     "node_modules/@vue/compiler-dom": {
-      "version": "3.5.21",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.21.tgz",
-      "integrity": "sha512-jNtbu/u97wiyEBJlJ9kmdw7tAr5Vy0Aj5CgQmo+6pxWNQhXZDPsRr1UWPN4v3Zf82s2H3kF51IbzZ4jMWAgPlQ==",
+      "version": "3.5.22",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.22.tgz",
+      "integrity": "sha512-W8RknzUM1BLkypvdz10OVsGxnMAuSIZs9Wdx1vzA3mL5fNMN15rhrSCLiTm6blWeACwUwizzPVqGJgOGBEN/hA==",
+      "license": "MIT",
       "dependencies": {
-        "@vue/compiler-core": "3.5.21",
-        "@vue/shared": "3.5.21"
+        "@vue/compiler-core": "3.5.22",
+        "@vue/shared": "3.5.22"
       }
     },
     "node_modules/@vue/compiler-sfc": {
-      "version": "3.5.21",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.21.tgz",
-      "integrity": "sha512-SXlyk6I5eUGBd2v8Ie7tF6ADHE9kCR6mBEuPyH1nUZ0h6Xx6nZI29i12sJKQmzbDyr2tUHMhhTt51Z6blbkTTQ==",
+      "version": "3.5.22",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.22.tgz",
+      "integrity": "sha512-tbTR1zKGce4Lj+JLzFXDq36K4vcSZbJ1RBu8FxcDv1IGRz//Dh2EBqksyGVypz3kXpshIfWKGOCcqpSbyGWRJQ==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.28.3",
-        "@vue/compiler-core": "3.5.21",
-        "@vue/compiler-dom": "3.5.21",
-        "@vue/compiler-ssr": "3.5.21",
-        "@vue/shared": "3.5.21",
+        "@babel/parser": "^7.28.4",
+        "@vue/compiler-core": "3.5.22",
+        "@vue/compiler-dom": "3.5.22",
+        "@vue/compiler-ssr": "3.5.22",
+        "@vue/shared": "3.5.22",
         "estree-walker": "^2.0.2",
-        "magic-string": "^0.30.18",
+        "magic-string": "^0.30.19",
         "postcss": "^8.5.6",
         "source-map-js": "^1.2.1"
       }
     },
     "node_modules/@vue/compiler-ssr": {
-      "version": "3.5.21",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.21.tgz",
-      "integrity": "sha512-vKQ5olH5edFZdf5ZrlEgSO1j1DMA4u23TVK5XR1uMhvwnYvVdDF0nHXJUblL/GvzlShQbjhZZ2uvYmDlAbgo9w==",
+      "version": "3.5.22",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.22.tgz",
+      "integrity": "sha512-GdgyLvg4R+7T8Nk2Mlighx7XGxq/fJf9jaVofc3IL0EPesTE86cP/8DD1lT3h1JeZr2ySBvyqKQJgbS54IX1Ww==",
+      "license": "MIT",
       "dependencies": {
-        "@vue/compiler-dom": "3.5.21",
-        "@vue/shared": "3.5.21"
+        "@vue/compiler-dom": "3.5.22",
+        "@vue/shared": "3.5.22"
       }
     },
     "node_modules/@vue/compiler-vue2": {
@@ -5941,49 +5946,54 @@
       }
     },
     "node_modules/@vue/reactivity": {
-      "version": "3.5.21",
-      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.21.tgz",
-      "integrity": "sha512-3ah7sa+Cwr9iiYEERt9JfZKPw4A2UlbY8RbbnH2mGCE8NwHkhmlZt2VsH0oDA3P08X3jJd29ohBDtX+TbD9AsA==",
+      "version": "3.5.22",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.22.tgz",
+      "integrity": "sha512-f2Wux4v/Z2pqc9+4SmgZC1p73Z53fyD90NFWXiX9AKVnVBEvLFOWCEgJD3GdGnlxPZt01PSlfmLqbLYzY/Fw4A==",
+      "license": "MIT",
       "dependencies": {
-        "@vue/shared": "3.5.21"
+        "@vue/shared": "3.5.22"
       }
     },
     "node_modules/@vue/runtime-core": {
-      "version": "3.5.21",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.21.tgz",
-      "integrity": "sha512-+DplQlRS4MXfIf9gfD1BOJpk5RSyGgGXD/R+cumhe8jdjUcq/qlxDawQlSI8hCKupBlvM+3eS1se5xW+SuNAwA==",
+      "version": "3.5.22",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.22.tgz",
+      "integrity": "sha512-EHo4W/eiYeAzRTN5PCextDUZ0dMs9I8mQ2Fy+OkzvRPUYQEyK9yAjbasrMCXbLNhF7P0OUyivLjIy0yc6VrLJQ==",
+      "license": "MIT",
       "dependencies": {
-        "@vue/reactivity": "3.5.21",
-        "@vue/shared": "3.5.21"
+        "@vue/reactivity": "3.5.22",
+        "@vue/shared": "3.5.22"
       }
     },
     "node_modules/@vue/runtime-dom": {
-      "version": "3.5.21",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.21.tgz",
-      "integrity": "sha512-3M2DZsOFwM5qI15wrMmNF5RJe1+ARijt2HM3TbzBbPSuBHOQpoidE+Pa+XEaVN+czbHf81ETRoG1ltztP2em8w==",
+      "version": "3.5.22",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.22.tgz",
+      "integrity": "sha512-Av60jsryAkI023PlN7LsqrfPvwfxOd2yAwtReCjeuugTJTkgrksYJJstg1e12qle0NarkfhfFu1ox2D+cQotww==",
+      "license": "MIT",
       "dependencies": {
-        "@vue/reactivity": "3.5.21",
-        "@vue/runtime-core": "3.5.21",
-        "@vue/shared": "3.5.21",
+        "@vue/reactivity": "3.5.22",
+        "@vue/runtime-core": "3.5.22",
+        "@vue/shared": "3.5.22",
         "csstype": "^3.1.3"
       }
     },
     "node_modules/@vue/server-renderer": {
-      "version": "3.5.21",
-      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.21.tgz",
-      "integrity": "sha512-qr8AqgD3DJPJcGvLcJKQo2tAc8OnXRcfxhOJCPF+fcfn5bBGz7VCcO7t+qETOPxpWK1mgysXvVT/j+xWaHeMWA==",
+      "version": "3.5.22",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.22.tgz",
+      "integrity": "sha512-gXjo+ao0oHYTSswF+a3KRHZ1WszxIqO7u6XwNHqcqb9JfyIL/pbWrrh/xLv7jeDqla9u+LK7yfZKHih1e1RKAQ==",
+      "license": "MIT",
       "dependencies": {
-        "@vue/compiler-ssr": "3.5.21",
-        "@vue/shared": "3.5.21"
+        "@vue/compiler-ssr": "3.5.22",
+        "@vue/shared": "3.5.22"
       },
       "peerDependencies": {
-        "vue": "3.5.21"
+        "vue": "3.5.22"
       }
     },
     "node_modules/@vue/shared": {
-      "version": "3.5.21",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.21.tgz",
-      "integrity": "sha512-+2k1EQpnYuVuu3N7atWyG3/xoFWIVJZq4Mz8XNOdScFI0etES75fbny/oU4lKWk/577P1zmg0ioYvpGEDZ3DLw=="
+      "version": "3.5.22",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.22.tgz",
+      "integrity": "sha512-F4yc6palwq3TT0u+FYf0Ns4Tfl9GRFURDN2gWG7L1ecIaS/4fCIuFOjMTnCyjsu/OK6vaDKLCrGAa+KvvH+h4w==",
+      "license": "MIT"
     },
     "node_modules/@vue/tsconfig": {
       "version": "0.8.1",
@@ -8176,7 +8186,8 @@
     "node_modules/csstype": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "license": "MIT"
     },
     "node_modules/data-uri-to-buffer": {
       "version": "4.0.1",
@@ -9702,7 +9713,8 @@
     "node_modules/estree-walker": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
-      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "license": "MIT"
     },
     "node_modules/esutils": {
       "version": "2.0.3",
@@ -12614,9 +12626,10 @@
       }
     },
     "node_modules/magic-string": {
-      "version": "0.30.18",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.18.tgz",
-      "integrity": "sha512-yi8swmWbO17qHhwIBNeeZxTceJMeBvWJaId6dyvTSOwTipqeHhMhOrz6513r1sOKnpvQ7zkhlG8tPrpilwTxHQ==",
+      "version": "0.30.19",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.19.tgz",
+      "integrity": "sha512-2N21sPY9Ws53PZvsEpVtNuSW+ScYbQdp4b9qUaL+9QkHUrGFKo56Lg9Emg5s9V/qrtNBmiR01sYhUOwu3H+VOw==",
+      "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
@@ -17943,15 +17956,16 @@
       "license": "MIT"
     },
     "node_modules/vue": {
-      "version": "3.5.21",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.21.tgz",
-      "integrity": "sha512-xxf9rum9KtOdwdRkiApWL+9hZEMWE90FHh8yS1+KJAiWYh+iGWV1FquPjoO9VUHQ+VIhsCXNNyZ5Sf4++RVZBA==",
+      "version": "3.5.22",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.22.tgz",
+      "integrity": "sha512-toaZjQ3a/G/mYaLSbV+QsQhIdMo9x5rrqIpYRObsJ6T/J+RyCSFwN2LHNVH9v8uIcljDNa3QzPVdv3Y6b9hAJQ==",
+      "license": "MIT",
       "dependencies": {
-        "@vue/compiler-dom": "3.5.21",
-        "@vue/compiler-sfc": "3.5.21",
-        "@vue/runtime-dom": "3.5.21",
-        "@vue/server-renderer": "3.5.21",
-        "@vue/shared": "3.5.21"
+        "@vue/compiler-dom": "3.5.22",
+        "@vue/compiler-sfc": "3.5.22",
+        "@vue/runtime-dom": "3.5.22",
+        "@vue/server-renderer": "3.5.22",
+        "@vue/shared": "3.5.22"
       },
       "peerDependencies": {
         "typescript": "*"
@@ -19192,11 +19206,11 @@
       }
     },
     "@babel/parser": {
-      "version": "7.28.3",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.3.tgz",
-      "integrity": "sha512-7+Ey1mAgYqFAx2h0RuoxcQT5+MlG3GTV0TQrgr7/ZliKsm/MNDxVVutlWaziMq7wJNAz8MTqz55XLpWvva6StA==",
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.4.tgz",
+      "integrity": "sha512-yZbBqeM6TkpP9du/I2pUZnJsRMGGvOuIrhjzC1AwHwW+6he4mni6Bp/m8ijn0iOuZuPI2BfkCoSRunpyjnrQKg==",
       "requires": {
-        "@babel/types": "^7.28.2"
+        "@babel/types": "^7.28.4"
       }
     },
     "@babel/runtime": {
@@ -19259,9 +19273,9 @@
       }
     },
     "@babel/types": {
-      "version": "7.28.2",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.2.tgz",
-      "integrity": "sha512-ruv7Ae4J5dUYULmeXw1gmb7rYRz57OWCPM57pHojnLq/3Z1CK2lNSLTCVjxVk1F/TZHwOZZrOWi0ur95BbLxNQ==",
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.4.tgz",
+      "integrity": "sha512-bkFqkLhh3pMBUQQkpVgWDWq/lqzc2678eUyDlTBhRqhCHFguYYGM0Efga7tYk4TogG/3x0EEl66/OQ+WGbWB/Q==",
       "requires": {
         "@babel/helper-string-parser": "^7.27.1",
         "@babel/helper-validator-identifier": "^7.27.1"
@@ -22775,12 +22789,12 @@
       "dev": true
     },
     "@vue/compiler-core": {
-      "version": "3.5.21",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.21.tgz",
-      "integrity": "sha512-8i+LZ0vf6ZgII5Z9XmUvrCyEzocvWT+TeR2VBUVlzIH6Tyv57E20mPZ1bCS+tbejgUgmjrEh7q/0F0bibskAmw==",
+      "version": "3.5.22",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.22.tgz",
+      "integrity": "sha512-jQ0pFPmZwTEiRNSb+i9Ow/I/cHv2tXYqsnHKKyCQ08irI2kdF5qmYedmF8si8mA7zepUFmJ2hqzS8CQmNOWOkQ==",
       "requires": {
-        "@babel/parser": "^7.28.3",
-        "@vue/shared": "3.5.21",
+        "@babel/parser": "^7.28.4",
+        "@vue/shared": "3.5.22",
         "entities": "^4.5.0",
         "estree-walker": "^2.0.2",
         "source-map-js": "^1.2.1"
@@ -22794,37 +22808,37 @@
       }
     },
     "@vue/compiler-dom": {
-      "version": "3.5.21",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.21.tgz",
-      "integrity": "sha512-jNtbu/u97wiyEBJlJ9kmdw7tAr5Vy0Aj5CgQmo+6pxWNQhXZDPsRr1UWPN4v3Zf82s2H3kF51IbzZ4jMWAgPlQ==",
+      "version": "3.5.22",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.22.tgz",
+      "integrity": "sha512-W8RknzUM1BLkypvdz10OVsGxnMAuSIZs9Wdx1vzA3mL5fNMN15rhrSCLiTm6blWeACwUwizzPVqGJgOGBEN/hA==",
       "requires": {
-        "@vue/compiler-core": "3.5.21",
-        "@vue/shared": "3.5.21"
+        "@vue/compiler-core": "3.5.22",
+        "@vue/shared": "3.5.22"
       }
     },
     "@vue/compiler-sfc": {
-      "version": "3.5.21",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.21.tgz",
-      "integrity": "sha512-SXlyk6I5eUGBd2v8Ie7tF6ADHE9kCR6mBEuPyH1nUZ0h6Xx6nZI29i12sJKQmzbDyr2tUHMhhTt51Z6blbkTTQ==",
+      "version": "3.5.22",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.22.tgz",
+      "integrity": "sha512-tbTR1zKGce4Lj+JLzFXDq36K4vcSZbJ1RBu8FxcDv1IGRz//Dh2EBqksyGVypz3kXpshIfWKGOCcqpSbyGWRJQ==",
       "requires": {
-        "@babel/parser": "^7.28.3",
-        "@vue/compiler-core": "3.5.21",
-        "@vue/compiler-dom": "3.5.21",
-        "@vue/compiler-ssr": "3.5.21",
-        "@vue/shared": "3.5.21",
+        "@babel/parser": "^7.28.4",
+        "@vue/compiler-core": "3.5.22",
+        "@vue/compiler-dom": "3.5.22",
+        "@vue/compiler-ssr": "3.5.22",
+        "@vue/shared": "3.5.22",
         "estree-walker": "^2.0.2",
-        "magic-string": "^0.30.18",
+        "magic-string": "^0.30.19",
         "postcss": "^8.5.6",
         "source-map-js": "^1.2.1"
       }
     },
     "@vue/compiler-ssr": {
-      "version": "3.5.21",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.21.tgz",
-      "integrity": "sha512-vKQ5olH5edFZdf5ZrlEgSO1j1DMA4u23TVK5XR1uMhvwnYvVdDF0nHXJUblL/GvzlShQbjhZZ2uvYmDlAbgo9w==",
+      "version": "3.5.22",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.22.tgz",
+      "integrity": "sha512-GdgyLvg4R+7T8Nk2Mlighx7XGxq/fJf9jaVofc3IL0EPesTE86cP/8DD1lT3h1JeZr2ySBvyqKQJgbS54IX1Ww==",
       "requires": {
-        "@vue/compiler-dom": "3.5.21",
-        "@vue/shared": "3.5.21"
+        "@vue/compiler-dom": "3.5.22",
+        "@vue/shared": "3.5.22"
       }
     },
     "@vue/compiler-vue2": {
@@ -22867,46 +22881,46 @@
       }
     },
     "@vue/reactivity": {
-      "version": "3.5.21",
-      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.21.tgz",
-      "integrity": "sha512-3ah7sa+Cwr9iiYEERt9JfZKPw4A2UlbY8RbbnH2mGCE8NwHkhmlZt2VsH0oDA3P08X3jJd29ohBDtX+TbD9AsA==",
+      "version": "3.5.22",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.22.tgz",
+      "integrity": "sha512-f2Wux4v/Z2pqc9+4SmgZC1p73Z53fyD90NFWXiX9AKVnVBEvLFOWCEgJD3GdGnlxPZt01PSlfmLqbLYzY/Fw4A==",
       "requires": {
-        "@vue/shared": "3.5.21"
+        "@vue/shared": "3.5.22"
       }
     },
     "@vue/runtime-core": {
-      "version": "3.5.21",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.21.tgz",
-      "integrity": "sha512-+DplQlRS4MXfIf9gfD1BOJpk5RSyGgGXD/R+cumhe8jdjUcq/qlxDawQlSI8hCKupBlvM+3eS1se5xW+SuNAwA==",
+      "version": "3.5.22",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.22.tgz",
+      "integrity": "sha512-EHo4W/eiYeAzRTN5PCextDUZ0dMs9I8mQ2Fy+OkzvRPUYQEyK9yAjbasrMCXbLNhF7P0OUyivLjIy0yc6VrLJQ==",
       "requires": {
-        "@vue/reactivity": "3.5.21",
-        "@vue/shared": "3.5.21"
+        "@vue/reactivity": "3.5.22",
+        "@vue/shared": "3.5.22"
       }
     },
     "@vue/runtime-dom": {
-      "version": "3.5.21",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.21.tgz",
-      "integrity": "sha512-3M2DZsOFwM5qI15wrMmNF5RJe1+ARijt2HM3TbzBbPSuBHOQpoidE+Pa+XEaVN+czbHf81ETRoG1ltztP2em8w==",
+      "version": "3.5.22",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.22.tgz",
+      "integrity": "sha512-Av60jsryAkI023PlN7LsqrfPvwfxOd2yAwtReCjeuugTJTkgrksYJJstg1e12qle0NarkfhfFu1ox2D+cQotww==",
       "requires": {
-        "@vue/reactivity": "3.5.21",
-        "@vue/runtime-core": "3.5.21",
-        "@vue/shared": "3.5.21",
+        "@vue/reactivity": "3.5.22",
+        "@vue/runtime-core": "3.5.22",
+        "@vue/shared": "3.5.22",
         "csstype": "^3.1.3"
       }
     },
     "@vue/server-renderer": {
-      "version": "3.5.21",
-      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.21.tgz",
-      "integrity": "sha512-qr8AqgD3DJPJcGvLcJKQo2tAc8OnXRcfxhOJCPF+fcfn5bBGz7VCcO7t+qETOPxpWK1mgysXvVT/j+xWaHeMWA==",
+      "version": "3.5.22",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.22.tgz",
+      "integrity": "sha512-gXjo+ao0oHYTSswF+a3KRHZ1WszxIqO7u6XwNHqcqb9JfyIL/pbWrrh/xLv7jeDqla9u+LK7yfZKHih1e1RKAQ==",
       "requires": {
-        "@vue/compiler-ssr": "3.5.21",
-        "@vue/shared": "3.5.21"
+        "@vue/compiler-ssr": "3.5.22",
+        "@vue/shared": "3.5.22"
       }
     },
     "@vue/shared": {
-      "version": "3.5.21",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.21.tgz",
-      "integrity": "sha512-+2k1EQpnYuVuu3N7atWyG3/xoFWIVJZq4Mz8XNOdScFI0etES75fbny/oU4lKWk/577P1zmg0ioYvpGEDZ3DLw=="
+      "version": "3.5.22",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.22.tgz",
+      "integrity": "sha512-F4yc6palwq3TT0u+FYf0Ns4Tfl9GRFURDN2gWG7L1ecIaS/4fCIuFOjMTnCyjsu/OK6vaDKLCrGAa+KvvH+h4w=="
     },
     "@vue/tsconfig": {
       "version": "0.8.1",
@@ -27522,9 +27536,9 @@
       }
     },
     "magic-string": {
-      "version": "0.30.18",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.18.tgz",
-      "integrity": "sha512-yi8swmWbO17qHhwIBNeeZxTceJMeBvWJaId6dyvTSOwTipqeHhMhOrz6513r1sOKnpvQ7zkhlG8tPrpilwTxHQ==",
+      "version": "0.30.19",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.19.tgz",
+      "integrity": "sha512-2N21sPY9Ws53PZvsEpVtNuSW+ScYbQdp4b9qUaL+9QkHUrGFKo56Lg9Emg5s9V/qrtNBmiR01sYhUOwu3H+VOw==",
       "requires": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
@@ -31112,15 +31126,15 @@
       "dev": true
     },
     "vue": {
-      "version": "3.5.21",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.21.tgz",
-      "integrity": "sha512-xxf9rum9KtOdwdRkiApWL+9hZEMWE90FHh8yS1+KJAiWYh+iGWV1FquPjoO9VUHQ+VIhsCXNNyZ5Sf4++RVZBA==",
+      "version": "3.5.22",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.22.tgz",
+      "integrity": "sha512-toaZjQ3a/G/mYaLSbV+QsQhIdMo9x5rrqIpYRObsJ6T/J+RyCSFwN2LHNVH9v8uIcljDNa3QzPVdv3Y6b9hAJQ==",
       "requires": {
-        "@vue/compiler-dom": "3.5.21",
-        "@vue/compiler-sfc": "3.5.21",
-        "@vue/runtime-dom": "3.5.21",
-        "@vue/server-renderer": "3.5.21",
-        "@vue/shared": "3.5.21"
+        "@vue/compiler-dom": "3.5.22",
+        "@vue/compiler-sfc": "3.5.22",
+        "@vue/runtime-dom": "3.5.22",
+        "@vue/server-renderer": "3.5.22",
+        "@vue/shared": "3.5.22"
       }
     },
     "vue-eslint-parser": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "core-js": "^3.45.1",
         "electron-squirrel-startup": "^1.0.1",
         "howler": "^2.2.4",
-        "pinia": "^2.3.1",
+        "pinia": "^3.0.3",
         "semver": "^7.7.2",
         "unzip-crx-3": "^0.2.0",
         "vue": "^3.5.22",
@@ -5907,6 +5907,30 @@
       "integrity": "sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==",
       "license": "MIT"
     },
+    "node_modules/@vue/devtools-kit": {
+      "version": "7.7.7",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-kit/-/devtools-kit-7.7.7.tgz",
+      "integrity": "sha512-wgoZtxcTta65cnZ1Q6MbAfePVFxfM+gq0saaeytoph7nEa7yMXoi6sCPy4ufO111B9msnw0VOWjPEFCXuAKRHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/devtools-shared": "^7.7.7",
+        "birpc": "^2.3.0",
+        "hookable": "^5.5.3",
+        "mitt": "^3.0.1",
+        "perfect-debounce": "^1.0.0",
+        "speakingurl": "^14.0.1",
+        "superjson": "^2.2.2"
+      }
+    },
+    "node_modules/@vue/devtools-shared": {
+      "version": "7.7.7",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-shared/-/devtools-shared-7.7.7.tgz",
+      "integrity": "sha512-+udSj47aRl5aKb0memBvcUG9koarqnxNM5yjuREvqwK6T3ap4mn3Zqqc17QrBFTqSMjr3HK1cvStEZpMDpfdyw==",
+      "license": "MIT",
+      "dependencies": {
+        "rfdc": "^1.4.1"
+      }
+    },
     "node_modules/@vue/language-core": {
       "version": "3.0.8",
       "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-3.0.8.tgz",
@@ -6857,6 +6881,15 @@
       "license": "MIT",
       "dependencies": {
         "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/birpc": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/birpc/-/birpc-2.6.1.tgz",
+      "integrity": "sha512-LPnFhlDpdSH6FJhJyn4M0kFO7vtQ5iPw24FnG0y21q09xC7e8+1LeR31S1MAIrDAHp4m7aas4bEkTDTvMAtebQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
       }
     },
     "node_modules/bl": {
@@ -7899,6 +7932,21 @@
       "version": "1.0.6",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/copy-anything": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/copy-anything/-/copy-anything-3.0.5.tgz",
+      "integrity": "sha512-yCEafptTtb4bk7GLEQoM8KVJpxAfdBJYaXyzQEgQQQgYrZiDp8SJmGKlYza6CYjEDNstAdNdKA3UuoULlEbS6w==",
+      "license": "MIT",
+      "dependencies": {
+        "is-what": "^4.1.8"
+      },
+      "engines": {
+        "node": ">=12.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
     },
     "node_modules/core-js": {
       "version": "3.45.1",
@@ -10990,6 +11038,12 @@
         "minimalistic-crypto-utils": "^1.0.1"
       }
     },
+    "node_modules/hookable": {
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/hookable/-/hookable-5.5.3.tgz",
+      "integrity": "sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==",
+      "license": "MIT"
+    },
     "node_modules/hosted-git-info": {
       "version": "2.8.9",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
@@ -11933,6 +11987,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-what": {
+      "version": "4.1.16",
+      "resolved": "https://registry.npmjs.org/is-what/-/is-what-4.1.16.tgz",
+      "integrity": "sha512-ZhMwEosbFJkA0YhFnNDgTM4ZxDRsS6HqTo7qsZM08fehyRYIYa0yHu5R6mgo1n/8MgaPBXiPimPD77baVFYg+A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
       }
     },
     "node_modules/is-wsl": {
@@ -13744,6 +13810,12 @@
         "node": ">= 8"
       }
     },
+    "node_modules/mitt": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+      "license": "MIT"
+    },
     "node_modules/mkdirp": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
@@ -14771,6 +14843,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/perfect-debounce": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-1.0.0.tgz",
+      "integrity": "sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==",
+      "license": "MIT"
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -14797,13 +14875,12 @@
       }
     },
     "node_modules/pinia": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/pinia/-/pinia-2.3.1.tgz",
-      "integrity": "sha512-khUlZSwt9xXCaTbbxFYBKDc/bWAGWJjOgvxETwkTN7KRm66EeT1ZdZj6i2ceh9sP2Pzqsbc704r2yngBrxBVug==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/pinia/-/pinia-3.0.3.tgz",
+      "integrity": "sha512-ttXO/InUULUXkMHpTdp9Fj4hLpD/2AoJdmAbAeW2yu1iy1k+pkFekQXw5VpC0/5p51IOR/jDaDRfRWRnMMsGOA==",
       "license": "MIT",
       "dependencies": {
-        "@vue/devtools-api": "^6.6.3",
-        "vue-demi": "^0.14.10"
+        "@vue/devtools-api": "^7.7.2"
       },
       "funding": {
         "url": "https://github.com/sponsors/posva"
@@ -14818,29 +14895,13 @@
         }
       }
     },
-    "node_modules/pinia/node_modules/vue-demi": {
-      "version": "0.14.10",
-      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.10.tgz",
-      "integrity": "sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==",
-      "hasInstallScript": true,
-      "bin": {
-        "vue-demi-fix": "bin/vue-demi-fix.js",
-        "vue-demi-switch": "bin/vue-demi-switch.js"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/antfu"
-      },
-      "peerDependencies": {
-        "@vue/composition-api": "^1.0.0-rc.1",
-        "vue": "^3.0.0-0 || ^2.6.0"
-      },
-      "peerDependenciesMeta": {
-        "@vue/composition-api": {
-          "optional": true
-        }
+    "node_modules/pinia/node_modules/@vue/devtools-api": {
+      "version": "7.7.7",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-7.7.7.tgz",
+      "integrity": "sha512-lwOnNBH2e7x1fIIbVT7yF5D+YWhqELm55/4ZKf45R9T8r9dE2AIOy8HKjfqzGsoTHFbWbr337O4E0A0QADnjBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/devtools-kit": "^7.7.7"
       }
     },
     "node_modules/pkg-dir": {
@@ -15790,8 +15851,9 @@
       }
     },
     "node_modules/rfdc": {
-      "version": "1.3.0",
-      "dev": true,
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+      "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
       "license": "MIT"
     },
     "node_modules/rimraf": {
@@ -16700,6 +16762,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/speakingurl": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/speakingurl/-/speakingurl-14.0.1.tgz",
+      "integrity": "sha512-1POYv7uv2gXoyGFpBCmpDVSNV74IfsWlDW216UPjbWufNf+bSU6GdbDsxdcxtfwb4xlI3yxzOTKClUosxARYrQ==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/splitpanes": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/splitpanes/-/splitpanes-4.0.4.tgz",
@@ -16968,6 +17039,18 @@
       "version": "2.1.2",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/superjson": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/superjson/-/superjson-2.2.2.tgz",
+      "integrity": "sha512-5JRxVqC8I8NuOUjzBbvVJAKNM8qoVuH0O77h4WInc/qC2q5IreqKxYwgkga3PfA22OayK2ikceb/B26dztPl+Q==",
+      "license": "MIT",
+      "dependencies": {
+        "copy-anything": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=16"
+      }
     },
     "node_modules/supports-color": {
       "version": "7.2.0",
@@ -22856,6 +22939,28 @@
       "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.6.4.tgz",
       "integrity": "sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g=="
     },
+    "@vue/devtools-kit": {
+      "version": "7.7.7",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-kit/-/devtools-kit-7.7.7.tgz",
+      "integrity": "sha512-wgoZtxcTta65cnZ1Q6MbAfePVFxfM+gq0saaeytoph7nEa7yMXoi6sCPy4ufO111B9msnw0VOWjPEFCXuAKRHA==",
+      "requires": {
+        "@vue/devtools-shared": "^7.7.7",
+        "birpc": "^2.3.0",
+        "hookable": "^5.5.3",
+        "mitt": "^3.0.1",
+        "perfect-debounce": "^1.0.0",
+        "speakingurl": "^14.0.1",
+        "superjson": "^2.2.2"
+      }
+    },
+    "@vue/devtools-shared": {
+      "version": "7.7.7",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-shared/-/devtools-shared-7.7.7.tgz",
+      "integrity": "sha512-+udSj47aRl5aKb0memBvcUG9koarqnxNM5yjuREvqwK6T3ap4mn3Zqqc17QrBFTqSMjr3HK1cvStEZpMDpfdyw==",
+      "requires": {
+        "rfdc": "^1.4.1"
+      }
+    },
     "@vue/language-core": {
       "version": "3.0.8",
       "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-3.0.8.tgz",
@@ -23534,6 +23639,11 @@
       "requires": {
         "file-uri-to-path": "1.0.0"
       }
+    },
+    "birpc": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/birpc/-/birpc-2.6.1.tgz",
+      "integrity": "sha512-LPnFhlDpdSH6FJhJyn4M0kFO7vtQ5iPw24FnG0y21q09xC7e8+1LeR31S1MAIrDAHp4m7aas4bEkTDTvMAtebQ=="
     },
     "bl": {
       "version": "4.1.0",
@@ -24287,6 +24397,14 @@
     "cookie-signature": {
       "version": "1.0.6",
       "dev": true
+    },
+    "copy-anything": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/copy-anything/-/copy-anything-3.0.5.tgz",
+      "integrity": "sha512-yCEafptTtb4bk7GLEQoM8KVJpxAfdBJYaXyzQEgQQQgYrZiDp8SJmGKlYza6CYjEDNstAdNdKA3UuoULlEbS6w==",
+      "requires": {
+        "is-what": "^4.1.8"
+      }
     },
     "core-js": {
       "version": "3.45.1",
@@ -26424,6 +26542,11 @@
         "minimalistic-crypto-utils": "^1.0.1"
       }
     },
+    "hookable": {
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/hookable/-/hookable-5.5.3.tgz",
+      "integrity": "sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ=="
+    },
     "hosted-git-info": {
       "version": "2.8.9",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
@@ -27055,6 +27178,11 @@
       "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
       "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
       "dev": true
+    },
+    "is-what": {
+      "version": "4.1.16",
+      "resolved": "https://registry.npmjs.org/is-what/-/is-what-4.1.16.tgz",
+      "integrity": "sha512-ZhMwEosbFJkA0YhFnNDgTM4ZxDRsS6HqTo7qsZM08fehyRYIYa0yHu5R6mgo1n/8MgaPBXiPimPD77baVFYg+A=="
     },
     "is-wsl": {
       "version": "3.1.0",
@@ -28231,6 +28359,11 @@
         "yallist": "^4.0.0"
       }
     },
+    "mitt": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw=="
+    },
     "mkdirp": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
@@ -28956,6 +29089,11 @@
       "version": "1.2.0",
       "dev": true
     },
+    "perfect-debounce": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-1.0.0.tgz",
+      "integrity": "sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA=="
+    },
     "picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -28972,19 +29110,20 @@
       "dev": true
     },
     "pinia": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/pinia/-/pinia-2.3.1.tgz",
-      "integrity": "sha512-khUlZSwt9xXCaTbbxFYBKDc/bWAGWJjOgvxETwkTN7KRm66EeT1ZdZj6i2ceh9sP2Pzqsbc704r2yngBrxBVug==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/pinia/-/pinia-3.0.3.tgz",
+      "integrity": "sha512-ttXO/InUULUXkMHpTdp9Fj4hLpD/2AoJdmAbAeW2yu1iy1k+pkFekQXw5VpC0/5p51IOR/jDaDRfRWRnMMsGOA==",
       "requires": {
-        "@vue/devtools-api": "^6.6.3",
-        "vue-demi": "^0.14.10"
+        "@vue/devtools-api": "^7.7.2"
       },
       "dependencies": {
-        "vue-demi": {
-          "version": "0.14.10",
-          "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.10.tgz",
-          "integrity": "sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==",
-          "requires": {}
+        "@vue/devtools-api": {
+          "version": "7.7.7",
+          "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-7.7.7.tgz",
+          "integrity": "sha512-lwOnNBH2e7x1fIIbVT7yF5D+YWhqELm55/4ZKf45R9T8r9dE2AIOy8HKjfqzGsoTHFbWbr337O4E0A0QADnjBg==",
+          "requires": {
+            "@vue/devtools-kit": "^7.7.7"
+          }
         }
       }
     },
@@ -29652,8 +29791,9 @@
       "dev": true
     },
     "rfdc": {
-      "version": "1.3.0",
-      "dev": true
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+      "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA=="
     },
     "rimraf": {
       "version": "3.0.2",
@@ -30269,6 +30409,11 @@
         }
       }
     },
+    "speakingurl": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/speakingurl/-/speakingurl-14.0.1.tgz",
+      "integrity": "sha512-1POYv7uv2gXoyGFpBCmpDVSNV74IfsWlDW216UPjbWufNf+bSU6GdbDsxdcxtfwb4xlI3yxzOTKClUosxARYrQ=="
+    },
     "splitpanes": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/splitpanes/-/splitpanes-4.0.4.tgz",
@@ -30448,6 +30593,14 @@
           "version": "2.1.2",
           "dev": true
         }
+      }
+    },
+    "superjson": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/superjson/-/superjson-2.2.2.tgz",
+      "integrity": "sha512-5JRxVqC8I8NuOUjzBbvVJAKNM8qoVuH0O77h4WInc/qC2q5IreqKxYwgkga3PfA22OayK2ikceb/B26dztPl+Q==",
+      "requires": {
+        "copy-anything": "^3.0.2"
       }
     },
     "supports-color": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,7 +58,7 @@
         "webpack": "^5.101.3",
         "webpack-merge": "^6.0.1",
         "worker-loader": "^3.0.8",
-        "zx": "^8.8.1"
+        "zx": "^8.8.3"
       },
       "engines": {
         "node": "^22.0.0",
@@ -19420,9 +19420,9 @@
       }
     },
     "node_modules/zx": {
-      "version": "8.8.1",
-      "resolved": "https://registry.npmjs.org/zx/-/zx-8.8.1.tgz",
-      "integrity": "sha512-qvsKBnvWHstHKCluKPlEgI/D3+mdiQyMoSSeFR8IX/aXzWIas5A297KxKgPJhuPXdrR6ma0Jzx43+GQ/8sqbrw==",
+      "version": "8.8.3",
+      "resolved": "https://registry.npmjs.org/zx/-/zx-8.8.3.tgz",
+      "integrity": "sha512-8GWaBTVU6wzTdqO0v5qwGMUFLCYduW7UUxaliRD+FXGRfYM8KLDGL93idbdGFLomHDi18ZxCfhAJqYZB8rJNvw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -32583,9 +32583,9 @@
       "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="
     },
     "zx": {
-      "version": "8.8.1",
-      "resolved": "https://registry.npmjs.org/zx/-/zx-8.8.1.tgz",
-      "integrity": "sha512-qvsKBnvWHstHKCluKPlEgI/D3+mdiQyMoSSeFR8IX/aXzWIas5A297KxKgPJhuPXdrR6ma0Jzx43+GQ/8sqbrw==",
+      "version": "8.8.3",
+      "resolved": "https://registry.npmjs.org/zx/-/zx-8.8.3.tgz",
+      "integrity": "sha512-8GWaBTVU6wzTdqO0v5qwGMUFLCYduW7UUxaliRD+FXGRfYM8KLDGL93idbdGFLomHDi18ZxCfhAJqYZB8rJNvw==",
       "dev": true
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,9 +32,9 @@
       },
       "devDependencies": {
         "@electron-forge/cli": "^7.9.0",
-        "@electron-forge/maker-dmg": "^7.8.3",
+        "@electron-forge/maker-dmg": "^7.9.0",
         "@electron-forge/maker-flatpak": "^7.9.0",
-        "@electron-forge/maker-squirrel": "^7.8.3",
+        "@electron-forge/maker-squirrel": "^7.9.0",
         "@electron-forge/maker-wix": "^7.9.0",
         "@electron-forge/maker-zip": "^7.9.0",
         "@electron-forge/plugin-webpack": "^7.9.0",
@@ -519,6 +519,7 @@
           "url": "https://tidelift.com/subscription/pkg/npm-.electron-forge-cli?utm_medium=referral&utm_source=npm_fund"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "@electron-forge/core": "7.9.0",
         "@electron-forge/core-utils": "7.9.0",
@@ -541,33 +542,6 @@
       },
       "engines": {
         "node": ">= 16.4.0"
-      }
-    },
-    "node_modules/@electron-forge/cli/node_modules/@electron-forge/shared-types": {
-      "version": "7.9.0",
-      "resolved": "https://registry.npmjs.org/@electron-forge/shared-types/-/shared-types-7.9.0.tgz",
-      "integrity": "sha512-6jZF+zq3SYMnweQpgr5fwlSgOd2yOZ5qlfz/CgXyVljiv0e0UThzpOjfTLuwuVgZX7a60xV+h0mg1h82Glu3wQ==",
-      "dev": true,
-      "dependencies": {
-        "@electron-forge/tracer": "7.9.0",
-        "@electron/packager": "^18.3.5",
-        "@electron/rebuild": "^3.7.0",
-        "listr2": "^7.0.2"
-      },
-      "engines": {
-        "node": ">= 16.4.0"
-      }
-    },
-    "node_modules/@electron-forge/cli/node_modules/@electron-forge/tracer": {
-      "version": "7.9.0",
-      "resolved": "https://registry.npmjs.org/@electron-forge/tracer/-/tracer-7.9.0.tgz",
-      "integrity": "sha512-7itsjW1WJQADg7Ly61ggI5CCRt+QDVx3HOZC1w69jMUtnipKyPRCbvTBf1oplsNqbIzZxceXdfex6W53YNehvA==",
-      "dev": true,
-      "dependencies": {
-        "chrome-trace-event": "^1.0.3"
-      },
-      "engines": {
-        "node": ">= 14.17.5"
       }
     },
     "node_modules/@electron-forge/cli/node_modules/@electron/get": {
@@ -728,33 +702,6 @@
         "node": ">= 16.4.0"
       }
     },
-    "node_modules/@electron-forge/core-utils/node_modules/@electron-forge/shared-types": {
-      "version": "7.9.0",
-      "resolved": "https://registry.npmjs.org/@electron-forge/shared-types/-/shared-types-7.9.0.tgz",
-      "integrity": "sha512-6jZF+zq3SYMnweQpgr5fwlSgOd2yOZ5qlfz/CgXyVljiv0e0UThzpOjfTLuwuVgZX7a60xV+h0mg1h82Glu3wQ==",
-      "dev": true,
-      "dependencies": {
-        "@electron-forge/tracer": "7.9.0",
-        "@electron/packager": "^18.3.5",
-        "@electron/rebuild": "^3.7.0",
-        "listr2": "^7.0.2"
-      },
-      "engines": {
-        "node": ">= 16.4.0"
-      }
-    },
-    "node_modules/@electron-forge/core-utils/node_modules/@electron-forge/tracer": {
-      "version": "7.9.0",
-      "resolved": "https://registry.npmjs.org/@electron-forge/tracer/-/tracer-7.9.0.tgz",
-      "integrity": "sha512-7itsjW1WJQADg7Ly61ggI5CCRt+QDVx3HOZC1w69jMUtnipKyPRCbvTBf1oplsNqbIzZxceXdfex6W53YNehvA==",
-      "dev": true,
-      "dependencies": {
-        "chrome-trace-event": "^1.0.3"
-      },
-      "engines": {
-        "node": ">= 14.17.5"
-      }
-    },
     "node_modules/@electron-forge/core-utils/node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -777,47 +724,6 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true
-    },
-    "node_modules/@electron-forge/core/node_modules/@electron-forge/maker-base": {
-      "version": "7.9.0",
-      "resolved": "https://registry.npmjs.org/@electron-forge/maker-base/-/maker-base-7.9.0.tgz",
-      "integrity": "sha512-u0jo2kaYRxh/Rai6DyFSGJcNLRVWxiKaGUjMhX1LrKolufUkCxxR4TEmv4Hvl03WTr9pQb06umlIrVMaNb+j9A==",
-      "dev": true,
-      "dependencies": {
-        "@electron-forge/shared-types": "7.9.0",
-        "fs-extra": "^10.0.0",
-        "which": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 16.4.0"
-      }
-    },
-    "node_modules/@electron-forge/core/node_modules/@electron-forge/shared-types": {
-      "version": "7.9.0",
-      "resolved": "https://registry.npmjs.org/@electron-forge/shared-types/-/shared-types-7.9.0.tgz",
-      "integrity": "sha512-6jZF+zq3SYMnweQpgr5fwlSgOd2yOZ5qlfz/CgXyVljiv0e0UThzpOjfTLuwuVgZX7a60xV+h0mg1h82Glu3wQ==",
-      "dev": true,
-      "dependencies": {
-        "@electron-forge/tracer": "7.9.0",
-        "@electron/packager": "^18.3.5",
-        "@electron/rebuild": "^3.7.0",
-        "listr2": "^7.0.2"
-      },
-      "engines": {
-        "node": ">= 16.4.0"
-      }
-    },
-    "node_modules/@electron-forge/core/node_modules/@electron-forge/tracer": {
-      "version": "7.9.0",
-      "resolved": "https://registry.npmjs.org/@electron-forge/tracer/-/tracer-7.9.0.tgz",
-      "integrity": "sha512-7itsjW1WJQADg7Ly61ggI5CCRt+QDVx3HOZC1w69jMUtnipKyPRCbvTBf1oplsNqbIzZxceXdfex6W53YNehvA==",
-      "dev": true,
-      "dependencies": {
-        "chrome-trace-event": "^1.0.3"
-      },
-      "engines": {
-        "node": ">= 14.17.5"
-      }
     },
     "node_modules/@electron-forge/core/node_modules/@electron/get": {
       "version": "3.1.0",
@@ -905,13 +811,13 @@
       }
     },
     "node_modules/@electron-forge/maker-base": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@electron-forge/maker-base/-/maker-base-7.8.3.tgz",
-      "integrity": "sha512-WmF66cHdziaK8Asi7IRTLxZjCZ8IqXXHr6IPl4d5oatN6s5RG+HHzG1hiJ7LzlOEntqdSpE8Wh2nB2TmyR4huQ==",
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/@electron-forge/maker-base/-/maker-base-7.9.0.tgz",
+      "integrity": "sha512-u0jo2kaYRxh/Rai6DyFSGJcNLRVWxiKaGUjMhX1LrKolufUkCxxR4TEmv4Hvl03WTr9pQb06umlIrVMaNb+j9A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@electron-forge/shared-types": "7.8.3",
+        "@electron-forge/shared-types": "7.9.0",
         "fs-extra": "^10.0.0",
         "which": "^2.0.2"
       },
@@ -920,14 +826,14 @@
       }
     },
     "node_modules/@electron-forge/maker-dmg": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@electron-forge/maker-dmg/-/maker-dmg-7.8.3.tgz",
-      "integrity": "sha512-N3yKU89D7pC/xPeblSQyBQT1DLKzZMl4V5kla6nc3LIA0oyjz99Gosv8IAj9vFkreQ5QRqpTIlu1ecDL9JY9dQ==",
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/@electron-forge/maker-dmg/-/maker-dmg-7.9.0.tgz",
+      "integrity": "sha512-W3kqbFuBIqxe/56eZmBv80Fw0RdXIL1DXF0D4O56ILnx7jW/d/j+8fJdie5dcw6nBySDIZbWnxsZiOIV2k2hrg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@electron-forge/maker-base": "7.8.3",
-        "@electron-forge/shared-types": "7.8.3",
+        "@electron-forge/maker-base": "7.9.0",
+        "@electron-forge/shared-types": "7.9.0",
         "fs-extra": "^10.0.0"
       },
       "engines": {
@@ -942,6 +848,7 @@
       "resolved": "https://registry.npmjs.org/@electron-forge/maker-flatpak/-/maker-flatpak-7.9.0.tgz",
       "integrity": "sha512-LqFWp61+ozlioFtqu+UryKjdsIdv+BLunDDjMRcdoMqiAblURz8bRgqq8FAdshiUt+iq4NPz6K9N0dKtSjhvuA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@electron-forge/maker-base": "7.9.0",
         "@electron-forge/shared-types": "7.9.0",
@@ -954,56 +861,15 @@
         "@malept/electron-installer-flatpak": "^0.11.4"
       }
     },
-    "node_modules/@electron-forge/maker-flatpak/node_modules/@electron-forge/maker-base": {
-      "version": "7.9.0",
-      "resolved": "https://registry.npmjs.org/@electron-forge/maker-base/-/maker-base-7.9.0.tgz",
-      "integrity": "sha512-u0jo2kaYRxh/Rai6DyFSGJcNLRVWxiKaGUjMhX1LrKolufUkCxxR4TEmv4Hvl03WTr9pQb06umlIrVMaNb+j9A==",
-      "dev": true,
-      "dependencies": {
-        "@electron-forge/shared-types": "7.9.0",
-        "fs-extra": "^10.0.0",
-        "which": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 16.4.0"
-      }
-    },
-    "node_modules/@electron-forge/maker-flatpak/node_modules/@electron-forge/shared-types": {
-      "version": "7.9.0",
-      "resolved": "https://registry.npmjs.org/@electron-forge/shared-types/-/shared-types-7.9.0.tgz",
-      "integrity": "sha512-6jZF+zq3SYMnweQpgr5fwlSgOd2yOZ5qlfz/CgXyVljiv0e0UThzpOjfTLuwuVgZX7a60xV+h0mg1h82Glu3wQ==",
-      "dev": true,
-      "dependencies": {
-        "@electron-forge/tracer": "7.9.0",
-        "@electron/packager": "^18.3.5",
-        "@electron/rebuild": "^3.7.0",
-        "listr2": "^7.0.2"
-      },
-      "engines": {
-        "node": ">= 16.4.0"
-      }
-    },
-    "node_modules/@electron-forge/maker-flatpak/node_modules/@electron-forge/tracer": {
-      "version": "7.9.0",
-      "resolved": "https://registry.npmjs.org/@electron-forge/tracer/-/tracer-7.9.0.tgz",
-      "integrity": "sha512-7itsjW1WJQADg7Ly61ggI5CCRt+QDVx3HOZC1w69jMUtnipKyPRCbvTBf1oplsNqbIzZxceXdfex6W53YNehvA==",
-      "dev": true,
-      "dependencies": {
-        "chrome-trace-event": "^1.0.3"
-      },
-      "engines": {
-        "node": ">= 14.17.5"
-      }
-    },
     "node_modules/@electron-forge/maker-squirrel": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@electron-forge/maker-squirrel/-/maker-squirrel-7.8.3.tgz",
-      "integrity": "sha512-6XSEhZMbgfjAaCm8A54pNjn4ghfxJgPu4i7ok3PhP44WOrFPaPivLttpvKRnxRb0PGZstPjPBFcwL1F9S1trjA==",
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/@electron-forge/maker-squirrel/-/maker-squirrel-7.9.0.tgz",
+      "integrity": "sha512-Ea3MrieWC1KRct1QSZeOBY+GIqHZO5bXj6xCuj81f6nz8JMCsXdgvKosdbfcJMSKu4SYZ52PtoweA6uAACfLww==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@electron-forge/maker-base": "7.8.3",
-        "@electron-forge/shared-types": "7.8.3",
+        "@electron-forge/maker-base": "7.9.0",
+        "@electron-forge/shared-types": "7.9.0",
         "fs-extra": "^10.0.0"
       },
       "engines": {
@@ -1018,6 +884,7 @@
       "resolved": "https://registry.npmjs.org/@electron-forge/maker-wix/-/maker-wix-7.9.0.tgz",
       "integrity": "sha512-Sve5ewRV3dhy1EIVNjLvc/3wYuTBqb2L0jtrcXuDYtX58bc4wFuHmDXkp5EwuNMx2QS+VPNfd1KCGWBV1ybj7w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@electron-forge/maker-base": "7.9.0",
         "@electron-forge/shared-types": "7.9.0",
@@ -1031,52 +898,12 @@
         "node": ">= 16.4.0"
       }
     },
-    "node_modules/@electron-forge/maker-wix/node_modules/@electron-forge/maker-base": {
-      "version": "7.9.0",
-      "resolved": "https://registry.npmjs.org/@electron-forge/maker-base/-/maker-base-7.9.0.tgz",
-      "integrity": "sha512-u0jo2kaYRxh/Rai6DyFSGJcNLRVWxiKaGUjMhX1LrKolufUkCxxR4TEmv4Hvl03WTr9pQb06umlIrVMaNb+j9A==",
-      "dev": true,
-      "dependencies": {
-        "@electron-forge/shared-types": "7.9.0",
-        "fs-extra": "^10.0.0",
-        "which": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 16.4.0"
-      }
-    },
-    "node_modules/@electron-forge/maker-wix/node_modules/@electron-forge/shared-types": {
-      "version": "7.9.0",
-      "resolved": "https://registry.npmjs.org/@electron-forge/shared-types/-/shared-types-7.9.0.tgz",
-      "integrity": "sha512-6jZF+zq3SYMnweQpgr5fwlSgOd2yOZ5qlfz/CgXyVljiv0e0UThzpOjfTLuwuVgZX7a60xV+h0mg1h82Glu3wQ==",
-      "dev": true,
-      "dependencies": {
-        "@electron-forge/tracer": "7.9.0",
-        "@electron/packager": "^18.3.5",
-        "@electron/rebuild": "^3.7.0",
-        "listr2": "^7.0.2"
-      },
-      "engines": {
-        "node": ">= 16.4.0"
-      }
-    },
-    "node_modules/@electron-forge/maker-wix/node_modules/@electron-forge/tracer": {
-      "version": "7.9.0",
-      "resolved": "https://registry.npmjs.org/@electron-forge/tracer/-/tracer-7.9.0.tgz",
-      "integrity": "sha512-7itsjW1WJQADg7Ly61ggI5CCRt+QDVx3HOZC1w69jMUtnipKyPRCbvTBf1oplsNqbIzZxceXdfex6W53YNehvA==",
-      "dev": true,
-      "dependencies": {
-        "chrome-trace-event": "^1.0.3"
-      },
-      "engines": {
-        "node": ">= 14.17.5"
-      }
-    },
     "node_modules/@electron-forge/maker-zip": {
       "version": "7.9.0",
       "resolved": "https://registry.npmjs.org/@electron-forge/maker-zip/-/maker-zip-7.9.0.tgz",
       "integrity": "sha512-UGeziReiz8yuDTjliOjvbdyulIHpKAWkDeW3kOcMTUmRcCgrCkBNr+Pp6ih8Q3aBhG+CCd4++oe2rDnnuVvxFw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@electron-forge/maker-base": "7.9.0",
         "@electron-forge/shared-types": "7.9.0",
@@ -1086,47 +913,6 @@
       },
       "engines": {
         "node": ">= 16.4.0"
-      }
-    },
-    "node_modules/@electron-forge/maker-zip/node_modules/@electron-forge/maker-base": {
-      "version": "7.9.0",
-      "resolved": "https://registry.npmjs.org/@electron-forge/maker-base/-/maker-base-7.9.0.tgz",
-      "integrity": "sha512-u0jo2kaYRxh/Rai6DyFSGJcNLRVWxiKaGUjMhX1LrKolufUkCxxR4TEmv4Hvl03WTr9pQb06umlIrVMaNb+j9A==",
-      "dev": true,
-      "dependencies": {
-        "@electron-forge/shared-types": "7.9.0",
-        "fs-extra": "^10.0.0",
-        "which": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 16.4.0"
-      }
-    },
-    "node_modules/@electron-forge/maker-zip/node_modules/@electron-forge/shared-types": {
-      "version": "7.9.0",
-      "resolved": "https://registry.npmjs.org/@electron-forge/shared-types/-/shared-types-7.9.0.tgz",
-      "integrity": "sha512-6jZF+zq3SYMnweQpgr5fwlSgOd2yOZ5qlfz/CgXyVljiv0e0UThzpOjfTLuwuVgZX7a60xV+h0mg1h82Glu3wQ==",
-      "dev": true,
-      "dependencies": {
-        "@electron-forge/tracer": "7.9.0",
-        "@electron/packager": "^18.3.5",
-        "@electron/rebuild": "^3.7.0",
-        "listr2": "^7.0.2"
-      },
-      "engines": {
-        "node": ">= 16.4.0"
-      }
-    },
-    "node_modules/@electron-forge/maker-zip/node_modules/@electron-forge/tracer": {
-      "version": "7.9.0",
-      "resolved": "https://registry.npmjs.org/@electron-forge/tracer/-/tracer-7.9.0.tgz",
-      "integrity": "sha512-7itsjW1WJQADg7Ly61ggI5CCRt+QDVx3HOZC1w69jMUtnipKyPRCbvTBf1oplsNqbIzZxceXdfex6W53YNehvA==",
-      "dev": true,
-      "dependencies": {
-        "chrome-trace-event": "^1.0.3"
-      },
-      "engines": {
-        "node": ">= 14.17.5"
       }
     },
     "node_modules/@electron-forge/plugin-base": {
@@ -1139,33 +925,6 @@
       },
       "engines": {
         "node": ">= 16.4.0"
-      }
-    },
-    "node_modules/@electron-forge/plugin-base/node_modules/@electron-forge/shared-types": {
-      "version": "7.9.0",
-      "resolved": "https://registry.npmjs.org/@electron-forge/shared-types/-/shared-types-7.9.0.tgz",
-      "integrity": "sha512-6jZF+zq3SYMnweQpgr5fwlSgOd2yOZ5qlfz/CgXyVljiv0e0UThzpOjfTLuwuVgZX7a60xV+h0mg1h82Glu3wQ==",
-      "dev": true,
-      "dependencies": {
-        "@electron-forge/tracer": "7.9.0",
-        "@electron/packager": "^18.3.5",
-        "@electron/rebuild": "^3.7.0",
-        "listr2": "^7.0.2"
-      },
-      "engines": {
-        "node": ">= 16.4.0"
-      }
-    },
-    "node_modules/@electron-forge/plugin-base/node_modules/@electron-forge/tracer": {
-      "version": "7.9.0",
-      "resolved": "https://registry.npmjs.org/@electron-forge/tracer/-/tracer-7.9.0.tgz",
-      "integrity": "sha512-7itsjW1WJQADg7Ly61ggI5CCRt+QDVx3HOZC1w69jMUtnipKyPRCbvTBf1oplsNqbIzZxceXdfex6W53YNehvA==",
-      "dev": true,
-      "dependencies": {
-        "chrome-trace-event": "^1.0.3"
-      },
-      "engines": {
-        "node": ">= 14.17.5"
       }
     },
     "node_modules/@electron-forge/plugin-webpack": {
@@ -1190,33 +949,6 @@
       },
       "engines": {
         "node": ">= 16.4.0"
-      }
-    },
-    "node_modules/@electron-forge/plugin-webpack/node_modules/@electron-forge/shared-types": {
-      "version": "7.9.0",
-      "resolved": "https://registry.npmjs.org/@electron-forge/shared-types/-/shared-types-7.9.0.tgz",
-      "integrity": "sha512-6jZF+zq3SYMnweQpgr5fwlSgOd2yOZ5qlfz/CgXyVljiv0e0UThzpOjfTLuwuVgZX7a60xV+h0mg1h82Glu3wQ==",
-      "dev": true,
-      "dependencies": {
-        "@electron-forge/tracer": "7.9.0",
-        "@electron/packager": "^18.3.5",
-        "@electron/rebuild": "^3.7.0",
-        "listr2": "^7.0.2"
-      },
-      "engines": {
-        "node": ">= 16.4.0"
-      }
-    },
-    "node_modules/@electron-forge/plugin-webpack/node_modules/@electron-forge/tracer": {
-      "version": "7.9.0",
-      "resolved": "https://registry.npmjs.org/@electron-forge/tracer/-/tracer-7.9.0.tgz",
-      "integrity": "sha512-7itsjW1WJQADg7Ly61ggI5CCRt+QDVx3HOZC1w69jMUtnipKyPRCbvTBf1oplsNqbIzZxceXdfex6W53YNehvA==",
-      "dev": true,
-      "dependencies": {
-        "chrome-trace-event": "^1.0.3"
-      },
-      "engines": {
-        "node": ">= 14.17.5"
       }
     },
     "node_modules/@electron-forge/plugin-webpack/node_modules/@types/retry": {
@@ -1564,41 +1296,14 @@
         "node": ">= 16.4.0"
       }
     },
-    "node_modules/@electron-forge/publisher-base/node_modules/@electron-forge/shared-types": {
+    "node_modules/@electron-forge/shared-types": {
       "version": "7.9.0",
       "resolved": "https://registry.npmjs.org/@electron-forge/shared-types/-/shared-types-7.9.0.tgz",
       "integrity": "sha512-6jZF+zq3SYMnweQpgr5fwlSgOd2yOZ5qlfz/CgXyVljiv0e0UThzpOjfTLuwuVgZX7a60xV+h0mg1h82Glu3wQ==",
       "dev": true,
-      "dependencies": {
-        "@electron-forge/tracer": "7.9.0",
-        "@electron/packager": "^18.3.5",
-        "@electron/rebuild": "^3.7.0",
-        "listr2": "^7.0.2"
-      },
-      "engines": {
-        "node": ">= 16.4.0"
-      }
-    },
-    "node_modules/@electron-forge/publisher-base/node_modules/@electron-forge/tracer": {
-      "version": "7.9.0",
-      "resolved": "https://registry.npmjs.org/@electron-forge/tracer/-/tracer-7.9.0.tgz",
-      "integrity": "sha512-7itsjW1WJQADg7Ly61ggI5CCRt+QDVx3HOZC1w69jMUtnipKyPRCbvTBf1oplsNqbIzZxceXdfex6W53YNehvA==",
-      "dev": true,
-      "dependencies": {
-        "chrome-trace-event": "^1.0.3"
-      },
-      "engines": {
-        "node": ">= 14.17.5"
-      }
-    },
-    "node_modules/@electron-forge/shared-types": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@electron-forge/shared-types/-/shared-types-7.8.3.tgz",
-      "integrity": "sha512-gkZtD7ALXHPDOthJo1rQYLDNfG09fdDRMWvjEgaXdF3Z69xXFfnOWPNuOkRUODNalMnuuGs6l7jDl+QFQgHlDg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@electron-forge/tracer": "7.8.3",
+        "@electron-forge/tracer": "7.9.0",
         "@electron/packager": "^18.3.5",
         "@electron/rebuild": "^3.7.0",
         "listr2": "^7.0.2"
@@ -1623,33 +1328,6 @@
       },
       "engines": {
         "node": ">= 16.4.0"
-      }
-    },
-    "node_modules/@electron-forge/template-base/node_modules/@electron-forge/shared-types": {
-      "version": "7.9.0",
-      "resolved": "https://registry.npmjs.org/@electron-forge/shared-types/-/shared-types-7.9.0.tgz",
-      "integrity": "sha512-6jZF+zq3SYMnweQpgr5fwlSgOd2yOZ5qlfz/CgXyVljiv0e0UThzpOjfTLuwuVgZX7a60xV+h0mg1h82Glu3wQ==",
-      "dev": true,
-      "dependencies": {
-        "@electron-forge/tracer": "7.9.0",
-        "@electron/packager": "^18.3.5",
-        "@electron/rebuild": "^3.7.0",
-        "listr2": "^7.0.2"
-      },
-      "engines": {
-        "node": ">= 16.4.0"
-      }
-    },
-    "node_modules/@electron-forge/template-base/node_modules/@electron-forge/tracer": {
-      "version": "7.9.0",
-      "resolved": "https://registry.npmjs.org/@electron-forge/tracer/-/tracer-7.9.0.tgz",
-      "integrity": "sha512-7itsjW1WJQADg7Ly61ggI5CCRt+QDVx3HOZC1w69jMUtnipKyPRCbvTBf1oplsNqbIzZxceXdfex6W53YNehvA==",
-      "dev": true,
-      "dependencies": {
-        "chrome-trace-event": "^1.0.3"
-      },
-      "engines": {
-        "node": ">= 14.17.5"
       }
     },
     "node_modules/@electron-forge/template-base/node_modules/debug": {
@@ -1703,60 +1381,6 @@
         "node": ">= 16.4.0"
       }
     },
-    "node_modules/@electron-forge/template-vite-typescript/node_modules/@electron-forge/shared-types": {
-      "version": "7.9.0",
-      "resolved": "https://registry.npmjs.org/@electron-forge/shared-types/-/shared-types-7.9.0.tgz",
-      "integrity": "sha512-6jZF+zq3SYMnweQpgr5fwlSgOd2yOZ5qlfz/CgXyVljiv0e0UThzpOjfTLuwuVgZX7a60xV+h0mg1h82Glu3wQ==",
-      "dev": true,
-      "dependencies": {
-        "@electron-forge/tracer": "7.9.0",
-        "@electron/packager": "^18.3.5",
-        "@electron/rebuild": "^3.7.0",
-        "listr2": "^7.0.2"
-      },
-      "engines": {
-        "node": ">= 16.4.0"
-      }
-    },
-    "node_modules/@electron-forge/template-vite-typescript/node_modules/@electron-forge/tracer": {
-      "version": "7.9.0",
-      "resolved": "https://registry.npmjs.org/@electron-forge/tracer/-/tracer-7.9.0.tgz",
-      "integrity": "sha512-7itsjW1WJQADg7Ly61ggI5CCRt+QDVx3HOZC1w69jMUtnipKyPRCbvTBf1oplsNqbIzZxceXdfex6W53YNehvA==",
-      "dev": true,
-      "dependencies": {
-        "chrome-trace-event": "^1.0.3"
-      },
-      "engines": {
-        "node": ">= 14.17.5"
-      }
-    },
-    "node_modules/@electron-forge/template-vite/node_modules/@electron-forge/shared-types": {
-      "version": "7.9.0",
-      "resolved": "https://registry.npmjs.org/@electron-forge/shared-types/-/shared-types-7.9.0.tgz",
-      "integrity": "sha512-6jZF+zq3SYMnweQpgr5fwlSgOd2yOZ5qlfz/CgXyVljiv0e0UThzpOjfTLuwuVgZX7a60xV+h0mg1h82Glu3wQ==",
-      "dev": true,
-      "dependencies": {
-        "@electron-forge/tracer": "7.9.0",
-        "@electron/packager": "^18.3.5",
-        "@electron/rebuild": "^3.7.0",
-        "listr2": "^7.0.2"
-      },
-      "engines": {
-        "node": ">= 16.4.0"
-      }
-    },
-    "node_modules/@electron-forge/template-vite/node_modules/@electron-forge/tracer": {
-      "version": "7.9.0",
-      "resolved": "https://registry.npmjs.org/@electron-forge/tracer/-/tracer-7.9.0.tgz",
-      "integrity": "sha512-7itsjW1WJQADg7Ly61ggI5CCRt+QDVx3HOZC1w69jMUtnipKyPRCbvTBf1oplsNqbIzZxceXdfex6W53YNehvA==",
-      "dev": true,
-      "dependencies": {
-        "chrome-trace-event": "^1.0.3"
-      },
-      "engines": {
-        "node": ">= 14.17.5"
-      }
-    },
     "node_modules/@electron-forge/template-webpack": {
       "version": "7.9.0",
       "resolved": "https://registry.npmjs.org/@electron-forge/template-webpack/-/template-webpack-7.9.0.tgz",
@@ -1785,64 +1409,10 @@
         "node": ">= 16.4.0"
       }
     },
-    "node_modules/@electron-forge/template-webpack-typescript/node_modules/@electron-forge/shared-types": {
-      "version": "7.9.0",
-      "resolved": "https://registry.npmjs.org/@electron-forge/shared-types/-/shared-types-7.9.0.tgz",
-      "integrity": "sha512-6jZF+zq3SYMnweQpgr5fwlSgOd2yOZ5qlfz/CgXyVljiv0e0UThzpOjfTLuwuVgZX7a60xV+h0mg1h82Glu3wQ==",
-      "dev": true,
-      "dependencies": {
-        "@electron-forge/tracer": "7.9.0",
-        "@electron/packager": "^18.3.5",
-        "@electron/rebuild": "^3.7.0",
-        "listr2": "^7.0.2"
-      },
-      "engines": {
-        "node": ">= 16.4.0"
-      }
-    },
-    "node_modules/@electron-forge/template-webpack-typescript/node_modules/@electron-forge/tracer": {
-      "version": "7.9.0",
-      "resolved": "https://registry.npmjs.org/@electron-forge/tracer/-/tracer-7.9.0.tgz",
-      "integrity": "sha512-7itsjW1WJQADg7Ly61ggI5CCRt+QDVx3HOZC1w69jMUtnipKyPRCbvTBf1oplsNqbIzZxceXdfex6W53YNehvA==",
-      "dev": true,
-      "dependencies": {
-        "chrome-trace-event": "^1.0.3"
-      },
-      "engines": {
-        "node": ">= 14.17.5"
-      }
-    },
-    "node_modules/@electron-forge/template-webpack/node_modules/@electron-forge/shared-types": {
-      "version": "7.9.0",
-      "resolved": "https://registry.npmjs.org/@electron-forge/shared-types/-/shared-types-7.9.0.tgz",
-      "integrity": "sha512-6jZF+zq3SYMnweQpgr5fwlSgOd2yOZ5qlfz/CgXyVljiv0e0UThzpOjfTLuwuVgZX7a60xV+h0mg1h82Glu3wQ==",
-      "dev": true,
-      "dependencies": {
-        "@electron-forge/tracer": "7.9.0",
-        "@electron/packager": "^18.3.5",
-        "@electron/rebuild": "^3.7.0",
-        "listr2": "^7.0.2"
-      },
-      "engines": {
-        "node": ">= 16.4.0"
-      }
-    },
-    "node_modules/@electron-forge/template-webpack/node_modules/@electron-forge/tracer": {
-      "version": "7.9.0",
-      "resolved": "https://registry.npmjs.org/@electron-forge/tracer/-/tracer-7.9.0.tgz",
-      "integrity": "sha512-7itsjW1WJQADg7Ly61ggI5CCRt+QDVx3HOZC1w69jMUtnipKyPRCbvTBf1oplsNqbIzZxceXdfex6W53YNehvA==",
-      "dev": true,
-      "dependencies": {
-        "chrome-trace-event": "^1.0.3"
-      },
-      "engines": {
-        "node": ">= 14.17.5"
-      }
-    },
     "node_modules/@electron-forge/tracer": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@electron-forge/tracer/-/tracer-7.8.3.tgz",
-      "integrity": "sha512-YVVDaPEUOvR1z+DDdj8wR/vO9OSlC91wz4/2Iqe9rqQz8sztnnQBClMAZTqu9bkDTFyHrns8j8v7tPVuVS6ULQ==",
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/@electron-forge/tracer/-/tracer-7.9.0.tgz",
+      "integrity": "sha512-7itsjW1WJQADg7Ly61ggI5CCRt+QDVx3HOZC1w69jMUtnipKyPRCbvTBf1oplsNqbIzZxceXdfex6W53YNehvA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -19767,27 +19337,6 @@
         "semver": "^7.2.1"
       },
       "dependencies": {
-        "@electron-forge/shared-types": {
-          "version": "7.9.0",
-          "resolved": "https://registry.npmjs.org/@electron-forge/shared-types/-/shared-types-7.9.0.tgz",
-          "integrity": "sha512-6jZF+zq3SYMnweQpgr5fwlSgOd2yOZ5qlfz/CgXyVljiv0e0UThzpOjfTLuwuVgZX7a60xV+h0mg1h82Glu3wQ==",
-          "dev": true,
-          "requires": {
-            "@electron-forge/tracer": "7.9.0",
-            "@electron/packager": "^18.3.5",
-            "@electron/rebuild": "^3.7.0",
-            "listr2": "^7.0.2"
-          }
-        },
-        "@electron-forge/tracer": {
-          "version": "7.9.0",
-          "resolved": "https://registry.npmjs.org/@electron-forge/tracer/-/tracer-7.9.0.tgz",
-          "integrity": "sha512-7itsjW1WJQADg7Ly61ggI5CCRt+QDVx3HOZC1w69jMUtnipKyPRCbvTBf1oplsNqbIzZxceXdfex6W53YNehvA==",
-          "dev": true,
-          "requires": {
-            "chrome-trace-event": "^1.0.3"
-          }
-        },
         "@electron/get": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/@electron/get/-/get-3.0.0.tgz",
@@ -19893,38 +19442,6 @@
         "username": "^5.1.0"
       },
       "dependencies": {
-        "@electron-forge/maker-base": {
-          "version": "7.9.0",
-          "resolved": "https://registry.npmjs.org/@electron-forge/maker-base/-/maker-base-7.9.0.tgz",
-          "integrity": "sha512-u0jo2kaYRxh/Rai6DyFSGJcNLRVWxiKaGUjMhX1LrKolufUkCxxR4TEmv4Hvl03WTr9pQb06umlIrVMaNb+j9A==",
-          "dev": true,
-          "requires": {
-            "@electron-forge/shared-types": "7.9.0",
-            "fs-extra": "^10.0.0",
-            "which": "^2.0.2"
-          }
-        },
-        "@electron-forge/shared-types": {
-          "version": "7.9.0",
-          "resolved": "https://registry.npmjs.org/@electron-forge/shared-types/-/shared-types-7.9.0.tgz",
-          "integrity": "sha512-6jZF+zq3SYMnweQpgr5fwlSgOd2yOZ5qlfz/CgXyVljiv0e0UThzpOjfTLuwuVgZX7a60xV+h0mg1h82Glu3wQ==",
-          "dev": true,
-          "requires": {
-            "@electron-forge/tracer": "7.9.0",
-            "@electron/packager": "^18.3.5",
-            "@electron/rebuild": "^3.7.0",
-            "listr2": "^7.0.2"
-          }
-        },
-        "@electron-forge/tracer": {
-          "version": "7.9.0",
-          "resolved": "https://registry.npmjs.org/@electron-forge/tracer/-/tracer-7.9.0.tgz",
-          "integrity": "sha512-7itsjW1WJQADg7Ly61ggI5CCRt+QDVx3HOZC1w69jMUtnipKyPRCbvTBf1oplsNqbIzZxceXdfex6W53YNehvA==",
-          "dev": true,
-          "requires": {
-            "chrome-trace-event": "^1.0.3"
-          }
-        },
         "@electron/get": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/@electron/get/-/get-3.1.0.tgz",
@@ -20009,27 +19526,6 @@
         "semver": "^7.2.1"
       },
       "dependencies": {
-        "@electron-forge/shared-types": {
-          "version": "7.9.0",
-          "resolved": "https://registry.npmjs.org/@electron-forge/shared-types/-/shared-types-7.9.0.tgz",
-          "integrity": "sha512-6jZF+zq3SYMnweQpgr5fwlSgOd2yOZ5qlfz/CgXyVljiv0e0UThzpOjfTLuwuVgZX7a60xV+h0mg1h82Glu3wQ==",
-          "dev": true,
-          "requires": {
-            "@electron-forge/tracer": "7.9.0",
-            "@electron/packager": "^18.3.5",
-            "@electron/rebuild": "^3.7.0",
-            "listr2": "^7.0.2"
-          }
-        },
-        "@electron-forge/tracer": {
-          "version": "7.9.0",
-          "resolved": "https://registry.npmjs.org/@electron-forge/tracer/-/tracer-7.9.0.tgz",
-          "integrity": "sha512-7itsjW1WJQADg7Ly61ggI5CCRt+QDVx3HOZC1w69jMUtnipKyPRCbvTBf1oplsNqbIzZxceXdfex6W53YNehvA==",
-          "dev": true,
-          "requires": {
-            "chrome-trace-event": "^1.0.3"
-          }
-        },
         "debug": {
           "version": "4.4.3",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -20048,24 +19544,24 @@
       }
     },
     "@electron-forge/maker-base": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@electron-forge/maker-base/-/maker-base-7.8.3.tgz",
-      "integrity": "sha512-WmF66cHdziaK8Asi7IRTLxZjCZ8IqXXHr6IPl4d5oatN6s5RG+HHzG1hiJ7LzlOEntqdSpE8Wh2nB2TmyR4huQ==",
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/@electron-forge/maker-base/-/maker-base-7.9.0.tgz",
+      "integrity": "sha512-u0jo2kaYRxh/Rai6DyFSGJcNLRVWxiKaGUjMhX1LrKolufUkCxxR4TEmv4Hvl03WTr9pQb06umlIrVMaNb+j9A==",
       "dev": true,
       "requires": {
-        "@electron-forge/shared-types": "7.8.3",
+        "@electron-forge/shared-types": "7.9.0",
         "fs-extra": "^10.0.0",
         "which": "^2.0.2"
       }
     },
     "@electron-forge/maker-dmg": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@electron-forge/maker-dmg/-/maker-dmg-7.8.3.tgz",
-      "integrity": "sha512-N3yKU89D7pC/xPeblSQyBQT1DLKzZMl4V5kla6nc3LIA0oyjz99Gosv8IAj9vFkreQ5QRqpTIlu1ecDL9JY9dQ==",
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/@electron-forge/maker-dmg/-/maker-dmg-7.9.0.tgz",
+      "integrity": "sha512-W3kqbFuBIqxe/56eZmBv80Fw0RdXIL1DXF0D4O56ILnx7jW/d/j+8fJdie5dcw6nBySDIZbWnxsZiOIV2k2hrg==",
       "dev": true,
       "requires": {
-        "@electron-forge/maker-base": "7.8.3",
-        "@electron-forge/shared-types": "7.8.3",
+        "@electron-forge/maker-base": "7.9.0",
+        "@electron-forge/shared-types": "7.9.0",
         "electron-installer-dmg": "^5.0.1",
         "fs-extra": "^10.0.0"
       }
@@ -20080,50 +19576,16 @@
         "@electron-forge/shared-types": "7.9.0",
         "@malept/electron-installer-flatpak": "^0.11.4",
         "fs-extra": "^10.0.0"
-      },
-      "dependencies": {
-        "@electron-forge/maker-base": {
-          "version": "7.9.0",
-          "resolved": "https://registry.npmjs.org/@electron-forge/maker-base/-/maker-base-7.9.0.tgz",
-          "integrity": "sha512-u0jo2kaYRxh/Rai6DyFSGJcNLRVWxiKaGUjMhX1LrKolufUkCxxR4TEmv4Hvl03WTr9pQb06umlIrVMaNb+j9A==",
-          "dev": true,
-          "requires": {
-            "@electron-forge/shared-types": "7.9.0",
-            "fs-extra": "^10.0.0",
-            "which": "^2.0.2"
-          }
-        },
-        "@electron-forge/shared-types": {
-          "version": "7.9.0",
-          "resolved": "https://registry.npmjs.org/@electron-forge/shared-types/-/shared-types-7.9.0.tgz",
-          "integrity": "sha512-6jZF+zq3SYMnweQpgr5fwlSgOd2yOZ5qlfz/CgXyVljiv0e0UThzpOjfTLuwuVgZX7a60xV+h0mg1h82Glu3wQ==",
-          "dev": true,
-          "requires": {
-            "@electron-forge/tracer": "7.9.0",
-            "@electron/packager": "^18.3.5",
-            "@electron/rebuild": "^3.7.0",
-            "listr2": "^7.0.2"
-          }
-        },
-        "@electron-forge/tracer": {
-          "version": "7.9.0",
-          "resolved": "https://registry.npmjs.org/@electron-forge/tracer/-/tracer-7.9.0.tgz",
-          "integrity": "sha512-7itsjW1WJQADg7Ly61ggI5CCRt+QDVx3HOZC1w69jMUtnipKyPRCbvTBf1oplsNqbIzZxceXdfex6W53YNehvA==",
-          "dev": true,
-          "requires": {
-            "chrome-trace-event": "^1.0.3"
-          }
-        }
       }
     },
     "@electron-forge/maker-squirrel": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@electron-forge/maker-squirrel/-/maker-squirrel-7.8.3.tgz",
-      "integrity": "sha512-6XSEhZMbgfjAaCm8A54pNjn4ghfxJgPu4i7ok3PhP44WOrFPaPivLttpvKRnxRb0PGZstPjPBFcwL1F9S1trjA==",
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/@electron-forge/maker-squirrel/-/maker-squirrel-7.9.0.tgz",
+      "integrity": "sha512-Ea3MrieWC1KRct1QSZeOBY+GIqHZO5bXj6xCuj81f6nz8JMCsXdgvKosdbfcJMSKu4SYZ52PtoweA6uAACfLww==",
       "dev": true,
       "requires": {
-        "@electron-forge/maker-base": "7.8.3",
-        "@electron-forge/shared-types": "7.8.3",
+        "@electron-forge/maker-base": "7.9.0",
+        "@electron-forge/shared-types": "7.9.0",
         "electron-winstaller": "^5.3.0",
         "fs-extra": "^10.0.0"
       }
@@ -20141,40 +19603,6 @@
         "log-symbols": "^4.0.0",
         "parse-author": "^2.0.0",
         "semver": "^7.2.1"
-      },
-      "dependencies": {
-        "@electron-forge/maker-base": {
-          "version": "7.9.0",
-          "resolved": "https://registry.npmjs.org/@electron-forge/maker-base/-/maker-base-7.9.0.tgz",
-          "integrity": "sha512-u0jo2kaYRxh/Rai6DyFSGJcNLRVWxiKaGUjMhX1LrKolufUkCxxR4TEmv4Hvl03WTr9pQb06umlIrVMaNb+j9A==",
-          "dev": true,
-          "requires": {
-            "@electron-forge/shared-types": "7.9.0",
-            "fs-extra": "^10.0.0",
-            "which": "^2.0.2"
-          }
-        },
-        "@electron-forge/shared-types": {
-          "version": "7.9.0",
-          "resolved": "https://registry.npmjs.org/@electron-forge/shared-types/-/shared-types-7.9.0.tgz",
-          "integrity": "sha512-6jZF+zq3SYMnweQpgr5fwlSgOd2yOZ5qlfz/CgXyVljiv0e0UThzpOjfTLuwuVgZX7a60xV+h0mg1h82Glu3wQ==",
-          "dev": true,
-          "requires": {
-            "@electron-forge/tracer": "7.9.0",
-            "@electron/packager": "^18.3.5",
-            "@electron/rebuild": "^3.7.0",
-            "listr2": "^7.0.2"
-          }
-        },
-        "@electron-forge/tracer": {
-          "version": "7.9.0",
-          "resolved": "https://registry.npmjs.org/@electron-forge/tracer/-/tracer-7.9.0.tgz",
-          "integrity": "sha512-7itsjW1WJQADg7Ly61ggI5CCRt+QDVx3HOZC1w69jMUtnipKyPRCbvTBf1oplsNqbIzZxceXdfex6W53YNehvA==",
-          "dev": true,
-          "requires": {
-            "chrome-trace-event": "^1.0.3"
-          }
-        }
       }
     },
     "@electron-forge/maker-zip": {
@@ -20188,40 +19616,6 @@
         "cross-zip": "^4.0.0",
         "fs-extra": "^10.0.0",
         "got": "^11.8.5"
-      },
-      "dependencies": {
-        "@electron-forge/maker-base": {
-          "version": "7.9.0",
-          "resolved": "https://registry.npmjs.org/@electron-forge/maker-base/-/maker-base-7.9.0.tgz",
-          "integrity": "sha512-u0jo2kaYRxh/Rai6DyFSGJcNLRVWxiKaGUjMhX1LrKolufUkCxxR4TEmv4Hvl03WTr9pQb06umlIrVMaNb+j9A==",
-          "dev": true,
-          "requires": {
-            "@electron-forge/shared-types": "7.9.0",
-            "fs-extra": "^10.0.0",
-            "which": "^2.0.2"
-          }
-        },
-        "@electron-forge/shared-types": {
-          "version": "7.9.0",
-          "resolved": "https://registry.npmjs.org/@electron-forge/shared-types/-/shared-types-7.9.0.tgz",
-          "integrity": "sha512-6jZF+zq3SYMnweQpgr5fwlSgOd2yOZ5qlfz/CgXyVljiv0e0UThzpOjfTLuwuVgZX7a60xV+h0mg1h82Glu3wQ==",
-          "dev": true,
-          "requires": {
-            "@electron-forge/tracer": "7.9.0",
-            "@electron/packager": "^18.3.5",
-            "@electron/rebuild": "^3.7.0",
-            "listr2": "^7.0.2"
-          }
-        },
-        "@electron-forge/tracer": {
-          "version": "7.9.0",
-          "resolved": "https://registry.npmjs.org/@electron-forge/tracer/-/tracer-7.9.0.tgz",
-          "integrity": "sha512-7itsjW1WJQADg7Ly61ggI5CCRt+QDVx3HOZC1w69jMUtnipKyPRCbvTBf1oplsNqbIzZxceXdfex6W53YNehvA==",
-          "dev": true,
-          "requires": {
-            "chrome-trace-event": "^1.0.3"
-          }
-        }
       }
     },
     "@electron-forge/plugin-base": {
@@ -20231,29 +19625,6 @@
       "dev": true,
       "requires": {
         "@electron-forge/shared-types": "7.9.0"
-      },
-      "dependencies": {
-        "@electron-forge/shared-types": {
-          "version": "7.9.0",
-          "resolved": "https://registry.npmjs.org/@electron-forge/shared-types/-/shared-types-7.9.0.tgz",
-          "integrity": "sha512-6jZF+zq3SYMnweQpgr5fwlSgOd2yOZ5qlfz/CgXyVljiv0e0UThzpOjfTLuwuVgZX7a60xV+h0mg1h82Glu3wQ==",
-          "dev": true,
-          "requires": {
-            "@electron-forge/tracer": "7.9.0",
-            "@electron/packager": "^18.3.5",
-            "@electron/rebuild": "^3.7.0",
-            "listr2": "^7.0.2"
-          }
-        },
-        "@electron-forge/tracer": {
-          "version": "7.9.0",
-          "resolved": "https://registry.npmjs.org/@electron-forge/tracer/-/tracer-7.9.0.tgz",
-          "integrity": "sha512-7itsjW1WJQADg7Ly61ggI5CCRt+QDVx3HOZC1w69jMUtnipKyPRCbvTBf1oplsNqbIzZxceXdfex6W53YNehvA==",
-          "dev": true,
-          "requires": {
-            "chrome-trace-event": "^1.0.3"
-          }
-        }
       }
     },
     "@electron-forge/plugin-webpack": {
@@ -20277,27 +19648,6 @@
         "webpack-merge": "^5.7.3"
       },
       "dependencies": {
-        "@electron-forge/shared-types": {
-          "version": "7.9.0",
-          "resolved": "https://registry.npmjs.org/@electron-forge/shared-types/-/shared-types-7.9.0.tgz",
-          "integrity": "sha512-6jZF+zq3SYMnweQpgr5fwlSgOd2yOZ5qlfz/CgXyVljiv0e0UThzpOjfTLuwuVgZX7a60xV+h0mg1h82Glu3wQ==",
-          "dev": true,
-          "requires": {
-            "@electron-forge/tracer": "7.9.0",
-            "@electron/packager": "^18.3.5",
-            "@electron/rebuild": "^3.7.0",
-            "listr2": "^7.0.2"
-          }
-        },
-        "@electron-forge/tracer": {
-          "version": "7.9.0",
-          "resolved": "https://registry.npmjs.org/@electron-forge/tracer/-/tracer-7.9.0.tgz",
-          "integrity": "sha512-7itsjW1WJQADg7Ly61ggI5CCRt+QDVx3HOZC1w69jMUtnipKyPRCbvTBf1oplsNqbIzZxceXdfex6W53YNehvA==",
-          "dev": true,
-          "requires": {
-            "chrome-trace-event": "^1.0.3"
-          }
-        },
         "@types/retry": {
           "version": "0.12.0",
           "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
@@ -20524,38 +19874,15 @@
       "dev": true,
       "requires": {
         "@electron-forge/shared-types": "7.9.0"
-      },
-      "dependencies": {
-        "@electron-forge/shared-types": {
-          "version": "7.9.0",
-          "resolved": "https://registry.npmjs.org/@electron-forge/shared-types/-/shared-types-7.9.0.tgz",
-          "integrity": "sha512-6jZF+zq3SYMnweQpgr5fwlSgOd2yOZ5qlfz/CgXyVljiv0e0UThzpOjfTLuwuVgZX7a60xV+h0mg1h82Glu3wQ==",
-          "dev": true,
-          "requires": {
-            "@electron-forge/tracer": "7.9.0",
-            "@electron/packager": "^18.3.5",
-            "@electron/rebuild": "^3.7.0",
-            "listr2": "^7.0.2"
-          }
-        },
-        "@electron-forge/tracer": {
-          "version": "7.9.0",
-          "resolved": "https://registry.npmjs.org/@electron-forge/tracer/-/tracer-7.9.0.tgz",
-          "integrity": "sha512-7itsjW1WJQADg7Ly61ggI5CCRt+QDVx3HOZC1w69jMUtnipKyPRCbvTBf1oplsNqbIzZxceXdfex6W53YNehvA==",
-          "dev": true,
-          "requires": {
-            "chrome-trace-event": "^1.0.3"
-          }
-        }
       }
     },
     "@electron-forge/shared-types": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@electron-forge/shared-types/-/shared-types-7.8.3.tgz",
-      "integrity": "sha512-gkZtD7ALXHPDOthJo1rQYLDNfG09fdDRMWvjEgaXdF3Z69xXFfnOWPNuOkRUODNalMnuuGs6l7jDl+QFQgHlDg==",
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/@electron-forge/shared-types/-/shared-types-7.9.0.tgz",
+      "integrity": "sha512-6jZF+zq3SYMnweQpgr5fwlSgOd2yOZ5qlfz/CgXyVljiv0e0UThzpOjfTLuwuVgZX7a60xV+h0mg1h82Glu3wQ==",
       "dev": true,
       "requires": {
-        "@electron-forge/tracer": "7.8.3",
+        "@electron-forge/tracer": "7.9.0",
         "@electron/packager": "^18.3.5",
         "@electron/rebuild": "^3.7.0",
         "listr2": "^7.0.2"
@@ -20576,27 +19903,6 @@
         "username": "^5.1.0"
       },
       "dependencies": {
-        "@electron-forge/shared-types": {
-          "version": "7.9.0",
-          "resolved": "https://registry.npmjs.org/@electron-forge/shared-types/-/shared-types-7.9.0.tgz",
-          "integrity": "sha512-6jZF+zq3SYMnweQpgr5fwlSgOd2yOZ5qlfz/CgXyVljiv0e0UThzpOjfTLuwuVgZX7a60xV+h0mg1h82Glu3wQ==",
-          "dev": true,
-          "requires": {
-            "@electron-forge/tracer": "7.9.0",
-            "@electron/packager": "^18.3.5",
-            "@electron/rebuild": "^3.7.0",
-            "listr2": "^7.0.2"
-          }
-        },
-        "@electron-forge/tracer": {
-          "version": "7.9.0",
-          "resolved": "https://registry.npmjs.org/@electron-forge/tracer/-/tracer-7.9.0.tgz",
-          "integrity": "sha512-7itsjW1WJQADg7Ly61ggI5CCRt+QDVx3HOZC1w69jMUtnipKyPRCbvTBf1oplsNqbIzZxceXdfex6W53YNehvA==",
-          "dev": true,
-          "requires": {
-            "chrome-trace-event": "^1.0.3"
-          }
-        },
         "debug": {
           "version": "4.4.3",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -20623,29 +19929,6 @@
         "@electron-forge/shared-types": "7.9.0",
         "@electron-forge/template-base": "7.9.0",
         "fs-extra": "^10.0.0"
-      },
-      "dependencies": {
-        "@electron-forge/shared-types": {
-          "version": "7.9.0",
-          "resolved": "https://registry.npmjs.org/@electron-forge/shared-types/-/shared-types-7.9.0.tgz",
-          "integrity": "sha512-6jZF+zq3SYMnweQpgr5fwlSgOd2yOZ5qlfz/CgXyVljiv0e0UThzpOjfTLuwuVgZX7a60xV+h0mg1h82Glu3wQ==",
-          "dev": true,
-          "requires": {
-            "@electron-forge/tracer": "7.9.0",
-            "@electron/packager": "^18.3.5",
-            "@electron/rebuild": "^3.7.0",
-            "listr2": "^7.0.2"
-          }
-        },
-        "@electron-forge/tracer": {
-          "version": "7.9.0",
-          "resolved": "https://registry.npmjs.org/@electron-forge/tracer/-/tracer-7.9.0.tgz",
-          "integrity": "sha512-7itsjW1WJQADg7Ly61ggI5CCRt+QDVx3HOZC1w69jMUtnipKyPRCbvTBf1oplsNqbIzZxceXdfex6W53YNehvA==",
-          "dev": true,
-          "requires": {
-            "chrome-trace-event": "^1.0.3"
-          }
-        }
       }
     },
     "@electron-forge/template-vite-typescript": {
@@ -20657,29 +19940,6 @@
         "@electron-forge/shared-types": "7.9.0",
         "@electron-forge/template-base": "7.9.0",
         "fs-extra": "^10.0.0"
-      },
-      "dependencies": {
-        "@electron-forge/shared-types": {
-          "version": "7.9.0",
-          "resolved": "https://registry.npmjs.org/@electron-forge/shared-types/-/shared-types-7.9.0.tgz",
-          "integrity": "sha512-6jZF+zq3SYMnweQpgr5fwlSgOd2yOZ5qlfz/CgXyVljiv0e0UThzpOjfTLuwuVgZX7a60xV+h0mg1h82Glu3wQ==",
-          "dev": true,
-          "requires": {
-            "@electron-forge/tracer": "7.9.0",
-            "@electron/packager": "^18.3.5",
-            "@electron/rebuild": "^3.7.0",
-            "listr2": "^7.0.2"
-          }
-        },
-        "@electron-forge/tracer": {
-          "version": "7.9.0",
-          "resolved": "https://registry.npmjs.org/@electron-forge/tracer/-/tracer-7.9.0.tgz",
-          "integrity": "sha512-7itsjW1WJQADg7Ly61ggI5CCRt+QDVx3HOZC1w69jMUtnipKyPRCbvTBf1oplsNqbIzZxceXdfex6W53YNehvA==",
-          "dev": true,
-          "requires": {
-            "chrome-trace-event": "^1.0.3"
-          }
-        }
       }
     },
     "@electron-forge/template-webpack": {
@@ -20691,29 +19951,6 @@
         "@electron-forge/shared-types": "7.9.0",
         "@electron-forge/template-base": "7.9.0",
         "fs-extra": "^10.0.0"
-      },
-      "dependencies": {
-        "@electron-forge/shared-types": {
-          "version": "7.9.0",
-          "resolved": "https://registry.npmjs.org/@electron-forge/shared-types/-/shared-types-7.9.0.tgz",
-          "integrity": "sha512-6jZF+zq3SYMnweQpgr5fwlSgOd2yOZ5qlfz/CgXyVljiv0e0UThzpOjfTLuwuVgZX7a60xV+h0mg1h82Glu3wQ==",
-          "dev": true,
-          "requires": {
-            "@electron-forge/tracer": "7.9.0",
-            "@electron/packager": "^18.3.5",
-            "@electron/rebuild": "^3.7.0",
-            "listr2": "^7.0.2"
-          }
-        },
-        "@electron-forge/tracer": {
-          "version": "7.9.0",
-          "resolved": "https://registry.npmjs.org/@electron-forge/tracer/-/tracer-7.9.0.tgz",
-          "integrity": "sha512-7itsjW1WJQADg7Ly61ggI5CCRt+QDVx3HOZC1w69jMUtnipKyPRCbvTBf1oplsNqbIzZxceXdfex6W53YNehvA==",
-          "dev": true,
-          "requires": {
-            "chrome-trace-event": "^1.0.3"
-          }
-        }
       }
     },
     "@electron-forge/template-webpack-typescript": {
@@ -20725,35 +19962,12 @@
         "@electron-forge/shared-types": "7.9.0",
         "@electron-forge/template-base": "7.9.0",
         "fs-extra": "^10.0.0"
-      },
-      "dependencies": {
-        "@electron-forge/shared-types": {
-          "version": "7.9.0",
-          "resolved": "https://registry.npmjs.org/@electron-forge/shared-types/-/shared-types-7.9.0.tgz",
-          "integrity": "sha512-6jZF+zq3SYMnweQpgr5fwlSgOd2yOZ5qlfz/CgXyVljiv0e0UThzpOjfTLuwuVgZX7a60xV+h0mg1h82Glu3wQ==",
-          "dev": true,
-          "requires": {
-            "@electron-forge/tracer": "7.9.0",
-            "@electron/packager": "^18.3.5",
-            "@electron/rebuild": "^3.7.0",
-            "listr2": "^7.0.2"
-          }
-        },
-        "@electron-forge/tracer": {
-          "version": "7.9.0",
-          "resolved": "https://registry.npmjs.org/@electron-forge/tracer/-/tracer-7.9.0.tgz",
-          "integrity": "sha512-7itsjW1WJQADg7Ly61ggI5CCRt+QDVx3HOZC1w69jMUtnipKyPRCbvTBf1oplsNqbIzZxceXdfex6W53YNehvA==",
-          "dev": true,
-          "requires": {
-            "chrome-trace-event": "^1.0.3"
-          }
-        }
       }
     },
     "@electron-forge/tracer": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@electron-forge/tracer/-/tracer-7.8.3.tgz",
-      "integrity": "sha512-YVVDaPEUOvR1z+DDdj8wR/vO9OSlC91wz4/2Iqe9rqQz8sztnnQBClMAZTqu9bkDTFyHrns8j8v7tPVuVS6ULQ==",
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/@electron-forge/tracer/-/tracer-7.9.0.tgz",
+      "integrity": "sha512-7itsjW1WJQADg7Ly61ggI5CCRt+QDVx3HOZC1w69jMUtnipKyPRCbvTBf1oplsNqbIzZxceXdfex6W53YNehvA==",
       "dev": true,
       "requires": {
         "chrome-trace-event": "^1.0.3"

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "dotenv": "^17.2.2",
     "electron": "^37.4.0",
     "esbuild-loader": "^4.3.0",
-    "eslint": "^9.35.0",
+    "eslint": "^9.36.0",
     "globals": "^16.4.0",
     "icon-gen": "^5.0.0",
     "mini-css-extract-plugin": "^2.9.4",

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "@vercel/webpack-asset-relocator-loader": "^1.10.0",
     "@vue/tsconfig": "^0.8.1",
     "dotenv": "^17.2.2",
-    "electron": "^37.4.0",
+    "electron": "^38.1.2",
     "esbuild-loader": "^4.3.0",
     "eslint": "^9.36.0",
     "globals": "^16.4.0",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   },
   "dependencies": {
     "@mdi/svg": "^7.4.47",
-    "@nextcloud/axios": "^2.5.1",
+    "@nextcloud/axios": "^2.5.2",
     "@nextcloud/browser-storage": "^0.4.0",
     "@nextcloud/capabilities": "^1.2.0",
     "@nextcloud/event-bus": "^3.3.2",

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "webpack": "^5.101.3",
     "webpack-merge": "^6.0.1",
     "worker-loader": "^3.0.8",
-    "zx": "^8.8.1"
+    "zx": "^8.8.3"
   },
   "engines": {
     "node": "^22.0.0",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@nextcloud/l10n": "^3.4.0",
     "@nextcloud/notify_push": "^1.3.0",
     "@nextcloud/router": "^3.0.1",
-    "@nextcloud/vue": "^9.0.0-rc.9",
+    "@nextcloud/vue": "^9.0.0",
     "@vueuse/core": "^13.7.0",
     "core-js": "^3.45.1",
     "electron-squirrel-startup": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "pinia": "^2.3.1",
     "semver": "^7.7.2",
     "unzip-crx-3": "^0.2.0",
-    "vue": "^3.5.21",
+    "vue": "^3.5.22",
     "vue-material-design-icons": "^5.3.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "core-js": "^3.45.1",
     "electron-squirrel-startup": "^1.0.1",
     "howler": "^2.2.4",
-    "pinia": "^2.3.1",
+    "pinia": "^3.0.3",
     "semver": "^7.7.2",
     "unzip-crx-3": "^0.2.0",
     "vue": "^3.5.22",

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "node-loader": "^2.1.0",
     "regenerator-runtime": "^0.14.1",
     "typescript": "^5.9.2",
-    "vue-tsc": "^3.0.6",
+    "vue-tsc": "^3.0.8",
     "webpack": "^5.101.3",
     "webpack-merge": "^6.0.1",
     "worker-loader": "^3.0.8",

--- a/package.json
+++ b/package.json
@@ -70,9 +70,9 @@
   },
   "devDependencies": {
     "@electron-forge/cli": "^7.9.0",
-    "@electron-forge/maker-dmg": "^7.8.3",
+    "@electron-forge/maker-dmg": "^7.9.0",
     "@electron-forge/maker-flatpak": "^7.9.0",
-    "@electron-forge/maker-squirrel": "^7.8.3",
+    "@electron-forge/maker-squirrel": "^7.9.0",
     "@electron-forge/maker-wix": "^7.9.0",
     "@electron-forge/maker-zip": "^7.9.0",
     "@electron-forge/plugin-webpack": "^7.9.0",


### PR DESCRIPTION
## Most of the dependencies

Minor changes

## Major bumps

### Pinia 2 -> 3

Vue 2 support dropped

### Electron 37 -> 38

https://www.electronjs.org/blog/electron-38-0

Breaking changes:
- Removed: macOS 11 support
- Removed: ELECTRON_OZONE_PLATFORM_HINT environment variable
- Removed: plugin-crashed event
- Deprecated: webFrame.routingId property
- Deprecated: webFrame.findFrameByRoutingId(routingId)

All not relevant

### @nextcloud/vue 9.0.0-rc.9 -> 9.0.0

- `feat(NcPopover): replace closeOnClickOutside with noCloseOnClickOutside`

Not relevant.