### PR TITLE
build: add missing ghost dependencies and remove unused dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@mdi/svg": "^7.4.47",
+        "@nextcloud/auth": "^2.5.3",
         "@nextcloud/axios": "^2.5.2",
         "@nextcloud/browser-storage": "^0.5.0",
         "@nextcloud/capabilities": "^1.2.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,8 @@
         "semver": "^7.7.4",
         "unzip-crx-3": "^0.2.0",
         "vue": "^3.5.30",
-        "vue-material-design-icons": "^5.3.1"
+        "vue-material-design-icons": "^5.3.1",
+        "vue-router": "^5.0.4"
       },
       "devDependencies": {
         "@electron-forge/cli": "^7.11.1",
@@ -18091,9 +18092,9 @@
       }
     },
     "node_modules/vue-router": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-5.0.3.tgz",
-      "integrity": "sha512-nG1c7aAFac7NYj8Hluo68WyWfc41xkEjaR0ViLHCa3oDvTQ/nIuLJlXJX1NUPw/DXzx/8+OKMng045HHQKQKWw==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-5.0.4.tgz",
+      "integrity": "sha512-lCqDLCI2+fKVRl2OzXuzdSWmxXFLQRxQbmHugnRpTMyYiT+hNaycV0faqG5FBHDXoYrZ6MQcX87BvbY8mQ20Bg==",
       "license": "MIT",
       "dependencies": {
         "@babel/generator": "^7.28.6",
@@ -31223,9 +31224,9 @@
       "requires": {}
     },
     "vue-router": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-5.0.3.tgz",
-      "integrity": "sha512-nG1c7aAFac7NYj8Hluo68WyWfc41xkEjaR0ViLHCa3oDvTQ/nIuLJlXJX1NUPw/DXzx/8+OKMng045HHQKQKWw==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-5.0.4.tgz",
+      "integrity": "sha512-lCqDLCI2+fKVRl2OzXuzdSWmxXFLQRxQbmHugnRpTMyYiT+hNaycV0faqG5FBHDXoYrZ6MQcX87BvbY8mQ20Bg==",
       "requires": {
         "@babel/generator": "^7.28.6",
         "@vue-macros/common": "^3.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,8 @@
         "unzip-crx-3": "^0.2.0",
         "vue": "^3.5.30",
         "vue-material-design-icons": "^5.3.1",
-        "vue-router": "^5.0.4"
+        "vue-router": "^5.0.4",
+        "webdav": "^5.9.0"
       },
       "devDependencies": {
         "@electron-forge/cli": "^7.11.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
         "@nextcloud/auth": "^2.5.3",
         "@nextcloud/axios": "^2.5.2",
         "@nextcloud/browser-storage": "^0.5.0",
-        "@nextcloud/capabilities": "^1.2.1",
         "@nextcloud/event-bus": "^3.3.2",
         "@nextcloud/files": "^4.0.0",
         "@nextcloud/initial-state": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "@nextcloud/auth": "^2.5.3",
     "@nextcloud/axios": "^2.5.2",
     "@nextcloud/browser-storage": "^0.5.0",
-    "@nextcloud/capabilities": "^1.2.1",
     "@nextcloud/event-bus": "^3.3.2",
     "@nextcloud/files": "^4.0.0",
     "@nextcloud/initial-state": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
   },
   "dependencies": {
     "@mdi/svg": "^7.4.47",
+    "@nextcloud/auth": "^2.5.3",
     "@nextcloud/axios": "^2.5.2",
     "@nextcloud/browser-storage": "^0.5.0",
     "@nextcloud/capabilities": "^1.2.1",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,8 @@
     "unzip-crx-3": "^0.2.0",
     "vue": "^3.5.30",
     "vue-material-design-icons": "^5.3.1",
-    "vue-router": "^5.0.4"
+    "vue-router": "^5.0.4",
+    "webdav": "^5.9.0"
   },
   "devDependencies": {
     "@electron-forge/cli": "^7.11.1",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,8 @@
     "semver": "^7.7.4",
     "unzip-crx-3": "^0.2.0",
     "vue": "^3.5.30",
-    "vue-material-design-icons": "^5.3.1"
+    "vue-material-design-icons": "^5.3.1",
+    "vue-router": "^5.0.4"
   },
   "devDependencies": {
     "@electron-forge/cli": "^7.11.1",

--- a/src/app/app.tray.js
+++ b/src/app/app.tray.js
@@ -4,7 +4,7 @@
  */
 
 const { app, Tray, Menu } = require('electron')
-const path = require('path')
+const path = require('node:path')
 const { getTrayIcon } = require('../shared/icons.utils.js')
 
 let isAppQuitting = false

--- a/src/shared/icons.utils.js
+++ b/src/shared/icons.utils.js
@@ -4,7 +4,7 @@
  */
 
 const { app, nativeTheme } = require('electron')
-const path = require('path')
+const path = require('node:path')
 const { getAppConfig } = require('../app/AppConfig.ts')
 const { isLinux, platform } = require('../app/system.utils.ts')
 


### PR DESCRIPTION
### ☑️ Resolves

- All the dependencies were available as transitive but not directly listed as dependencies
- `@nextcloud/capabilities` is no longer used
- Also, import node built-in modules with `node:` prefix to distinguish from npm packages
