### PR TITLE
fix(talk): preset signaling mode for Talk v23.0.2+, remove unused initial state

### DIFF
--- a/src/shared/setupWebPage.js
+++ b/src/shared/setupWebPage.js
@@ -140,7 +140,9 @@ function getInitialStateFromCapabilities(capabilities, userMetadata) {
 	// TODO: make sure all used initial state is covered and there is no MISSED values
 	return {
 		spreed: {
-			signaling_mode: 'external', // MISSED
+			// Capability added in Talk v23.0.2
+			// TODO: use signaling settings as the fallback for older servers
+			signaling_mode: capabilities?.spreed?.config?.signaling?.mode ?? 'external',
 			user_group_ids: userMetadata?.groups,
 		},
 		core: {

--- a/src/shared/setupWebPage.js
+++ b/src/shared/setupWebPage.js
@@ -137,28 +137,11 @@ function getInitialStateFromCapabilities(capabilities, userMetadata) {
 		}).reduce((acc, { app, key, value }) => ((acc[app] ??= {})[key] = value, acc), {})
 	*/
 
-	// TODO: make sure all use initial state is covered and there is no MISSED values
-	// TODO: when possible, migrate Initial State to capabilities
+	// TODO: make sure all used initial state is covered and there is no MISSED values
 	return {
 		spreed: {
-			call_enabled: capabilities?.spreed?.config?.call?.enabled,
 			signaling_mode: 'external', // MISSED
-			sip_dialin_info: '', // MISSED
-			grid_videos_limit: 19, // MISSED
-			grid_videos_limit_enforced: false, // MISSED
-			federation_enabled: capabilities?.spreed?.config?.federation?.enabled,
-			// default_permissions - MISSED (!)
-			start_conversations: capabilities?.spreed?.config?.conversations?.['can-create'],
-			circles_enabled: capabilities?.circles !== undefined,
-			guests_accounts_enabled: true, // MISSED
-			read_status_privacy: capabilities?.spreed?.config?.chat?.['read-privacy'],
-			typing_privacy: capabilities?.spreed?.config?.chat?.['typing-privacy'],
-			play_sounds: true, // MISSED
-			force_enable_blur_filter: 'yes', // Unused
 			user_group_ids: userMetadata?.groups,
-			attachment_folder: capabilities?.spreed?.config?.attachments?.folder,
-			attachment_folder_free_space: userMetadata?.quota?.free ?? 0,
-			enable_matterbridge: false, // MISSED
 		},
 		core: {
 			// reference-provider-list - MISSED


### PR DESCRIPTION
### ☑️ Resolves

- Follow-up: https://github.com/nextcloud/spreed/pull/17279
- Remove the unused initial state on the Talk v24's frontend:
  - Replaced on the frontend with old Talk/circles/guiests capabilities:
    - `call_enabled`, `federation_enabled`, `start_conversations`, `circles_enabled`, `guests_accounts_enabled`, `read_status_privacy`, `typing_privacy`, `attachment_folder`, `attachment_folder_free_space`
    - Available on Talk v17 or earlier => supports connecting to an old server
  - Replaced on the frontend with new Talk v23.0.2 capabilities ...
    - ... and may have a reasonable default fallback: `grid_videos_limit`, `grid_videos_limit_enforced`
    - ... and may have a local state: `play_sounds`
    - ... and have no fallback, but not critical: `sip_dialin_info`, `enable_matterbridge`
- Use new Talk v23.0.2 capability for `signaling_mode` initial state
  - Fallback is needed for older servers. To be added in another PR.
