### PR TITLE
build: update built-in Talk versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,8 +42,8 @@
     "ts:check": "vue-tsc --noEmit"
   },
   "talk": {
-    "stable": "v22.0.6",
-    "beta": "v22.0.6",
+    "stable": "v22.0.7",
+    "beta": "v22.0.7",
     "dev": "main"
   },
   "dependencies": {


### PR DESCRIPTION
## Update Built-in Talk Version

Stable:
- Current: v22.0.6
- Latest: v22.0.7

Beta:
- Current: v22.0.6
- Latest: v22.0.7

Updating stable from v22.0.6 to v22.0.7
Updating beta from v22.0.6 to v22.0.7