### PR TITLE
build: update built-in Talk versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   },
   "talk": {
     "stable": "v23.0.4",
-    "beta": "v23.0.4",
+    "beta": "v24.0.0-rc.1",
     "dev": "main"
   },
   "dependencies": {


### PR DESCRIPTION
## Update Built-in Talk Version

Stable:
- Current: v23.0.4
- Latest: v23.0.4

Beta:
- Current: v23.0.4
- Latest: v24.0.0-rc.1

Updating beta from v23.0.4 to v24.0.0-rc.1