### PR TITLE
fix(linux/wayland): infinite load due to Chromium bug with ready-to-show

### DIFF
--- a/src/certificate/certificate.window.ts
+++ b/src/certificate/certificate.window.ts
@@ -8,7 +8,7 @@ import type { UntrustedCertificateDetails } from '../app/certificate.service.ts'
 
 import { BrowserWindow, ipcMain } from 'electron'
 import { applyContextMenu } from '../app/applyContextMenu.js'
-import { applyZoom, buildTitle, getScaledWindowMinSize, getScaledWindowSize, getWindowUrl } from '../app/utils.ts'
+import { applyZoom, buildTitle, getScaledWindowMinSize, getScaledWindowSize, getWindowUrl, onReadyToShow } from '../app/utils.ts'
 import { getBrowserWindowIcon } from '../shared/icons.utils.js'
 
 /**
@@ -46,7 +46,7 @@ export function showCertificateTrustDialog(parentWindow: BrowserWindow, details:
 	applyContextMenu(window)
 	applyZoom(window)
 	window.removeMenu()
-	window.on('ready-to-show', () => window.show())
+	onReadyToShow(window, () => window.show())
 
 	window.loadURL(getWindowUrl('certificate') + '#' + encodeURIComponent(JSON.stringify(details)))
 

--- a/src/help/help.window.js
+++ b/src/help/help.window.js
@@ -6,7 +6,7 @@
 const { BrowserWindow } = require('electron')
 const { applyContextMenu } = require('../app/applyContextMenu.js')
 const { applyExternalLinkHandler } = require('../app/externalLinkHandlers.ts')
-const { getScaledWindowSize, applyZoom, buildTitle, getWindowUrl } = require('../app/utils.ts')
+const { getScaledWindowSize, applyZoom, buildTitle, getWindowUrl, onReadyToShow } = require('../app/utils.ts')
 const { getBrowserWindowIcon } = require('../shared/icons.utils.js')
 
 /**
@@ -43,9 +43,7 @@ function createHelpWindow(parentWindow) {
 	applyContextMenu(window)
 	applyZoom(window)
 
-	window.on('ready-to-show', () => {
-		window.show()
-	})
+	onReadyToShow(window, () => window.show())
 
 	return window
 }

--- a/src/upgrade/upgrade.window.ts
+++ b/src/upgrade/upgrade.window.ts
@@ -6,7 +6,7 @@
 import { BrowserWindow } from 'electron'
 import { applyContextMenu } from '../app/applyContextMenu.js'
 import { applyExternalLinkHandler } from '../app/externalLinkHandlers.ts'
-import { applyZoom, buildTitle, getScaledWindowSize, getWindowUrl } from '../app/utils.ts'
+import { applyZoom, buildTitle, getScaledWindowSize, getWindowUrl, onReadyToShow } from '../app/utils.ts'
 import { getBrowserWindowIcon } from '../shared/icons.utils.js'
 
 /**
@@ -39,9 +39,7 @@ export function createUpgradeWindow() {
 	applyExternalLinkHandler(window)
 	applyZoom(window)
 
-	window.on('ready-to-show', () => {
-		window.show()
-	})
+	onReadyToShow(window, () => window.show())
 
 	return window
 }


### PR DESCRIPTION
### ☑️ Resolves

- Leftovers from: https://github.com/nextcloud/talk-desktop/pull/1709

I missed windows that used `.on` instead of `.once` 😶