### PR TITLE
build: update built-in Talk versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "ts:check": "vue-tsc --noEmit"
   },
   "talk": {
-    "stable": "v22.0.7",
+    "stable": "v22.0.8",
     "beta": "v22.0.7",
     "dev": "main"
   },


### PR DESCRIPTION
## Update Built-in Talk Version

Stable:
- Current: v22.0.7
- Latest: v22.0.8

Beta:
- Current: v22.0.7
- Latest: v23.0.0-rc.1

Updating stable from v22.0.7 to v22.0.8