### PR TITLE
fix(linux/wayland): allow native title bar

### DIFF
--- a/src/app/AppConfig.ts
+++ b/src/app/AppConfig.ts
@@ -7,7 +7,7 @@ import { app, webContents } from 'electron'
 import { readFile, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import { readManagedConfig } from './managedConfig.service.ts'
-import { isMac, isWayland } from './system.utils.ts'
+import { isMac } from './system.utils.ts'
 
 const APP_CONFIG_FILE_NAME = 'config.json'
 
@@ -169,8 +169,7 @@ const managedAppConfig = readManagedConfig()
  * Overrides any config value if set, including user defined.
  */
 const forcedAppConfig: Partial<AppConfig> = Object.fromEntries(Object.entries({
-	// See: https://github.com/electron/electron/issues/49244
-	systemTitleBar: isWayland ? false : undefined,
+	// Nothing at the moment
 }).filter(([, value]) => value !== undefined))
 
 /** Local cache of the config file mixed with the default values */

--- a/src/talk/renderer/Settings/DesktopSettingsSection.vue
+++ b/src/talk/renderer/Settings/DesktopSettingsSection.vue
@@ -22,7 +22,6 @@ import { useAppConfigStore } from './appConfig.store.ts'
 import { useAppConfigValue } from './useAppConfigValue.ts'
 
 const isLinux = window.systemInfo.isLinux
-const isWayland = window.systemInfo.isWayland
 
 const { isRelaunchRequired } = storeToRefs(useAppConfigStore())
 
@@ -76,7 +75,7 @@ const secondarySpeakerDevice = useAppConfigValue('secondarySpeakerDevice')
 		<NcFormGroup :label="t('talk_desktop', 'Appearance')">
 			<NcFormBox>
 				<NcFormBoxSwitch v-model="monochromeTrayIcon" :label="t('talk_desktop', 'Use monochrome tray icon')" />
-				<NcFormBoxSwitch v-if="!isWayland" v-model="systemTitleBar" :label="t('talk_desktop', 'Use system title bar')" />
+				<NcFormBoxSwitch v-model="systemTitleBar" :label="t('talk_desktop', 'Use system title bar')" />
 			</NcFormBox>
 		</NcFormGroup>
 


### PR DESCRIPTION
### ☑️ Resolves

- Fix: https://github.com/nextcloud/talk-desktop/issues/1771
- Apparently, the issue comes from running the app via VS Code integrated terminal when installed via snap