### PR TITLE
build: update built-in Talk versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,8 +42,8 @@
     "typecheck": "vue-tsc --noEmit"
   },
   "talk": {
-    "stable": "v22.0.2",
-    "beta": "v22.0.2",
+    "stable": "v22.0.4",
+    "beta": "v22.0.4",
     "dev": "main"
   },
   "dependencies": {


### PR DESCRIPTION
## Update Built-in Talk Version

Stable:
- Current: v22.0.2
- Latest: v22.0.4

Beta:
- Current: v22.0.2
- Latest: v22.0.4

Updating stable from v22.0.2 to v22.0.4
Updating beta from v22.0.2 to v22.0.4