### PR TITLE
release: v2.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,20 @@
 
 # Changelog
 
+## v2.0.2 - 2025-09-27
+
+### Fixes
+
+- Experimental fix for video streams [#1478](https://github.com/nextcloud/talk-desktop/pull/1478)
+
+### Changes
+
+- Built-in Talk in binaries is updated to v22.0.0 in both beta and stable release channels [#1480](https://github.com/nextcloud/talk-desktop/pull/1480)
+
+
 ## v2.0.1-beta - 2025-09-12
+
+### Changes
 
 - Built-in Talk in binaries is updated to v22.0.0-rc.2 in the beta release channel [#1465](https://github.com/nextcloud/talk-desktop/pull/1465)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "talk-desktop",
-  "version": "2.0.1-beta",
+  "version": "2.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "talk-desktop",
-      "version": "2.0.1-beta",
+      "version": "2.0.2",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@mdi/svg": "^7.4.47",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "talk-desktop",
   "productName": "Nextcloud Talk",
   "desktopName": "com.nextcloud.talk.desktop",
-  "version": "2.0.1-beta",
+  "version": "2.0.2",
   "bugs": {
     "url": "https://github.com/nextcloud/talk-desktop/issues",
     "create": "https://github.com/nextcloud/talk-desktop/issues/new/choose"


### PR DESCRIPTION
## v2.0.2 - 2025-09-27

### Fixes

- Experimental fix for video streams [#1478](https://github.com/nextcloud/talk-desktop/pull/1478)

### Changes

- Built-in Talk in binaries is updated to v22.0.0 in both beta and stable release channels [#1480](https://github.com/nextcloud/talk-desktop/pull/1480)