### PR TITLE
feat(Viewer): add zoom/pan and rotate to image viewer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "electron-squirrel-startup": "^1.0.1",
         "howler": "^2.2.4",
         "mri": "^1.2.0",
+        "panzoom": "^9.4.4",
         "pinia": "^3.0.4",
         "semver": "^7.7.4",
         "unzip-crx-3": "^0.2.0",
@@ -5889,6 +5890,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/amator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/amator/-/amator-1.1.0.tgz",
+      "integrity": "sha512-V5+aH8pe+Z3u/UG3L3pG3BaFQGXAyXHVQDroRwjPHdh08bcUEchAVsU1MCuJSCaU5o60wTK6KaE6te5memzgYw==",
+      "license": "MIT",
+      "dependencies": {
+        "bezier-easing": "^2.0.3"
+      }
+    },
     "node_modules/ansi-escapes": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-5.0.0.tgz",
@@ -6216,6 +6226,12 @@
     "node_modules/batch": {
       "version": "0.6.1",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/bezier-easing": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/bezier-easing/-/bezier-easing-2.1.0.tgz",
+      "integrity": "sha512-gbIqZ/eslnUFC1tjEvtz0sgx+xTK20wDnYMIA27VA04R7w6xxXQPZDbibjA9DTWZRA2CXtwHykkVzlCaAJAZig==",
       "license": "MIT"
     },
     "node_modules/big.js": {
@@ -13640,6 +13656,12 @@
       "integrity": "sha512-yFehXNWRs4cM0+dz7QxCd06hTbWbSkV0ISsqBfkntU6TOY4Qm3Q88fRRLOddkGh2Qq6dZvnKVAahfhjcUvLnyA==",
       "license": "MIT"
     },
+    "node_modules/ngraph.events": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/ngraph.events/-/ngraph.events-1.4.0.tgz",
+      "integrity": "sha512-NeDGI4DSyjBNBRtA86222JoYietsmCXbs8CEB0dZ51Xeh4lhVl1y3wpWLumczvnha8sFQIW4E0vvVWwgmX2mGw==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/nice-try": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
@@ -14299,6 +14321,17 @@
     "node_modules/pako": {
       "version": "1.0.11",
       "license": "(MIT AND Zlib)"
+    },
+    "node_modules/panzoom": {
+      "version": "9.4.4",
+      "resolved": "https://registry.npmjs.org/panzoom/-/panzoom-9.4.4.tgz",
+      "integrity": "sha512-r1KfkNZvsBw59IPq7Yy+GWZnZE1YCG/t7aG6caSkij/TBqdxTzmxNTm/lHf3h6qlVMFisIGIO+lgS2Ym23PIoA==",
+      "license": "MIT",
+      "dependencies": {
+        "amator": "^1.1.0",
+        "ngraph.events": "^1.2.2",
+        "wheel": "^1.0.0"
+      }
     },
     "node_modules/param-case": {
       "version": "3.0.4",
@@ -18800,6 +18833,12 @@
         "webidl-conversions": "^3.0.0"
       }
     },
+    "node_modules/wheel": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wheel/-/wheel-1.0.0.tgz",
+      "integrity": "sha512-XiCMHibOiqalCQ+BaNSwRoZ9FDTAvOsXxGHXChBugewDj7HC8VBIER71dEOiRH1fSdLbRCQzngKTSiZ06ZQzeA==",
+      "license": "MIT"
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "dev": true,
@@ -22979,6 +23018,14 @@
       "integrity": "sha512-d9dYqZTS90WLiU0I5c6DHj/HcKkF8ZyGN3G5x8wSbslulz70KOxaqCT0hQCo9KOyhVqzqGojvNdJXoTumZOtcw==",
       "dev": true
     },
+    "amator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/amator/-/amator-1.1.0.tgz",
+      "integrity": "sha512-V5+aH8pe+Z3u/UG3L3pG3BaFQGXAyXHVQDroRwjPHdh08bcUEchAVsU1MCuJSCaU5o60wTK6KaE6te5memzgYw==",
+      "requires": {
+        "bezier-easing": "^2.0.3"
+      }
+    },
     "ansi-escapes": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-5.0.0.tgz",
@@ -23198,6 +23245,11 @@
     "batch": {
       "version": "0.6.1",
       "dev": true
+    },
+    "bezier-easing": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/bezier-easing/-/bezier-easing-2.1.0.tgz",
+      "integrity": "sha512-gbIqZ/eslnUFC1tjEvtz0sgx+xTK20wDnYMIA27VA04R7w6xxXQPZDbibjA9DTWZRA2CXtwHykkVzlCaAJAZig=="
     },
     "big.js": {
       "version": "5.2.2",
@@ -28224,6 +28276,11 @@
       "resolved": "https://registry.npmjs.org/nested-property/-/nested-property-4.0.0.tgz",
       "integrity": "sha512-yFehXNWRs4cM0+dz7QxCd06hTbWbSkV0ISsqBfkntU6TOY4Qm3Q88fRRLOddkGh2Qq6dZvnKVAahfhjcUvLnyA=="
     },
+    "ngraph.events": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/ngraph.events/-/ngraph.events-1.4.0.tgz",
+      "integrity": "sha512-NeDGI4DSyjBNBRtA86222JoYietsmCXbs8CEB0dZ51Xeh4lhVl1y3wpWLumczvnha8sFQIW4E0vvVWwgmX2mGw=="
+    },
     "nice-try": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
@@ -28651,6 +28708,16 @@
     },
     "pako": {
       "version": "1.0.11"
+    },
+    "panzoom": {
+      "version": "9.4.4",
+      "resolved": "https://registry.npmjs.org/panzoom/-/panzoom-9.4.4.tgz",
+      "integrity": "sha512-r1KfkNZvsBw59IPq7Yy+GWZnZE1YCG/t7aG6caSkij/TBqdxTzmxNTm/lHf3h6qlVMFisIGIO+lgS2Ym23PIoA==",
+      "requires": {
+        "amator": "^1.1.0",
+        "ngraph.events": "^1.2.2",
+        "wheel": "^1.0.0"
+      }
     },
     "param-case": {
       "version": "3.0.4",
@@ -31683,6 +31750,11 @@
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
       }
+    },
+    "wheel": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wheel/-/wheel-1.0.0.tgz",
+      "integrity": "sha512-XiCMHibOiqalCQ+BaNSwRoZ9FDTAvOsXxGHXChBugewDj7HC8VBIER71dEOiRH1fSdLbRCQzngKTSiZ06ZQzeA=="
     },
     "which": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "electron-squirrel-startup": "^1.0.1",
     "howler": "^2.2.4",
     "mri": "^1.2.0",
+    "panzoom": "^9.4.4",
     "pinia": "^3.0.4",
     "semver": "^7.7.4",
     "unzip-crx-3": "^0.2.0",

--- a/src/talk/renderer/Viewer/ViewerApp.vue
+++ b/src/talk/renderer/Viewer/ViewerApp.vue
@@ -7,6 +7,7 @@
 import { translate as t } from '@nextcloud/l10n'
 import { generateUrl } from '@nextcloud/router'
 import { computed, ref } from 'vue'
+import NcActionButton from '@nextcloud/vue/components/NcActionButton'
 import NcActionLink from '@nextcloud/vue/components/NcActionLink'
 import NcModal from '@nextcloud/vue/components/NcModal'
 import IconOpenInNew from 'vue-material-design-icons/OpenInNew.vue'
@@ -19,6 +20,7 @@ function noop() {}
 const isOpen = ref(false)
 const onClose = ref(noop)
 const file = ref(null)
+const viewerRef = ref(null)
 
 const viewComponent = computed(() => file.value && window.OCA.Viewer.availableHandlers.find((handler) => handler.mimes.includes(file.value.mime))?.component)
 
@@ -67,9 +69,19 @@ defineExpose({
 		<component
 			:is="viewComponent"
 			v-if="viewComponent"
+			ref="viewerRef"
 			:file="file" />
 
 		<template #actions>
+			<NcActionButton
+				v-for="action in (viewerRef?.actions ?? [])"
+				:key="action.key"
+				@click="action.onClick()">
+				<template #icon>
+					<component :is="action.icon" :size="20" />
+				</template>
+				{{ action.label }}
+			</NcActionButton>
 			<NcActionLink :href="link">
 				<template #icon>
 					<IconOpenInNew :size="20" />

--- a/src/talk/renderer/Viewer/ViewerHandlerImages.vue
+++ b/src/talk/renderer/Viewer/ViewerHandlerImages.vue
@@ -68,16 +68,25 @@ function disposePanzoom() {
 	grabbing.value = false
 }
 
+/**
+ * @param {Function} handleLoadEnd - Callback to signal load completion
+ */
 function onImageLoad(handleLoadEnd) {
 	handleLoadEnd(false)
 	initPanzoom()
 }
 
+/**
+ * @param {Function} handleLoadEnd - Callback to signal load error
+ */
 function onImageError(handleLoadEnd) {
 	handleLoadEnd(true)
 	disposePanzoom()
 }
 
+/**
+ * @param {MouseEvent} event - The double-click event
+ */
 function onDoubleClick(event) {
 	if (!instance.value) {
 		return

--- a/src/talk/renderer/Viewer/ViewerHandlerImages.vue
+++ b/src/talk/renderer/Viewer/ViewerHandlerImages.vue
@@ -125,7 +125,7 @@ function onDoubleClick(event) {
 	if (scale.value === 1) {
 		instance.smoothZoom(x, y, ZOOM_FACTOR)
 	} else {
-		instance.smoothZoomAbs(x, y, 0)
+		instance.smoothZoomAbs(x, y, ZOOM_MIN)
 	}
 }
 

--- a/src/talk/renderer/Viewer/ViewerHandlerImages.vue
+++ b/src/talk/renderer/Viewer/ViewerHandlerImages.vue
@@ -4,7 +4,8 @@
 -->
 
 <script setup>
-import { computed } from 'vue'
+import panzoom from 'panzoom'
+import { computed, onBeforeUnmount, ref, watch } from 'vue'
 import ViewerHandlerMedia from './ViewerHandlerMedia.vue'
 import { generateFilePreviewUrl } from './viewer.utils.ts'
 
@@ -14,19 +15,135 @@ const props = defineProps({
 		required: true,
 	},
 })
+const ZOOM_MIN = 1
+const ZOOM_MAX = 8
+const ZOOM_FACTOR = 3
 
 const src = computed(() => generateFilePreviewUrl(props.file.fileid, props.file.etag))
+
+const wrapperRef = ref(null)
+const instance = ref(null)
+const scale = ref(1)
+const grabbing = ref(false)
+
+const cursorClass = computed(() => {
+	if (scale.value === 1) {
+		return 'viewer-image--zoom-in'
+	}
+	return grabbing.value ? 'viewer-image--grabbing' : 'viewer-image--grab'
+})
+
+function initPanzoom() {
+	if (!wrapperRef.value) {
+		return
+	}
+	instance.value = panzoom(wrapperRef.value, {
+		minZoom: ZOOM_MIN,
+		maxZoom: ZOOM_MAX,
+		bounds: true,
+		boundsPadding: 0.1,
+	})
+	instance.value.on('zoom', (pz) => {
+		const transform = pz.getTransform()
+		scale.value = transform.scale
+		if (transform.scale <= ZOOM_MIN) {
+			pz.smoothMoveTo(0, 0)
+		}
+	})
+	instance.value.on('panstart', (pz) => {
+		if (pz.getTransform().scale <= ZOOM_MIN) {
+			return
+		}
+		grabbing.value = true
+	})
+	instance.value.on('panend', () => {
+		grabbing.value = false
+	})
+}
+
+function disposePanzoom() {
+	instance.value?.dispose()
+	instance.value = null
+	scale.value = 1
+	grabbing.value = false
+}
+
+function onImageLoad(handleLoadEnd) {
+	handleLoadEnd(false)
+	initPanzoom()
+}
+
+function onImageError(handleLoadEnd) {
+	handleLoadEnd(true)
+	disposePanzoom()
+}
+
+function onDoubleClick(event) {
+	if (!instance.value) {
+		return
+	}
+	event.preventDefault()
+	event.stopPropagation()
+	const rect = event.currentTarget.getBoundingClientRect()
+	const x = event.clientX - rect.left
+	const y = event.clientY - rect.top
+	if (scale.value === 1) {
+		instance.value.smoothZoom(x, y, ZOOM_FACTOR)
+	} else {
+		instance.value.smoothZoomAbs(x, y, 0)
+	}
+}
+
+watch(src, disposePanzoom)
+
+onBeforeUnmount(disposePanzoom)
 </script>
 
 <template>
-	<ViewerHandlerMedia v-slot="{ mediaClass, handleLoadEnd }">
-		<img
-			:key="src"
-			class="viewer-image"
-			:class="mediaClass"
-			:src="src"
-			:alt="file.basename"
-			@load="handleLoadEnd(false)"
-			@error="handleLoadEnd(true)">
+	<ViewerHandlerMedia v-slot="{ handleLoadEnd }">
+		<div class="viewer-image-container" @dblclick.capture="onDoubleClick">
+			<div ref="wrapperRef" class="viewer-image-wrapper" :class="cursorClass">
+				<img
+					:key="src"
+					class="viewer-image"
+					:src="src"
+					:alt="file.basename"
+					@load="onImageLoad(handleLoadEnd)"
+					@error="onImageError(handleLoadEnd)">
+			</div>
+		</div>
 	</ViewerHandlerMedia>
 </template>
+
+<style scoped>
+.viewer-image-container {
+	width: 100%;
+	height: 100%;
+	overflow: hidden;
+}
+
+.viewer-image-wrapper {
+	width: 100%;
+	height: 100%;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+}
+
+.viewer-image {
+	max-width: 100%;
+	max-height: 100%;
+}
+
+.viewer-image--zoom-in {
+	cursor: zoom-in;
+}
+
+.viewer-image--grab {
+	cursor: grab;
+}
+
+.viewer-image--grabbing {
+	cursor: grabbing;
+}
+</style>

--- a/src/talk/renderer/Viewer/ViewerHandlerImages.vue
+++ b/src/talk/renderer/Viewer/ViewerHandlerImages.vue
@@ -48,7 +48,7 @@ function clampToBounds() {
 	if (rect.bottom < parentRect.bottom) newY += parentRect.bottom - rect.bottom
 
 	if (newX !== x || newY !== y) {
-		instance.smoothMoveTo(newX, newY)
+		instance.moveTo(newX, newY)
 	}
 }
 
@@ -56,6 +56,9 @@ function initPanzoom() {
 	instance = panzoom(panzoomWrapperRef.value, {
 		minZoom: ZOOM_MIN,
 		maxZoom: ZOOM_MAX,
+		// Disable inertia so the image stops immediately on release,
+		// allowing clampToBounds to take effect without being overridden
+		smoothScroll: false,
 		beforeMouseDown() {
 			return scale.value <= ZOOM_MIN
 		},
@@ -74,6 +77,9 @@ function initPanzoom() {
 			return
 		}
 		grabbing.value = true
+	})
+	instance.on('pan', () => {
+		clampToBounds()
 	})
 	instance.on('panend', () => {
 		grabbing.value = false

--- a/src/talk/renderer/Viewer/ViewerHandlerImages.vue
+++ b/src/talk/renderer/Viewer/ViewerHandlerImages.vue
@@ -41,7 +41,10 @@ function initPanzoom() {
 		minZoom: ZOOM_MIN,
 		maxZoom: ZOOM_MAX,
 		bounds: true,
-		boundsPadding: 0.1,
+		boundsPadding: 0,
+		beforeMouseDown() {
+			return scale.value <= ZOOM_MIN
+		},
 	})
 	instance.value.on('zoom', (pz) => {
 		const transform = pz.getTransform()
@@ -111,10 +114,11 @@ onBeforeUnmount(disposePanzoom)
 <template>
 	<ViewerHandlerMedia v-slot="{ handleLoadEnd }">
 		<div class="viewer-image-container" @dblclick.capture="onDoubleClick">
-			<div ref="wrapperRef" class="viewer-image-wrapper" :class="cursorClass">
+			<div ref="wrapperRef" class="viewer-image-wrapper">
 				<img
 					:key="src"
 					class="viewer-image"
+					:class="cursorClass"
 					:src="src"
 					:alt="file.basename"
 					@load="onImageLoad(handleLoadEnd)"

--- a/src/talk/renderer/Viewer/ViewerHandlerImages.vue
+++ b/src/talk/renderer/Viewer/ViewerHandlerImages.vue
@@ -6,6 +6,9 @@
 <script setup>
 import panzoom from 'panzoom'
 import { computed, onBeforeUnmount, ref, useTemplateRef, watch } from 'vue'
+import { translate as t } from '@nextcloud/l10n'
+import IconRotateLeft from 'vue-material-design-icons/RotateLeft.vue'
+import IconRotateRight from 'vue-material-design-icons/RotateRight.vue'
 import ViewerHandlerMedia from './ViewerHandlerMedia.vue'
 import { generateFilePreviewUrl } from './viewer.utils.ts'
 
@@ -18,6 +21,7 @@ const props = defineProps({
 const ZOOM_MIN = 1
 const ZOOM_MAX = 8
 const ZOOM_FACTOR = 3
+const ROTATION_STEP = 90
 
 const src = computed(() => generateFilePreviewUrl(props.file.fileid, props.file.etag))
 
@@ -25,6 +29,7 @@ const panzoomWrapperRef = useTemplateRef('panzoomWrapper')
 let instance = null
 const scale = ref(1)
 const grabbing = ref(false)
+const rotation = ref(0)
 
 const cursorClass = computed(() => {
 	if (scale.value === 1) {
@@ -129,7 +134,25 @@ function onDoubleClick(event) {
 	}
 }
 
-watch(src, disposePanzoom)
+function rotateLeft() {
+	rotation.value -= ROTATION_STEP
+}
+
+function rotateRight() {
+	rotation.value += ROTATION_STEP
+}
+
+const actions = computed(() => [
+	{ key: 'rotate-left', label: t('talk_desktop', 'Rotate left'), icon: IconRotateLeft, onClick: rotateLeft },
+	{ key: 'rotate-right', label: t('talk_desktop', 'Rotate right'), icon: IconRotateRight, onClick: rotateRight },
+])
+
+defineExpose({ actions })
+
+watch(src, () => {
+	disposePanzoom()
+	rotation.value = 0
+})
 
 onBeforeUnmount(disposePanzoom)
 </script>
@@ -143,6 +166,7 @@ onBeforeUnmount(disposePanzoom)
 					:key="src"
 					class="viewer-image"
 					:class="cursorClass"
+					:style="{ transform: `rotate(${rotation}deg)` }"
 					:src="src"
 					:alt="file.basename"
 					@load="onImageLoad(handleLoadEnd)"
@@ -170,6 +194,7 @@ onBeforeUnmount(disposePanzoom)
 .viewer-image {
 	max-width: 100%;
 	max-height: 100%;
+	transition: transform 0.3s ease;
 }
 
 .viewer-image--zoom-in {

--- a/src/talk/renderer/Viewer/ViewerHandlerImages.vue
+++ b/src/talk/renderer/Viewer/ViewerHandlerImages.vue
@@ -5,7 +5,7 @@
 
 <script setup>
 import panzoom from 'panzoom'
-import { computed, onBeforeUnmount, ref, watch } from 'vue'
+import { computed, onBeforeUnmount, ref, useTemplateRef, watch } from 'vue'
 import ViewerHandlerMedia from './ViewerHandlerMedia.vue'
 import { generateFilePreviewUrl } from './viewer.utils.ts'
 
@@ -21,8 +21,8 @@ const ZOOM_FACTOR = 3
 
 const src = computed(() => generateFilePreviewUrl(props.file.fileid, props.file.etag))
 
-const wrapperRef = ref(null)
-const instance = ref(null)
+const panzoomWrapperRef = useTemplateRef('panzoomWrapper')
+let instance = null
 const scale = ref(1)
 const grabbing = ref(false)
 
@@ -34,10 +34,7 @@ const cursorClass = computed(() => {
 })
 
 function initPanzoom() {
-	if (!wrapperRef.value) {
-		return
-	}
-	instance.value = panzoom(wrapperRef.value, {
+	instance = panzoom(panzoomWrapperRef.value, {
 		minZoom: ZOOM_MIN,
 		maxZoom: ZOOM_MAX,
 		bounds: true,
@@ -46,27 +43,27 @@ function initPanzoom() {
 			return scale.value <= ZOOM_MIN
 		},
 	})
-	instance.value.on('zoom', (pz) => {
+	instance.on('zoom', (pz) => {
 		const transform = pz.getTransform()
 		scale.value = transform.scale
 		if (transform.scale <= ZOOM_MIN) {
 			pz.smoothMoveTo(0, 0)
 		}
 	})
-	instance.value.on('panstart', (pz) => {
+	instance.on('panstart', (pz) => {
 		if (pz.getTransform().scale <= ZOOM_MIN) {
 			return
 		}
 		grabbing.value = true
 	})
-	instance.value.on('panend', () => {
+	instance.on('panend', () => {
 		grabbing.value = false
 	})
 }
 
 function disposePanzoom() {
-	instance.value?.dispose()
-	instance.value = null
+	instance?.dispose()
+	instance = null
 	scale.value = 1
 	grabbing.value = false
 }
@@ -91,7 +88,7 @@ function onImageError(handleLoadEnd) {
  * @param {MouseEvent} event - The double-click event
  */
 function onDoubleClick(event) {
-	if (!instance.value) {
+	if (!instance) {
 		return
 	}
 	event.preventDefault()
@@ -100,9 +97,9 @@ function onDoubleClick(event) {
 	const x = event.clientX - rect.left
 	const y = event.clientY - rect.top
 	if (scale.value === 1) {
-		instance.value.smoothZoom(x, y, ZOOM_FACTOR)
+		instance.smoothZoom(x, y, ZOOM_FACTOR)
 	} else {
-		instance.value.smoothZoomAbs(x, y, 0)
+		instance.smoothZoomAbs(x, y, 0)
 	}
 }
 
@@ -113,8 +110,9 @@ onBeforeUnmount(disposePanzoom)
 
 <template>
 	<ViewerHandlerMedia v-slot="{ handleLoadEnd }">
+		<!-- capture phase intercepts dblclick before panzoom's own handler; stopPropagation prevents the parent viewer from closing -->
 		<div class="viewer-image-container" @dblclick.capture="onDoubleClick">
-			<div ref="wrapperRef" class="viewer-image-wrapper">
+			<div ref="panzoomWrapper" class="viewer-image-wrapper">
 				<img
 					:key="src"
 					class="viewer-image"

--- a/src/talk/renderer/Viewer/ViewerHandlerImages.vue
+++ b/src/talk/renderer/Viewer/ViewerHandlerImages.vue
@@ -33,12 +33,29 @@ const cursorClass = computed(() => {
 	return grabbing.value ? 'viewer-image--grabbing' : 'viewer-image--grab'
 })
 
+function clampToBounds() {
+	if (!instance) return
+	const el = panzoomWrapperRef.value
+	const rect = el.getBoundingClientRect()
+	const parentRect = el.parentElement.getBoundingClientRect()
+	const { x, y } = instance.getTransform()
+
+	let newX = x
+	let newY = y
+	if (rect.left > parentRect.left) newX -= rect.left - parentRect.left
+	if (rect.right < parentRect.right) newX += parentRect.right - rect.right
+	if (rect.top > parentRect.top) newY -= rect.top - parentRect.top
+	if (rect.bottom < parentRect.bottom) newY += parentRect.bottom - rect.bottom
+
+	if (newX !== x || newY !== y) {
+		instance.smoothMoveTo(newX, newY)
+	}
+}
+
 function initPanzoom() {
 	instance = panzoom(panzoomWrapperRef.value, {
 		minZoom: ZOOM_MIN,
 		maxZoom: ZOOM_MAX,
-		bounds: true,
-		boundsPadding: 0,
 		beforeMouseDown() {
 			return scale.value <= ZOOM_MIN
 		},
@@ -48,6 +65,8 @@ function initPanzoom() {
 		scale.value = transform.scale
 		if (transform.scale <= ZOOM_MIN) {
 			pz.smoothMoveTo(0, 0)
+		} else {
+			clampToBounds()
 		}
 	})
 	instance.on('panstart', (pz) => {
@@ -58,6 +77,7 @@ function initPanzoom() {
 	})
 	instance.on('panend', () => {
 		grabbing.value = false
+		clampToBounds()
 	})
 }
 


### PR DESCRIPTION
## Summary

Adds zoom/pan and rotate controls to the image viewer in Talk Desktop.

### Zoom and pan

Installs [`panzoom`](https://github.com/anvaka/panzoom) (v9.4.4, 6 kB) — same library already used in spreed for screen share zoom ([spreed#14028](https://github.com/nextcloud/spreed/pull/14028)).

- Scroll wheel / trackpad pinch → zoom in/out (1× – 8×), centered on cursor
- Drag to pan when zoomed in
- Double-click to zoom in 3× at cursor position; double-click again to reset to 1×
- Auto-centers image when zoom returns to 1× (smooth animation)
- Panning blocked at minimum zoom to prevent accidental image shifts
- Cursor feedback: `zoom-in` at 1×, `grab` / `grabbing` when zoomed

Addresses the macOS limitation where pinch-to-zoom had no effect and Cmd+/- zoomed the entire application UI instead of the image.

Closes #1535

### Rotate

Adds rotate left (−90°) and rotate right (+90°) buttons to the actions menu.

- Rotation state and controls are fully self-contained in `ViewerHandlerImages`
- Unbounded angle increments ensure the CSS transition always animates in the correct direction
- Rotation resets when switching images
- `ViewerHandlerImages` exposes an `actions` array; `ViewerApp` renders it generically via `component :is` — no image-specific code leaks into the generic component

Closes #1757

## Architecture

Handler components can expose an `actions` array to contribute entries to the viewer's action menu without modifying `ViewerApp`. Each action is `{ key, label, icon, onClick }`. This keeps `ViewerApp` generic and all feature-specific logic inside the handler.

## Test plan

- [ ] Open an image in the viewer
- [ ] Scroll wheel / trackpad pinch zooms image centered on cursor
- [ ] Drag image while zoomed in — panning works, cursor shows grab/grabbing
- [ ] Double-click to zoom in 3×; double-click again to reset
- [ ] Open a second image — zoom/pan state resets
- [ ] Actions menu shows Rotate left, Rotate right, Open in web browser
- [ ] Rotate right repeatedly — image turns clockwise in 90° steps with smooth animation
- [ ] Rotate left repeatedly — counter-clockwise
- [ ] Mix left and right — always rotates in the correct direction
- [ ] Switch to another image — rotation resets to 0°
- [ ] Open a video in the viewer — rotate buttons are not shown
- [ ] Zoom in, then rotate — both transforms apply independently

Assisted-by: ClaudeCode:claude-sonnet-4-6