### PR TITLE
ci: fix version comparison with update-built-in-talk on major updates

### DIFF
--- a/scripts/semver.utils.mjs
+++ b/scripts/semver.utils.mjs
@@ -5,20 +5,14 @@
 
 /**
  * Is version A greater than version B?
+ *
  * @param {string} versionA - Version A
  * @param {string} versionB - Version B
  * @return {boolean} - Whether version A greater than version B
  */
 export function semverGt(versionA, versionB) {
-	const parse = (v) => [...v.split('-')[0].split('.').map((v) => parseInt(v)), v.split('-')[1] || 'z']
-	const a = parse(versionA)
-	const b = parse(versionB)
-	for (let i = 0; i < a.length; i++) {
-		if (a[i] > b[i]) {
-			return true
-		} else if (a[i] < b[i]) {
-			return false
-		}
-	}
-	return false
+	const normalized = (version) => version.includes('-') ? version : `${version}-z`
+	const a = normalized(versionA)
+	const b = normalized(versionB)
+	return a.localeCompare(b, 'en', { numeric: true }) > 0
 }


### PR DESCRIPTION
### ☑️ Resolves

- Ref: https://github.com/nextcloud/talk-desktop/pull/1638
- `parseInt('v23')` is `NaN`
- Simplify comparison by using `localCompare` with `numeric`