### PR TITLE
build: update built-in Talk versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   },
   "talk": {
     "stable": "v22.0.8",
-    "beta": "v22.0.7",
+    "beta": "v23.0.0-rc.2",
     "dev": "main"
   },
   "dependencies": {


### PR DESCRIPTION
## Update Built-in Talk Version

Stable:
- Current: v22.0.8
- Latest: v22.0.8

Beta:
- Current: v22.0.7
- Latest: v23.0.0-rc.2

Updating beta from v22.0.7 to v23.0.0-rc.2