### PR TITLE
fix(linux): title bar is not transparent

### DIFF
--- a/src/authentication/authentication.window.js
+++ b/src/authentication/authentication.window.js
@@ -32,7 +32,7 @@ function createAuthenticationWindow() {
 		icon: getBrowserWindowIcon(),
 		titleBarStyle: getAppConfig('systemTitleBar') ? 'default' : 'hidden',
 		titleBarOverlay: {
-			color: '#00000000', // Transparent
+			color: '#FFFFFF00',
 			symbolColor: '#FFFFFF', // White
 			height: Math.round(TITLE_BAR_HEIGHT * zoomFactor),
 		},

--- a/src/talk/talk.window.js
+++ b/src/talk/talk.window.js
@@ -36,7 +36,7 @@ function createTalkWindow() {
 		icon: getBrowserWindowIcon(),
 		titleBarStyle: getAppConfig('systemTitleBar') ? 'default' : 'hidden',
 		titleBarOverlay: {
-			color: '#00000000', // Transparent
+			color: '#FFFFFF00',
 			symbolColor: '#FFFFFF', // White
 			height: Math.round(TITLE_BAR_HEIGHT * zoomFactor),
 		},


### PR DESCRIPTION
### ☑️ Resolves

- Apparently, `#00000000` casts to `0` int, which counts as "no value" and fallbacks to default

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
<img width="195" height="91" alt="image" src="https://github.com/user-attachments/assets/767c18f3-b8d0-4d7b-9625-728fd38ae952" /> | <img width="193" height="91" alt="image" src="https://github.com/user-attachments/assets/b21649b9-9658-459b-8b6b-ed0342718be9" />
