### PR TITLE
fix(l10n): Typo in German translation of autostart

### DIFF
--- a/l10n/de.js
+++ b/l10n/de.js
@@ -57,7 +57,7 @@ OC.L10N.register(
     "Always" : "Immer",
     "When not in \"Do not disturb\"" : "Wenn du nicht im \"Nicht stören\"-Modus bist",
     "Never" : "Niemals",
-    "Launch at startup" : "Beim Anmeldung starten",
+    "Launch at startup" : "Bei Anmeldung starten",
     "Theme" : "Design",
     "System default" : "Systemstandard",
     "Light" : "Hell",

--- a/l10n/de.json
+++ b/l10n/de.json
@@ -55,7 +55,7 @@
     "Always" : "Immer",
     "When not in \"Do not disturb\"" : "Wenn du nicht im \"Nicht stören\"-Modus bist",
     "Never" : "Niemals",
-    "Launch at startup" : "Beim Anmeldung starten",
+    "Launch at startup" : "Bei Anmeldung starten",
     "Theme" : "Design",
     "System default" : "Systemstandard",
     "Light" : "Hell",

--- a/l10n/de_DE.js
+++ b/l10n/de_DE.js
@@ -57,7 +57,7 @@ OC.L10N.register(
     "Always" : "Immer",
     "When not in \"Do not disturb\"" : "Wenn Sie nicht im \"Nicht stören\"-Modus sind",
     "Never" : "Niemals",
-    "Launch at startup" : "Beim Anmeldung starten",
+    "Launch at startup" : "Bei Anmeldung starten",
     "Theme" : "Design",
     "System default" : "Systemstandard",
     "Light" : "Hell",

--- a/l10n/de_DE.json
+++ b/l10n/de_DE.json
@@ -55,7 +55,7 @@
     "Always" : "Immer",
     "When not in \"Do not disturb\"" : "Wenn Sie nicht im \"Nicht stören\"-Modus sind",
     "Never" : "Niemals",
-    "Launch at startup" : "Beim Anmeldung starten",
+    "Launch at startup" : "Bei Anmeldung starten",
     "Theme" : "Design",
     "System default" : "Systemstandard",
     "Light" : "Hell",


### PR DESCRIPTION
### ☑️ Resolves

- Fix: The german translation of the autostart feature in the settings menu had a letter too much.

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
<img width="889" height="801" alt="grafik" src="https://github.com/user-attachments/assets/d3733672-cdb5-41d1-9a7b-a35e3b649d8c" /> | removed the "m"
