### PR TITLE
fix(build): do not define appName and appVersion via Talk values

### DIFF
--- a/webpack.renderer.config.js
+++ b/webpack.renderer.config.js
@@ -18,16 +18,6 @@ const { getAppInfo } = require('./scripts/utils/appinfo.utils.cjs')
 const TALK_PATH = path.resolve(__dirname, process.env.TALK_PATH ?? 'spreed')
 const CHANNEL = process.env.CHANNEL ?? 'dev'
 
-/**
- * appName and appVersion constants are set by process.env.npm_package_* in @nextcloud/webpack-vue-config.
- * During build in this project, env variables will be different and constants will be incorrect.
- * To keep values correct - set implicitly.
- */
-const talkPackage = require(`${TALK_PATH}/package.json`)
-
-process.env.npm_package_name = talkPackage.name
-process.env.npm_package_version = talkPackage.version
-
 const MAX_NEXTCLOUD_VERSION = getAppInfo(TALK_PATH).maxVersion
 const NEXTCLOUD_MASTER_VERSION = 33
 


### PR DESCRIPTION
### ☑️ Resolves

- I don't remember why I thought in the beginning that it must have Talk values
- The only affected place - the version in the settings dialog
- Alternatively, we can just remove the version on desktop
- P.S. Localisation of Talk Desktop is done via another PR

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
<img width="912" height="820" alt="image" src="https://github.com/user-attachments/assets/c1d1b455-4a0b-44ba-b441-59a93f2733f4" /> | <img width="918" height="832" alt="image" src="https://github.com/user-attachments/assets/4ac68a0a-dd9b-4ef6-8bc6-fe93c5446bf9" />
