### PR TITLE
fix(deps): downgrade to electron@38.1.2 due to issues on Wayland

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,7 @@
         "@vue/tsconfig": "^0.8.1",
         "cheerio": "^1.1.2",
         "dotenv": "^17.2.3",
-        "electron": "^38.4.0",
+        "electron": "38.1.2",
         "esbuild-loader": "^4.4.0",
         "eslint": "^9.39.0",
         "globals": "^16.4.0",
@@ -9050,9 +9050,9 @@
       "dev": true
     },
     "node_modules/electron": {
-      "version": "38.4.0",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-38.4.0.tgz",
-      "integrity": "sha512-9CsXKbGf2qpofVe2pQYSgom2E//zLDJO2rGLLbxgy9tkdTOs7000Gte+d/PUtzLjI/DS95jDK0ojYAeqjLvpYg==",
+      "version": "38.1.2",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-38.1.2.tgz",
+      "integrity": "sha512-WXUcN3W8h8NTTZViA3KNX0rV2YBU0X0mEUM3ubupXTDY4QtIN7tmiqYVOKSKpR2LckTmBWGuEeY4D6xVoffwKQ==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -25668,9 +25668,9 @@
       "dev": true
     },
     "electron": {
-      "version": "38.4.0",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-38.4.0.tgz",
-      "integrity": "sha512-9CsXKbGf2qpofVe2pQYSgom2E//zLDJO2rGLLbxgy9tkdTOs7000Gte+d/PUtzLjI/DS95jDK0ojYAeqjLvpYg==",
+      "version": "38.1.2",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-38.1.2.tgz",
+      "integrity": "sha512-WXUcN3W8h8NTTZViA3KNX0rV2YBU0X0mEUM3ubupXTDY4QtIN7tmiqYVOKSKpR2LckTmBWGuEeY4D6xVoffwKQ==",
       "dev": true,
       "requires": {
         "@electron/get": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "@vue/tsconfig": "^0.8.1",
     "cheerio": "^1.1.2",
     "dotenv": "^17.2.3",
-    "electron": "^38.4.0",
+    "electron": "38.1.2",
     "esbuild-loader": "^4.4.0",
     "eslint": "^9.39.0",
     "globals": "^16.4.0",


### PR DESCRIPTION
### ☑️ Resolves

- Fix: https://github.com/nextcloud/talk-desktop/issues/1517
- After Electron 38.2.0 (including 39.0.0) the app doesn't work well on Linux:
  - Likely from: https://github.com/electron/electron/pull/48301
  - Some users report tray icon issues
  - Some users report cursor issues
  - Some users cannot run the app
  - Some users report devtools issues, but fixed in 39
    - https://github.com/electron/electron/pull/48600
- Downgrade to 38.1.2