### PR TITLE
build: update built-in Talk versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,8 +42,8 @@
     "ts:check": "vue-tsc --noEmit"
   },
   "talk": {
-    "stable": "v22.0.4",
-    "beta": "v22.0.4",
+    "stable": "v22.0.5",
+    "beta": "v22.0.5",
     "dev": "main"
   },
   "dependencies": {


### PR DESCRIPTION
## Update Built-in Talk Version

Stable:
- Current: v22.0.4
- Latest: v22.0.5

Beta:
- Current: v22.0.4
- Latest: v22.0.5

Updating stable from v22.0.4 to v22.0.5
Updating beta from v22.0.4 to v22.0.5