### PR TITLE
build: update built-in Talk versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,8 +42,8 @@
     "ts:check": "vue-tsc --noEmit"
   },
   "talk": {
-    "stable": "v22.0.8",
-    "beta": "v23.0.0-rc.2",
+    "stable": "v23.0.1",
+    "beta": "v23.0.1",
     "dev": "main"
   },
   "dependencies": {


### PR DESCRIPTION
## Update Built-in Talk Version

Stable:
- Current: v22.0.8
- Latest: v23.0.1

Beta:
- Current: v23.0.0-rc.2
- Latest: v23.0.1

Updating stable from v22.0.8 to v23.0.1
Updating beta from v23.0.0-rc.2 to v23.0.1