### PR TITLE
build: update built-in Talk versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,8 +42,8 @@
     "ts:check": "vue-tsc --noEmit"
   },
   "talk": {
-    "stable": "v23.0.3",
-    "beta": "v23.0.3",
+    "stable": "v23.0.4",
+    "beta": "v23.0.4",
     "dev": "main"
   },
   "dependencies": {


### PR DESCRIPTION
## Update Built-in Talk Version

Stable:
- Current: v23.0.3
- Latest: v23.0.4

Beta:
- Current: v23.0.3
- Latest: v23.0.4

Updating stable from v23.0.3 to v23.0.4
Updating beta from v23.0.3 to v23.0.4