### PR TITLE
chore: remove `process` from renderer

### DIFF
--- a/src/preload.js
+++ b/src/preload.js
@@ -19,7 +19,6 @@ const packageInfo = {
  * @global
  */
 const TALK_DESKTOP = {
-	process,
 	/**
 	 * Subset of package.json meta-data
 	 *


### PR DESCRIPTION
### ☑️ Resolves

- Was added in https://github.com/nextcloud/talk-desktop/pull/917
- I don't know why it was there. It is not needed and not used.