### PR TITLE
feat: add enterprise server URL configuration

### DIFF
--- a/src/app/policy.config.ts
+++ b/src/app/policy.config.ts
@@ -9,6 +9,7 @@ import { isMac, isWindows } from './system.utils.ts'
 
 export type PolicyConfig = {
 	serverUrl?: string
+	enforceServerUrl?: boolean
 }
 
 /**
@@ -17,7 +18,7 @@ export type PolicyConfig = {
  * @param key - Registry key
  * @param name - Value name
  */
-function getWindowsPolicyValue(key: string, name: string): string | undefined {
+function getRegistryValue(key: string, name: string): string | undefined {
 	try {
 		const stdout = execFileSync('reg', ['query', key, '/v', name], { encoding: 'utf8', windowsHide: true })
 		return stdout.match(new RegExp(`\\s${name}\\s+REG_\\w+\\s+(.+)`, 'i'))?.[1]?.trim()
@@ -27,37 +28,30 @@ function getWindowsPolicyValue(key: string, name: string): string | undefined {
 }
 
 /**
- * Get deployment configuration from Windows policy.
- */
-function getWindowsPolicyConfig(): PolicyConfig {
-	for (const key of ['HKLM\\Software\\Policies\\Nextcloud\\Talk', 'HKCU\\Software\\Policies\\Nextcloud\\Talk']) {
-		const serverUrl = getWindowsPolicyValue(key, 'ServerUrl')
-		if (serverUrl) {
-			return { serverUrl }
-		}
-	}
-
-	return {}
-}
-
-/**
- * Get deployment configuration from macOS managed preferences.
- */
-function getMacPolicyConfig(): PolicyConfig {
-	const serverUrl = systemPreferences.getUserDefault('ServerUrl', 'string')
-	return serverUrl ? { serverUrl } : {}
-}
-
-/**
  * Get deployment configuration from OS policy.
  */
 export function getPolicyConfig(): PolicyConfig {
 	if (isWindows) {
-		return getWindowsPolicyConfig()
+		for (const key of ['HKLM\\Software\\Policies\\Nextcloud\\Talk', 'HKCU\\Software\\Policies\\Nextcloud\\Talk']) {
+			const serverUrl = getRegistryValue(key, 'ServerUrl')
+			if (serverUrl) {
+				const enforceServerUrl = getRegistryValue(key, 'EnforceServerUrl')
+				return {
+					serverUrl,
+					enforceServerUrl: enforceServerUrl === '1' || enforceServerUrl === '0x1' || enforceServerUrl?.toLowerCase() === 'true',
+				}
+			}
+		}
 	}
 
 	if (isMac) {
-		return getMacPolicyConfig()
+		const serverUrl = systemPreferences.getUserDefault('ServerUrl', 'string')
+		if (serverUrl) {
+			return {
+				serverUrl,
+				enforceServerUrl: systemPreferences.getUserDefault('EnforceServerUrl', 'boolean'),
+			}
+		}
 	}
 
 	return {}

--- a/src/app/policy.config.ts
+++ b/src/app/policy.config.ts
@@ -1,0 +1,64 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { systemPreferences } from 'electron'
+import { execFileSync } from 'node:child_process'
+import { isMac, isWindows } from './system.utils.ts'
+
+export type PolicyConfig = {
+	serverUrl?: string
+}
+
+/**
+ * Read a single Windows policy registry value.
+ *
+ * @param key - Registry key
+ * @param name - Value name
+ */
+function getWindowsPolicyValue(key: string, name: string): string | undefined {
+	try {
+		const stdout = execFileSync('reg', ['query', key, '/v', name], { encoding: 'utf8', windowsHide: true })
+		return stdout.match(new RegExp(`\\s${name}\\s+REG_\\w+\\s+(.+)`, 'i'))?.[1]?.trim()
+	} catch {
+		return undefined
+	}
+}
+
+/**
+ * Get deployment configuration from Windows policy.
+ */
+function getWindowsPolicyConfig(): PolicyConfig {
+	for (const key of ['HKLM\\Software\\Policies\\Nextcloud\\Talk', 'HKCU\\Software\\Policies\\Nextcloud\\Talk']) {
+		const serverUrl = getWindowsPolicyValue(key, 'ServerUrl')
+		if (serverUrl) {
+			return { serverUrl }
+		}
+	}
+
+	return {}
+}
+
+/**
+ * Get deployment configuration from macOS managed preferences.
+ */
+function getMacPolicyConfig(): PolicyConfig {
+	const serverUrl = systemPreferences.getUserDefault('ServerUrl', 'string')
+	return serverUrl ? { serverUrl } : {}
+}
+
+/**
+ * Get deployment configuration from OS policy.
+ */
+export function getPolicyConfig(): PolicyConfig {
+	if (isWindows) {
+		return getWindowsPolicyConfig()
+	}
+
+	if (isMac) {
+		return getMacPolicyConfig()
+	}
+
+	return {}
+}

--- a/src/authentication/renderer/AuthenticationApp.vue
+++ b/src/authentication/renderer/AuthenticationApp.vue
@@ -44,7 +44,12 @@ const serverUrl = computed(() => {
 const state = ref('idle')
 const stateText = ref('')
 
-onMounted(() => {
+onMounted(async () => {
+	const { serverUrl } = await window.TALK_DESKTOP.getPolicyConfig()
+	if (serverUrl) {
+		rawServerUrl.value = serverUrl
+	}
+
 	if (enforceDomain) {
 		login()
 	}

--- a/src/authentication/renderer/AuthenticationApp.vue
+++ b/src/authentication/renderer/AuthenticationApp.vue
@@ -29,7 +29,7 @@ let [prefilledServer, prefilledUser] = atIndex === -1
 	: [prefilledAccount.slice(atIndex + 1), prefilledAccount.slice(0, atIndex)]
 
 const rawServerUrl = ref(BUILD_CONFIG.domain ?? prefilledServer)
-const enforceDomain = Boolean(BUILD_CONFIG.domain && BUILD_CONFIG.enforceDomain)
+let enforceDomain = Boolean(BUILD_CONFIG.domain && BUILD_CONFIG.enforceDomain)
 
 const allowReset = computed(() => !!(rawServerUrl.value && !enforceDomain))
 
@@ -45,8 +45,9 @@ const state = ref('idle')
 const stateText = ref('')
 
 onMounted(async () => {
-	const { serverUrl } = await window.TALK_DESKTOP.getPolicyConfig()
+	const { serverUrl, enforceServerUrl } = await window.TALK_DESKTOP.getPolicyConfig()
 	if (serverUrl) {
+		enforceDomain ||= Boolean(enforceServerUrl)
 		rawServerUrl.value = serverUrl
 	}
 

--- a/src/main.js
+++ b/src/main.js
@@ -18,6 +18,7 @@ const { triggerDownloadUrl } = require('./app/downloads.ts')
 const { setupReleaseNotificationScheduler, checkForUpdate } = require('./app/githubRelease.service.ts')
 const { initLaunchAtStartupListener } = require('./app/launchAtStartup.config.ts')
 const { runMigrations } = require('./app/migration.service.ts')
+const { getPolicyConfig } = require('./app/policy.config.ts')
 const { systemInfo, isLinux, isMac, isWindows, isSameExecution, isSquirrel, relaunchApp } = require('./app/system.utils.ts')
 const { applyTheme } = require('./app/theme.config.ts')
 const { buildTitle, onReadyToShow } = require('./app/utils.ts')
@@ -76,6 +77,7 @@ if (!app.requestSingleInstanceLock()) {
 
 ipcMain.on('app:quit', () => app.quit())
 ipcMain.handle('app:getSystemInfo', () => systemInfo)
+ipcMain.handle('app:getPolicyConfig', () => getPolicyConfig())
 ipcMain.handle('app:buildTitle', (event, title) => buildTitle(title))
 ipcMain.handle('app:getSystemL10n', () => ({
 	locale: app.getLocale().replace('-', '_') ?? 'en',

--- a/src/preload.js
+++ b/src/preload.js
@@ -45,7 +45,7 @@ const TALK_DESKTOP = {
 	/**
 	 * Get deployment configuration from policy.
 	 *
-	 * @return {Promise<{ serverUrl?: string }>}
+	 * @return {Promise<{ serverUrl?: string, enforceServerUrl?: boolean }>}
 	 */
 	getPolicyConfig: () => ipcRenderer.invoke('app:getPolicyConfig'),
 	/**

--- a/src/preload.js
+++ b/src/preload.js
@@ -43,6 +43,12 @@ const TALK_DESKTOP = {
 	 */
 	getSystemInfo: () => ipcRenderer.invoke('app:getSystemInfo'),
 	/**
+	 * Get deployment configuration from policy.
+	 *
+	 * @return {Promise<{ serverUrl?: string }>}
+	 */
+	getPolicyConfig: () => ipcRenderer.invoke('app:getPolicyConfig'),
+	/**
 	 * Get system locale and preferred language
 	 *
 	 * @return {Promise<{ locale: string, language: string }>}


### PR DESCRIPTION
Add enterprise policy support so IT admins can preconfigure the Nextcloud server URL via Windows GPO (HKLM/HKCU\Software\Policies\Nextcloud\Talk) or macOS MDM preferences on com.nextcloud.talk.mac. The app reads ServerUrl at startup and optionally EnforceServerUrl to prefill the login field and skip the setup window when enforcement is enabled.