### PR TITLE
fix(settings): Check devices cannot be open from the main menu settings

### DIFF
--- a/src/talk/renderer/TalkDesktop.vue
+++ b/src/talk/renderer/TalkDesktop.vue
@@ -17,6 +17,18 @@ provide('talk:isInitialized', isTalkInitialized)
 useNotificationsStore()
 
 window.OCA.Viewer = createViewer()
+
+/*
+	A dummy node to fix NcModal issue by adding the "last node".
+	It must be added after other apps like Viewer are initialized to be truly "the last one".
+
+	NcModal teleports itself BEFORE the last element in the container:
+		NcModal / mounted() / document.body.insertBefore(this.$el, document.body.lastChild)
+	Thus, if the current modal is the second modal, and there are no elements after the first modal, when the second modal will be open BEFORE the first one (under it).
+
+	TODO: removed after using switching to Teleport: https://github.com/nextcloud-libraries/nextcloud-vue/pull/7514/
+*/
+document.body.appendChild(document.createElement('div'))
 </script>
 
 <template>


### PR DESCRIPTION
### ☑️ Resolves

- Fix: https://github.com/nextcloud/talk-desktop/issues/1559
- A proper solution: https://github.com/nextcloud-libraries/nextcloud-vue/pull/7514/

`NcModal` is mounted before the last node in the `body`.
This means if the Settings modal is the last one, the "Check devices" is mounted before (under) the settings.

See: https://github.com/nextcloud-libraries/nextcloud-vue/blob/v9.3.0/src/components/NcModal/NcModal.vue#L676

Why it works on the Web but breaks in the menu: the menu opens `NcPopover` added to the end of the body, which is removed after settings are open. Thus the settings dialog is the last node and media settings are open before.

A workaround — add a dummy node at the end of the body. Then the dialog is not the last node anymore.