### PR TITLE
fix(title-bar): dev menu color

### DIFF
--- a/src/talk/renderer/TitleBar/components/DevMenu.vue
+++ b/src/talk/renderer/TitleBar/components/DevMenu.vue
@@ -110,7 +110,7 @@ async function openChromeWebRtcInternals() {
 		container="body"
 		force-menu>
 		<template #icon>
-			<IconDeveloperBoard :size="20" fill-color="var(--color-header-contrast)" />
+			<IconDeveloperBoard :size="20" fill-color="var(--color-background-plain-text)" />
 		</template>
 
 		<NcActionButton @click="openDevTools">


### PR DESCRIPTION
### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
<img width="292" height="91" alt="image" src="https://github.com/user-attachments/assets/164fc7c8-7792-444d-ac29-9f89b4f134a9" /> | <img width="285" height="94" alt="image" src="https://github.com/user-attachments/assets/1d5058f6-154b-4064-8f78-9478c36dcccf" />
