### PR TITLE
fix(userstatus): Allow overwriting the user status like in the web without having to restore first

### DIFF
--- a/src/talk/renderer/UserStatus/components/UserStatusForm.vue
+++ b/src/talk/renderer/UserStatus/components/UserStatusForm.vue
@@ -98,7 +98,6 @@ async function revertStatus() {
 
 		<UserStatusFormCustomMessage
 			class="user-status-form__row"
-			:disabled="!!backupStatus"
 			:message="userStatus.message"
 			:icon="userStatus.icon"
 			@update:message="patchStatus({ message: $event })"


### PR DESCRIPTION
This aligns with the Web behaviour and is the expected behaviour until the user status is generally redone to allow a stack of user statuses.

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
Web | <img width="788" height="1010" alt="grafik" src="https://github.com/user-attachments/assets/a6af3973-f878-4d80-a68c-eb1d031b5333" />
<img width="698" height="1158" alt="Bildschirmfoto vom 2025-11-11 20-45-57" src="https://github.com/user-attachments/assets/cbde9d1a-b0fc-4431-bba0-447c8169b7b1" /> | <img width="570" height="972" alt="grafik" src="https://github.com/user-attachments/assets/af0e3211-2f33-4203-b9cc-2fd8d2afb043" />
