### PR TITLE
fix(mac): correct "Report a bug" window menu link

### DIFF
--- a/src/app/app.menu.js
+++ b/src/app/app.menu.js
@@ -122,7 +122,7 @@ function setupMenu() {
 				? []
 				: [
 						createLinkMenuItem('Homepage', packageJson.repository.url),
-						createLinkMenuItem('Report a bug', packageJson.bugs),
+						createLinkMenuItem('Report a bug', packageJson.bugs.create),
 						createLinkMenuItem('Source Code', packageJson.repository.url),
 					]
 			),

--- a/src/talk/renderer/TitleBar/components/MainMenu.vue
+++ b/src/talk/renderer/TitleBar/components/MainMenu.vue
@@ -100,7 +100,7 @@ onBeforeUnmount(() => {
 		</NcActionButton>
 		<NcActionLink
 			v-if="!BUILD_CONFIG.isBranded"
-			:href="packageInfo.bugs.create || packageInfo.bugs.url"
+			:href="packageInfo.bugs.create"
 			target="_blank"
 			close-after-click>
 			<template #icon>


### PR DESCRIPTION
### ☑️ Resolves

- Fix: https://github.com/nextcloud/talk-desktop/issues/1729
- In the past `package.json` had only the `bugs` link
- Then it became an object with 2 links now: issue list and creating an issue
- I forgot to update the macOS menu in the past