### PR TITLE
fix(globals): fallback to the file icon for unknown mime types

### DIFF
--- a/src/shared/globals/globals.js
+++ b/src/shared/globals/globals.js
@@ -25,8 +25,10 @@ const OC = {
 	MimeType: {
 		// TODO: better to move this function from global to @nextcloud/files or @nextcloud/router
 		getIconUrl(mimeType) {
+			const defaultFileIcon = require('@global-styles/core/img/filetypes/file.svg')
+
 			if (!mimeType) {
-				return undefined
+				return defaultFileIcon
 			}
 
 			while (MimeTypeList.aliases[mimeType]) {
@@ -39,7 +41,7 @@ const OC = {
 			try {
 				return require(`@global-styles/core/img/filetypes/${icon}.svg`)
 			} catch {
-				return undefined
+				return defaultFileIcon
 			}
 		},
 	},


### PR DESCRIPTION
### ☑️ Resolves

- Fix: handling an edge case when the mime type is unknown, fallback to files