### PR TITLE
fix(talk): title bar controls color is not inline with theming

### DIFF
--- a/src/authentication/authentication.window.js
+++ b/src/authentication/authentication.window.js
@@ -6,7 +6,7 @@
 const { BrowserWindow } = require('electron')
 const { getAppConfig } = require('../app/AppConfig.ts')
 const { applyContextMenu } = require('../app/applyContextMenu.js')
-const { getScaledWindowSize, applyZoom, buildTitle, getWindowUrl } = require('../app/utils.ts')
+const { getScaledWindowSize, applyZoom, buildTitle, getWindowUrl, getTitleBarSymbolColor } = require('../app/utils.ts')
 const { TITLE_BAR_HEIGHT } = require('../constants.js')
 const { getBrowserWindowIcon } = require('../shared/icons.utils.js')
 
@@ -33,7 +33,7 @@ function createAuthenticationWindow() {
 		titleBarStyle: getAppConfig('systemTitleBar') ? 'default' : 'hidden',
 		titleBarOverlay: {
 			color: '#FFFFFF00',
-			symbolColor: '#FFFFFF', // White
+			symbolColor: getTitleBarSymbolColor(),
 			height: Math.round(TITLE_BAR_HEIGHT * zoomFactor),
 		},
 		// Position of the top left corner of the traffic light on Mac

--- a/src/talk/talk.window.js
+++ b/src/talk/talk.window.js
@@ -9,7 +9,7 @@ const { getAppConfig } = require('../app/AppConfig.ts')
 const { applyContextMenu } = require('../app/applyContextMenu.js')
 const { applyDownloadHandler } = require('../app/downloads.ts')
 const { applyExternalLinkHandler } = require('../app/externalLinkHandlers.ts')
-const { getScaledWindowMinSize, getScaledWindowSize, applyZoom, buildTitle, getWindowUrl } = require('../app/utils.ts')
+const { getScaledWindowMinSize, getScaledWindowSize, applyZoom, buildTitle, getWindowUrl, getTitleBarSymbolColor } = require('../app/utils.ts')
 const { applyWheelZoom } = require('../app/zoom.service.ts')
 const { TITLE_BAR_HEIGHT } = require('../constants.js')
 const { BUILD_CONFIG } = require('../shared/build.config.ts')
@@ -37,7 +37,7 @@ function createTalkWindow() {
 		titleBarStyle: getAppConfig('systemTitleBar') ? 'default' : 'hidden',
 		titleBarOverlay: {
 			color: '#FFFFFF00',
-			symbolColor: '#FFFFFF', // White
+			symbolColor: getTitleBarSymbolColor(),
 			height: Math.round(TITLE_BAR_HEIGHT * zoomFactor),
 		},
 		// Position of the top left corner of the traffic light on Mac


### PR DESCRIPTION
### ☑️ Resolves

- OS determines the title bar control color based on the background color (dark/light)
- But we have a different calculation in theming
- It may result in a wrong color, different from other app elements
- Before it was fixed by hardcoding `#FFFFFF`
- After it is calculated the same way theming does

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
OS-defined | <img width="1400" height="900" alt="image" src="https://github.com/user-attachments/assets/3dd50988-8c0a-4b4d-81b8-2b561c49d76e" />
Before on blue | <img width="1400" height="900" alt="image" src="https://github.com/user-attachments/assets/3c087eea-6727-489b-8e84-d7a0da42b314" />
Before on bright | <img width="1400" height="900" alt="image" src="https://github.com/user-attachments/assets/53e50159-4175-4e7d-981f-0356530c2273" />
After on blue | <img width="1400" height="900" alt="image" src="https://github.com/user-attachments/assets/3c087eea-6727-489b-8e84-d7a0da42b314" />
After on bright | <img width="1400" height="900" alt="image" src="https://github.com/user-attachments/assets/d65d1bc6-9e8d-441a-b563-dfcb2032f717" />
