### PR TITLE
build(deps): bump to Electron 41 with workarounds for known issues on Wayland

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,7 @@
         "cheerio": "^1.2.0",
         "css-loader": "^7.1.4",
         "dotenv": "^17.3.1",
-        "electron": "38.1.2",
+        "electron": "^41.1.1",
         "esbuild-loader": "^4.4.2",
         "eslint": "^9.39.1",
         "globals": "^17.4.0",
@@ -8358,15 +8358,15 @@
       "dev": true
     },
     "node_modules/electron": {
-      "version": "38.1.2",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-38.1.2.tgz",
-      "integrity": "sha512-WXUcN3W8h8NTTZViA3KNX0rV2YBU0X0mEUM3ubupXTDY4QtIN7tmiqYVOKSKpR2LckTmBWGuEeY4D6xVoffwKQ==",
+      "version": "41.1.1",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-41.1.1.tgz",
+      "integrity": "sha512-8bgvDhBjli+3Z2YCKgzzoBPh6391pr7Xv2h/tTJG4ETgvPvUxZomObbZLs31mUzYb6VrlcDDd9cyWyNKtPm3tA==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "@electron/get": "^2.0.0",
-        "@types/node": "^22.7.7",
+        "@types/node": "^24.9.0",
         "extract-zip": "^2.0.1"
       },
       "bin": {
@@ -8653,6 +8653,23 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/electron/node_modules/@types/node": {
+      "version": "24.12.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
+      "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
+    "node_modules/electron/node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "dev": true,
       "license": "MIT"
     },
@@ -24652,14 +24669,31 @@
       "dev": true
     },
     "electron": {
-      "version": "38.1.2",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-38.1.2.tgz",
-      "integrity": "sha512-WXUcN3W8h8NTTZViA3KNX0rV2YBU0X0mEUM3ubupXTDY4QtIN7tmiqYVOKSKpR2LckTmBWGuEeY4D6xVoffwKQ==",
+      "version": "41.1.1",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-41.1.1.tgz",
+      "integrity": "sha512-8bgvDhBjli+3Z2YCKgzzoBPh6391pr7Xv2h/tTJG4ETgvPvUxZomObbZLs31mUzYb6VrlcDDd9cyWyNKtPm3tA==",
       "dev": true,
       "requires": {
         "@electron/get": "^2.0.0",
-        "@types/node": "^22.7.7",
+        "@types/node": "^24.9.0",
         "extract-zip": "^2.0.1"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "24.12.2",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
+          "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
+          "dev": true,
+          "requires": {
+            "undici-types": "~7.16.0"
+          }
+        },
+        "undici-types": {
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+          "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+          "dev": true
+        }
       }
     },
     "electron-installer-common": {

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "cheerio": "^1.2.0",
     "css-loader": "^7.1.4",
     "dotenv": "^17.3.1",
-    "electron": "38.1.2",
+    "electron": "^41.1.1",
     "esbuild-loader": "^4.4.2",
     "eslint": "^9.39.1",
     "globals": "^17.4.0",

--- a/src/app/AppConfig.ts
+++ b/src/app/AppConfig.ts
@@ -1,4 +1,4 @@
-/*
+/*!
  * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
@@ -6,7 +6,7 @@
 import { app, webContents } from 'electron'
 import { readFile, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
-import { isLinux, isMac } from './system.utils.ts'
+import { isWayland, isMac } from './system.utils.ts'
 
 const APP_CONFIG_FILE_NAME = 'config.json'
 
@@ -69,7 +69,8 @@ export type AppConfig = {
 	theme: 'default' | 'dark' | 'light'
 	/**
 	 * Whether to use a custom title bar or the system default.
-	 * Default: true on Linux, false otherwise.
+	 * Default: false.
+	 * Not available on Linux on Wayland
 	 */
 	systemTitleBar: boolean
 	/**
@@ -139,7 +140,7 @@ const defaultAppConfig: AppConfig = {
 	accounts: [],
 	launchAtStartup: false,
 	theme: 'default',
-	systemTitleBar: isLinux,
+	systemTitleBar: false,
 	monochromeTrayIcon: isMac,
 	zoomFactor: 1,
 	playSoundChat: 'respect-dnd',
@@ -149,6 +150,14 @@ const defaultAppConfig: AppConfig = {
 	secondarySpeakerDevice: null,
 	trustedFingerprints: [],
 }
+
+/**
+ * Forced App Config
+ */
+const forcedAppConfig: Partial<AppConfig> = Object.fromEntries(Object.entries({
+	// See: https://github.com/electron/electron/issues/49244
+	systemTitleBar: isWayland ? false : undefined
+}).filter(([, value]) => value !== undefined))
 
 /** Local cache of the config file mixed with the default values */
 const appConfig: Partial<AppConfig> = {}
@@ -213,7 +222,7 @@ export function getAppConfig<T extends AppConfigKey>(key?: T): AppConfig | AppCo
 		throw new Error('The application config is not initialized yet')
 	}
 
-	const config = { ...defaultAppConfig, ...appConfig }
+	const config = { ...defaultAppConfig, ...appConfig, ...forcedAppConfig }
 
 	if (key) {
 		return config[key]
@@ -238,7 +247,7 @@ export function setAppConfig<K extends AppConfigKey>(key: K, value?: AppConfig[K
 		appConfig[key] = value
 	} else {
 		delete appConfig[key]
-		value = defaultAppConfig[key]
+		value = getAppConfig(key)
 	}
 
 	for (const contents of webContents.getAllWebContents()) {

--- a/src/app/utils.ts
+++ b/src/app/utils.ts
@@ -10,6 +10,7 @@ import { APP_ORIGIN } from '../constants.js'
 import { BUILD_CONFIG } from '../shared/build.config.ts'
 import { getAppConfig } from './AppConfig.ts'
 import { appData } from './AppData.js'
+import { isWayland } from './system.utils.ts'
 
 /**
  * Get the scaled window size based on the current zoom factor
@@ -68,7 +69,7 @@ export function getScaledWindowMinSize({ minWidth, minHeight }: { minWidth: numb
  */
 export function applyZoom(window: BrowserWindow) {
 	const zoomFactor = getAppConfig('zoomFactor')
-	window.once('ready-to-show', () => {
+	onReadyToShow(window, () => {
 		window.webContents.setZoomFactor(zoomFactor)
 	})
 }
@@ -169,4 +170,25 @@ export function getTitleBarSymbolColor(backgroundColor: string = BUILD_CONFIG.ba
 	function invertTextColor(color: string): boolean {
 		return colorContrast(color, '#ffffff') < 4.5
 	}
+}
+
+/**
+ * Equivalent to 'ready-to-show' event, but with a workaround for Chromium + Wayland issue on some GPUs
+ *
+ * @param window - Browser window
+ * @param callback - Callback
+ */
+export function onReadyToShow(window: BrowserWindow, callback: () => void) {
+	if (!isWayland) {
+		window.once('ready-to-show', callback)
+		return
+	}
+
+	// 'ready-to-show' may not be triggered on Wayland due to GPU sync issues in Chromium on some GPUs and VMware
+	// A workaround: wait for the page load and then for a tick
+	// See: https://github.com/electron/electron/issues/48859
+	window.webContents.once('did-finish-load', async () => {
+		await window.webContents.executeJavaScript('new Promise((resolve) => setTimeout(resolve, 0))')
+		callback()
+	})
 }

--- a/src/callbox/callbox.window.ts
+++ b/src/callbox/callbox.window.ts
@@ -6,7 +6,7 @@
 import { BrowserWindow, screen } from 'electron'
 import { getAppConfig } from '../app/AppConfig.ts'
 import { isMac, isWindows } from '../app/system.utils.ts'
-import { applyZoom, getScaledWindowSize, getWindowUrl } from '../app/utils.ts'
+import { applyZoom, getScaledWindowSize, getWindowUrl, onReadyToShow } from '../app/utils.ts'
 import { BUILD_CONFIG } from '../shared/build.config.ts'
 import { getBrowserWindowIcon } from '../shared/icons.utils.js'
 
@@ -70,7 +70,7 @@ export function createCallboxWindow(params: CallboxParams) {
 
 	window.loadURL(getWindowUrl('callbox') + '?' + new URLSearchParams(params))
 
-	window.once('ready-to-show', () => window.showInactive())
+	onReadyToShow(window, () => window.showInactive())
 
 	return window
 }

--- a/src/main.js
+++ b/src/main.js
@@ -20,7 +20,7 @@ const { initLaunchAtStartupListener } = require('./app/launchAtStartup.config.ts
 const { runMigrations } = require('./app/migration.service.ts')
 const { systemInfo, isLinux, isMac, isWindows, isSameExecution, isSquirrel, relaunchApp } = require('./app/system.utils.ts')
 const { applyTheme } = require('./app/theme.config.ts')
-const { buildTitle } = require('./app/utils.ts')
+const { buildTitle, onReadyToShow } = require('./app/utils.ts')
 const { enableWebRequestInterceptor, disableWebRequestInterceptor } = require('./app/webRequestInterceptor.js')
 const { createAuthenticationWindow } = require('./authentication/authentication.window.js')
 const { openLoginWebView } = require('./authentication/login.window.js')
@@ -185,7 +185,7 @@ app.whenReady().then(async () => {
 		// There is no window (possible on macOS) - create
 		if (!mainWindow || mainWindow.isDestroyed()) {
 			mainWindow = createMainWindow()
-			mainWindow.once('ready-to-show', () => mainWindow.show())
+			onReadyToShow(mainWindow, () => mainWindow.show())
 			return
 		}
 
@@ -243,7 +243,7 @@ app.whenReady().then(async () => {
 
 	mainWindow = createWelcomeWindow()
 	createMainWindow = createWelcomeWindow
-	mainWindow.once('ready-to-show', () => mainWindow.show())
+	onReadyToShow(mainWindow, () => mainWindow.show())
 
 	ipcMain.once('appData:receive', async (event, newAppData) => {
 		appData.fromJSON(newAppData)
@@ -264,7 +264,7 @@ app.whenReady().then(async () => {
 			createMainWindow = createAuthenticationWindow
 		}
 
-		mainWindow.once('ready-to-show', () => {
+		onReadyToShow(mainWindow, () => {
 			// Do not show the main window if it is the Talk Window opened in the background
 			const isTalkWindow = createMainWindow === createTalkWindow
 			if (!isTalkWindow || !openInBackground) {
@@ -304,7 +304,7 @@ app.whenReady().then(async () => {
 		mainWindow.close()
 		mainWindow = createTalkWindow()
 		createMainWindow = createTalkWindow
-		mainWindow.once('ready-to-show', () => mainWindow.show())
+		onReadyToShow(mainWindow, () => mainWindow.show())
 	})
 
 	ipcMain.handle('authentication:logout', async () => {
@@ -314,7 +314,7 @@ app.whenReady().then(async () => {
 			app.setBadgeCount(0)
 			const authenticationWindow = createAuthenticationWindow()
 			createMainWindow = createAuthenticationWindow
-			authenticationWindow.once('ready-to-show', () => authenticationWindow.show())
+			onReadyToShow(authenticationWindow, () => authenticationWindow.show())
 
 			mainWindow.destroy()
 			mainWindow = authenticationWindow
@@ -341,7 +341,7 @@ app.whenReady().then(async () => {
 		isInWindowRelaunch = true
 		mainWindow.destroy()
 		mainWindow = createMainWindow()
-		mainWindow.once('ready-to-show', () => mainWindow.show())
+		onReadyToShow(mainWindow, () => mainWindow.show())
 		isInWindowRelaunch = false
 	})
 
@@ -359,7 +359,7 @@ app.whenReady().then(async () => {
 			// dock icon is clicked and there are no other windows open.
 			// See window-all-closed event handler.
 			mainWindow = createMainWindow()
-			mainWindow.once('ready-to-show', () => mainWindow.show())
+			onReadyToShow(mainWindow, () => mainWindow.show())
 		}
 	})
 })

--- a/src/talk/renderer/Settings/DesktopSettingsSection.vue
+++ b/src/talk/renderer/Settings/DesktopSettingsSection.vue
@@ -22,6 +22,7 @@ import { useAppConfigStore } from './appConfig.store.ts'
 import { useAppConfigValue } from './useAppConfigValue.ts'
 
 const isLinux = window.systemInfo.isLinux
+const isWayland = window.systemInfo.isWayland
 
 const { isRelaunchRequired } = storeToRefs(useAppConfigStore())
 
@@ -73,7 +74,7 @@ const secondarySpeakerDevice = useAppConfigValue('secondarySpeakerDevice')
 		<NcFormGroup :label="t('talk_desktop', 'Appearance')">
 			<NcFormBox>
 				<NcFormBoxSwitch v-model="monochromeTrayIcon" :label="t('talk_desktop', 'Use monochrome tray icon')" />
-				<NcFormBoxSwitch v-model="systemTitleBar" :label="t('talk_desktop', 'Use system title bar')" />
+				<NcFormBoxSwitch v-if="!isWayland" v-model="systemTitleBar" :label="t('talk_desktop', 'Use system title bar')" />
 			</NcFormBox>
 		</NcFormGroup>
 


### PR DESCRIPTION
### ☑️ Resolves

- Electron 38 is EOL
  - Fix: https://github.com/nextcloud/talk-desktop/pull/1706
  - Also needed for improved msix support and some minor improvements like saving macos tray icon position
- Includes some workarounds:
  - Ref: https://github.com/nextcloud/talk-desktop/issues/1640
  - Uses custom `ready-to-show` on Wayland
  - Removed system title bar support on Wayland
- There are still some issues with the tray icon - will be fixed in another PR

