### PR TITLE
feat: predefine server + user by last used with `accounts` config

### DIFF
--- a/src/app/AppConfig.ts
+++ b/src/app/AppConfig.ts
@@ -40,6 +40,14 @@ export type AppConfig = {
 	 */
 	lastAppVersion?: string
 
+	/**
+	 * List of the accounts in the app in the {user}@{server} or {server} format,
+	 * E.g. nextcloud.tld, alice@nextcloud.tld, bob@company.tld@company.tld/nextcloud.
+	 * Currently only the first element is used for login suggestion, populated from the last used accounts or manually set.
+	 * This config is to be extended with complete multi-account support.
+	 */
+	accounts?: string[]
+
 	// ----------------
 	// General settings
 	// ----------------
@@ -128,6 +136,7 @@ export type AppConfigKey = keyof AppConfig
  * Get the default config
  */
 const defaultAppConfig: AppConfig = {
+	accounts: [],
 	launchAtStartup: false,
 	theme: 'default',
 	systemTitleBar: isLinux,

--- a/src/authentication/login.window.js
+++ b/src/authentication/login.window.js
@@ -20,9 +20,10 @@ const genId = () => Math.random().toString(36).slice(2, 9)
  *
  * @param {import('electron').BrowserWindow} parentWindow - Parent window
  * @param {string} serverUrl - Server URL
+ * @param {string} [user] - Preset User ID
  * @return {Promise<import('./login.service.js').Credentials|Error>}
  */
-function openLoginWebView(parentWindow, serverUrl) {
+function openLoginWebView(parentWindow, serverUrl, user) {
 	return new Promise((resolve) => {
 		const WIDTH = 750
 		const HEIGHT = 750
@@ -55,7 +56,9 @@ function openLoginWebView(parentWindow, serverUrl) {
 		})
 		window.removeMenu()
 
-		window.loadURL(`${serverUrl}/index.php/login/flow`, {
+		// Undocumented but widely used feature
+		const presetUserQuery = user ? `?user=${encodeURIComponent(user)}` : ''
+		window.loadURL(`${serverUrl}/index.php/login/flow${presetUserQuery}`, {
 			// User-Agent header is used as the app name, device and session
 			// On the login flow page and then on the Personal settings / Security / Devices & Sessions
 			// Format used by all the clients: {HostUsername} ({ApplicationName} - {OS})

--- a/src/help/renderer/diagnosis.service.ts
+++ b/src/help/renderer/diagnosis.service.ts
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+import type { AppConfigKey } from '../../app/AppConfig.ts'
+
 import { appData } from '../../app/AppData.js'
 import { getAppConfig } from '../../shared/appConfig.service.ts'
 
@@ -63,6 +65,10 @@ function table(data: string[][]) {
 
 const printBool = (value: boolean) => value ? '✅ yes' : '❌ no'
 
+const SENSITIVE_CONFIG_KEYS: AppConfigKey[] = ['accounts', 'trustedFingerprints']
+
+const omit = <T extends Record<string, unknown>>(obj: T, keys: (keyof T)[]) => Object.fromEntries(Object.entries(obj).filter(([key]) => !keys.includes(key as keyof T)))
+
 /**
  * Generate a diagnosis report in Markdown format
  */
@@ -99,7 +105,7 @@ ${table([
 #### Application config
 
 \`\`\`json
-${JSON.stringify(getAppConfig(), null, 2)}
+${JSON.stringify(omit(getAppConfig(), SENSITIVE_CONFIG_KEYS), null, 2)}
 \`\`\`
 `
 }

--- a/src/main.js
+++ b/src/main.js
@@ -302,7 +302,7 @@ app.whenReady().then(async () => {
 
 	ipcMain.handle('talk:focus', async () => focusMainWindow())
 
-	ipcMain.handle('authentication:openLoginWebView', async (event, serverUrl) => openLoginWebView(mainWindow, serverUrl))
+	ipcMain.handle('authentication:openLoginWebView', async (event, serverUrl, user) => openLoginWebView(mainWindow, serverUrl, user))
 
 	ipcMain.handle('authentication:login', async (event, newAppData) => {
 		appData.fromJSON(newAppData)

--- a/src/preload.js
+++ b/src/preload.js
@@ -152,9 +152,10 @@ const TALK_DESKTOP = {
 	 * Open a web-view modal window with Nextcloud Server login page
 	 *
 	 * @param {string} server - Server URL
+	 * @param {string} [user] - Preset User ID
 	 * @return {Promise<import('./accounts/login.service.js').Credentials|Error>}
 	 */
-	openLoginWebView: (server) => ipcRenderer.invoke('authentication:openLoginWebView', server),
+	openLoginWebView: (server, user) => ipcRenderer.invoke('authentication:openLoginWebView', server, user),
 	/**
 	 * Open main window after logging in
 	 *

--- a/src/shared/appConfig.service.ts
+++ b/src/shared/appConfig.service.ts
@@ -44,3 +44,17 @@ export function getAppConfigValue<K extends AppConfigKey>(key: K) {
 
 	return appConfig[key]
 }
+
+/**
+ * Set an application config value
+ *
+ * @param key - The key of the config value
+ * @param value - The value to set
+ */
+export function setAppConfigValue<K extends AppConfigKey>(key: K, value?: AppConfig[K]) {
+	if (!appConfig) {
+		throw new Error('AppConfig is not initialized')
+	}
+
+	window.TALK_DESKTOP.setAppConfig(key, value)
+}

--- a/src/welcome/welcome.js
+++ b/src/welcome/welcome.js
@@ -5,6 +5,7 @@
 
 import { appData } from '../app/AppData.js'
 import { refetchAppDataWithRetry } from '../app/appData.service.js'
+import { getAppConfigValue, initAppConfig, setAppConfigValue } from '../shared/appConfig.service.ts'
 import { initGlobals } from '../shared/globals/globals.js'
 import { applyAxiosInterceptors } from '../shared/setupWebPage.js'
 
@@ -32,6 +33,13 @@ applyAxiosInterceptors()
 if (appData.credentials) {
 	await window.TALK_DESKTOP.enableWebRequestInterceptor(appData.serverUrl, { credentials: appData.credentials })
 	await refetchAppDataWithRetry(appData)
+	// Init accounts in case this is the first run with the new config
+	// TODO: replace with a proper migration when the migration system supports it
+	await initAppConfig()
+	const accounts = getAppConfigValue('accounts')
+	if (!accounts.length) {
+		await setAppConfigValue('accounts', [`${appData.credentials.user}@${appData.serverUrl.replace(/^https?:\/\//, '')}`])
+	}
 }
 
 window.TALK_DESKTOP.sendAppData(appData.toJSON())


### PR DESCRIPTION
### ☑️ Resolves

- When a user logs out, the user needs to enter the same server URL and username again on login
- Saving the last used account in the config to predefine it during login
- `X` button on the input clears the item
- Allows adding predefined server URL via command line later
- UI and usage are quite simple at the moment. huge changes will come with complete multi-account support

### 🖼️ Screenshots

#### Authentication window has the last used server preset

<img width="450" height="500" alt="image" src="https://github.com/user-attachments/assets/bcf51fe3-919e-424e-960b-4f62772ee27c" />

#### Login view has the last used username for this server

<img width="752" height="782" alt="image" src="https://github.com/user-attachments/assets/92bff5bb-32c7-468a-a8db-805f9425d2c7" />
