### PR TITLE
fix(talk): increase visibility of new update availability in the main menu

### DIFF
--- a/src/talk/renderer/TitleBar/components/MainMenu.vue
+++ b/src/talk/renderer/TitleBar/components/MainMenu.vue
@@ -20,6 +20,7 @@ import IconInformationOutline from 'vue-material-design-icons/InformationOutline
 import IconMenu from 'vue-material-design-icons/Menu.vue'
 import IconReload from 'vue-material-design-icons/Reload.vue'
 import IconWeb from 'vue-material-design-icons/Web.vue'
+import UiDotBadge from './UiDotBadge.vue'
 import { BUILD_CONFIG } from '../../../../shared/build.config.ts'
 import { getCurrentTalkRoutePath } from '../../TalkWrapper/talk.service.ts'
 
@@ -43,7 +44,6 @@ onBeforeUnmount(() => {
 })
 
 window.TALK_DESKTOP.checkForUpdate()
-
 </script>
 
 <template>
@@ -52,7 +52,29 @@ window.TALK_DESKTOP.checkForUpdate()
 		variant="tertiary-no-background"
 		container="body">
 		<template #icon>
-			<IconMenu :size="20" fill-color="var(--color-background-plain-text)" />
+			<UiDotBadge inset-inline-end="10%" :enabled="updateAvailable">
+				<IconMenu :size="20" fill-color="var(--color-background-plain-text)" />
+			</UiDotBadge>
+		</template>
+
+		<template v-if="updateAvailable">
+			<NcActionLink
+				href="https://github.com/nextcloud/talk-desktop/releases/latest"
+				target="_blank"
+				close-after-click>
+				<template #icon>
+					<UiDotBadge
+						inset-block-start="32%"
+						inset-inline-end="22%"
+						enabled
+						no-outline>
+						<IconCloudDownloadOutline :size="20" />
+					</UiDotBadge>
+				</template>
+				{{ t('talk_desktop', 'Update') }}
+			</NcActionLink>
+
+			<NcActionSeparator />
 		</template>
 
 		<template v-if="isTalkInitialized">
@@ -62,9 +84,9 @@ window.TALK_DESKTOP.checkForUpdate()
 				</template>
 				{{ t('talk_desktop', 'Open in web browser') }}
 			</NcActionButton>
-		</template>
 
-		<NcActionSeparator />
+			<NcActionSeparator />
+		</template>
 
 		<NcActionButton @click="reload">
 			<template #icon>
@@ -72,16 +94,6 @@ window.TALK_DESKTOP.checkForUpdate()
 			</template>
 			{{ t('talk_desktop', 'Force reload') }}
 		</NcActionButton>
-		<NcActionLink
-			v-if="updateAvailable"
-			href="https://github.com/nextcloud/talk-desktop/releases/latest"
-			target="_blank"
-			close-after-click>
-			<template #icon>
-				<IconCloudDownloadOutline :size="20" />
-			</template>
-			{{ t('talk_desktop', 'Update') }}
-		</NcActionLink>
 		<NcActionLink
 			v-if="!BUILD_CONFIG.isBranded"
 			:href="packageInfo.bugs.create || packageInfo.bugs.url"

--- a/src/talk/renderer/TitleBar/components/UiDotBadge.vue
+++ b/src/talk/renderer/TitleBar/components/UiDotBadge.vue
@@ -1,0 +1,76 @@
+<!--
+  - SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+  -->
+
+<script setup lang="ts">
+const {
+	enabled = false,
+	size = '6px',
+	insetBlockStart = '20%',
+	insetInlineEnd = '20%',
+	noOutline = false,
+} = defineProps<{
+	/**
+	 * Whether to show the dot
+	 */
+	enabled?: boolean
+	/**
+	 * CSS size of the dot, e.g. '6px'. With the gap around it will be twice bigger.
+	 */
+	size?: string
+	/**
+	 * Position of the dot's center from the block start.
+	 * Default is 20%, but due to different icon's shape the perfect position might vary.
+	 */
+	insetBlockStart?: string
+	/**
+	 * Position of the dot's center from the inline end.
+	 * Default is 20%, but due to different icon's shape the perfect position might vary.
+	 */
+	insetInlineEnd?: string
+	/**
+	 * Whether to remove the transparent outline around the dot icon.
+	 * The outline helps to separate the dot from the icon, but may look bad when the dote does not overlap with the icon at all.
+	 */
+	noOutline?: boolean
+}>()
+</script>
+
+<template>
+	<span :class="$style.dotBadge">
+		<span :class="{ [$style.dotBadge__iconWithDotHole]: enabled && !noOutline }">
+			<slot />
+		</span>
+		<sup v-if="enabled" :class="[$style.dotBadge__dot]" />
+	</span>
+</template>
+
+<style module>
+.dotBadge {
+	position: relative;
+}
+
+/* Adding a mask to create a gap between the the dot and the icon (like a hole), so they do not touch */
+.dotBadge__iconWithDotHole {
+	/* radial-gradient circle is defined by radius, not diameter size. */
+	/* Using diameter size as the radius here is intentional to make the hole twice bigger than the dot. */
+	mask: radial-gradient(circle v-bind(size) at top v-bind(insetBlockStart) right v-bind(insetInlineEnd), transparent 100%, white 100%);
+
+	/* radial-gradient does not support logical properties */
+	&:dir(rtl) {
+		mask: radial-gradient(circle v-bind(size) at top v-bind(insetBlockStart) left v-bind(insetInlineEnd), transparent 100%, white 100%);
+	}
+}
+
+.dotBadge__dot {
+	display: inline-block;
+	border-radius: 50%;
+	width: v-bind(size);
+	height: v-bind(size);
+	background-color: var(--color-text-error);
+	position: absolute;
+	inset-block-start: calc(v-bind(insetBlockStart) - v-bind(size) / 2);
+	inset-inline-end: calc(v-bind(insetInlineEnd) - v-bind(size) / 2);
+}
+</style>


### PR DESCRIPTION
### ☑️ Resolves

- Add a red dot badge on the main menu when the update is available to indicate that there is something new, similar to the notifications app on the web
- Add the same dot on the `Update` menu item to show that is new in the menu
- Move the menu item to the top in an individual group

### 🖼️ Screenshots

Before | After
-- | --
<img width="306" height="290" alt="image" src="https://github.com/user-attachments/assets/d9397a3a-7788-4ec9-ac42-b87cced79ea2" /> | <img width="308" height="303" alt="image" src="https://github.com/user-attachments/assets/704be381-0072-4429-bdfa-f150641bd6b6" />

Light | Dark
-- | --
<img width="232" height="41" alt="image" src="https://github.com/user-attachments/assets/592321ff-7a1b-4ecf-a642-ff22263cbee4" /> | <img width="232" height="44" alt="image" src="https://github.com/user-attachments/assets/dd423796-808e-42bb-908e-a28bcd462ed6" />
