### PR TITLE
feat: notify about updates in main menu

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -14,7 +14,7 @@ const { registerAppProtocolHandler } = require('./app/appProtocol.ts')
 const { verifyCertificate, promptCertificateTrust } = require('./app/certificate.service.ts')
 const { openChromeWebRtcInternals } = require('./app/dev.utils.ts')
 const { triggerDownloadUrl } = require('./app/downloads.ts')
-const { setupReleaseNotificationScheduler } = require('./app/githubReleaseNotification.service.js')
+const { setupReleaseNotificationScheduler, registerUpdateIpcHandlers } = require('./app/githubReleaseNotification.service.js')
 const { initLaunchAtStartupListener } = require('./app/launchAtStartup.config.ts')
 const { runMigrations } = require('./app/migration.service.ts')
 const { systemInfo, isLinux, isMac, isWindows, isSameExecution, relaunchApp } = require('./app/system.utils.ts')
@@ -143,6 +143,7 @@ app.whenReady().then(async () => {
 	applyTheme()
 	initLaunchAtStartupListener()
 	registerAppProtocolHandler()
+	registerUpdateIpcHandlers()
 
 	/**
 	 * Schedule check for a new version available to download from GitHub

--- a/src/preload.js
+++ b/src/preload.js
@@ -187,6 +187,23 @@ const TALK_DESKTOP = {
 	 */
 	showHelp: () => ipcRenderer.invoke('help:show'),
 	/**
+	 * Check for a new GitHub release and receive info
+	 *
+	 * @return {Promise<{available:boolean,tag:string|null,url:string|null}>}
+	 */
+	checkForUpdate: () => ipcRenderer.invoke('github-release:check'),
+	/**
+	 * Listen for push notifications about new releases
+	 *
+	 * @param {() => void} callback - Callback
+	 * @return {() => void} unsubscribe
+	 */
+	onNewVersion: (callback) => {
+		const handler = () => callback()
+		ipcRenderer.on('github-release:new-version', handler)
+		return () => ipcRenderer.removeListener('github-release:new-version', handler)
+	},
+	/**
 	 * Show the upgrade window
 	 *
 	 * @return {Promise<void>}

--- a/src/talk/renderer/TitleBar/components/MainMenu.vue
+++ b/src/talk/renderer/TitleBar/components/MainMenu.vue
@@ -8,12 +8,13 @@ import type { Ref } from 'vue'
 
 import { t } from '@nextcloud/l10n'
 import { generateUrl } from '@nextcloud/router'
-import { inject } from 'vue'
+import { inject, onBeforeUnmount, ref } from 'vue'
 import NcActionButton from '@nextcloud/vue/components/NcActionButton'
 import NcActionLink from '@nextcloud/vue/components/NcActionLink'
 import NcActions from '@nextcloud/vue/components/NcActions'
 import NcActionSeparator from '@nextcloud/vue/components/NcActionSeparator'
 import IconBugOutline from 'vue-material-design-icons/BugOutline.vue'
+import IconCloudDownloadOutline from 'vue-material-design-icons/CloudDownloadOutline.vue'
 import IconCogOutline from 'vue-material-design-icons/CogOutline.vue'
 import IconInformationOutline from 'vue-material-design-icons/InformationOutline.vue'
 import IconMenu from 'vue-material-design-icons/Menu.vue'
@@ -30,6 +31,19 @@ const showHelp = () => window.TALK_DESKTOP.showHelp()
 const reload = () => window.location.reload()
 const openSettings = () => window.OCA.Talk.Settings.open()
 const openInWeb = () => window.open(generateUrl(getCurrentTalkRoutePath()), '_blank')
+
+const updateAvailable = ref(false)
+
+const unsubscribeNewVersion = window.TALK_DESKTOP.onNewVersion(() => {
+	updateAvailable.value = true
+})
+
+onBeforeUnmount(() => {
+	unsubscribeNewVersion()
+})
+
+window.TALK_DESKTOP.checkForUpdate()
+
 </script>
 
 <template>
@@ -42,7 +56,7 @@ const openInWeb = () => window.open(generateUrl(getCurrentTalkRoutePath()), '_bl
 		</template>
 
 		<template v-if="isTalkInitialized">
-			<NcActionButton @click="openInWeb">
+			<NcActionButton close-after-click @click="openInWeb">
 				<template #icon>
 					<IconWeb :size="20" />
 				</template>
@@ -58,7 +72,21 @@ const openInWeb = () => window.open(generateUrl(getCurrentTalkRoutePath()), '_bl
 			</template>
 			{{ t('talk_desktop', 'Force reload') }}
 		</NcActionButton>
-		<NcActionLink v-if="!BUILD_CONFIG.isBranded" :href="packageInfo.bugs.create || packageInfo.bugs.url" target="_blank">
+		<NcActionLink
+			v-if="updateAvailable"
+			href="https://github.com/nextcloud/talk-desktop/releases/latest"
+			target="_blank"
+			close-after-click>
+			<template #icon>
+				<IconCloudDownloadOutline :size="20" />
+			</template>
+			{{ t('talk_desktop', 'Update') }}
+		</NcActionLink>
+		<NcActionLink
+			v-if="!BUILD_CONFIG.isBranded"
+			:href="packageInfo.bugs.create || packageInfo.bugs.url"
+			target="_blank"
+			close-after-click>
 			<template #icon>
 				<IconBugOutline :size="20" />
 			</template>
@@ -73,7 +101,7 @@ const openInWeb = () => window.open(generateUrl(getCurrentTalkRoutePath()), '_bl
 			</template>
 			{{ t('talk_desktop', 'App settings') }}
 		</NcActionButton>
-		<NcActionButton @click="showHelp">
+		<NcActionButton close-after-click @click="showHelp">
 			<template #icon>
 				<IconInformationOutline :size="20" />
 			</template>


### PR DESCRIPTION
### ☑️ Resolves

- Fix: #155

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
<img width="268" height="267" alt="before" src="https://github.com/user-attachments/assets/2f18364d-79b8-4728-89e9-45586365ad9d" /> (and OS notification) | <img width="268" height="329" alt="after" src="https://github.com/user-attachments/assets/4de23581-6ace-40b5-9ec4-9af387cda833" />

When a new update is available, the burger menu gets a little notification dot and a new menu entry for updating appears. This replaces the often overlooked OS notification.