### PR TITLE
fix(talk): remove title bar in fullscreen mode

### DIFF
--- a/src/shared/setupWebPage.js
+++ b/src/shared/setupWebPage.js
@@ -194,8 +194,8 @@ function applyInitialState() {
  * Set CSS variable for --header-height
  */
 function applyHeaderHeight() {
-	document.body.style.setProperty('--header-height', `${TITLE_BAR_HEIGHT}px`, 'important')
-	document.documentElement.style.setProperty('--header-height', `${TITLE_BAR_HEIGHT}px`, 'important')
+	document.body.style.setProperty('--header-height', `${TITLE_BAR_HEIGHT}px`)
+	document.documentElement.style.setProperty('--header-height', `${TITLE_BAR_HEIGHT}px`)
 }
 
 /**


### PR DESCRIPTION
### ☑️ Resolves

- Remove extra `!important` on Talk Desktop variables override, breaking Talk Web full-screen styles override
- See also: https://github.com/nextcloud/spreed/pull/16357

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/9ab89b3e-b522-4e9f-981d-f63f20ab369e" /> | <img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/83e1f299-ec45-4df9-9c04-50afce091264" />
