### PR TITLE
build: allow build without TALK_PATH

### DIFF
--- a/build/resolveBuildConfig.js
+++ b/build/resolveBuildConfig.js
@@ -76,7 +76,7 @@ function resolveBuildConfig() {
  * Resolve path to the build-in Talk
  */
 function resolveTalkPath() {
-	return resolve(process.env.TALK_PATH) ?? resolve(__dirname, '../spreed')
+	return process.env.TALK_PATH ? resolve(process.env.TALK_PATH) : resolve(__dirname, '../spreed')
 }
 
 /**


### PR DESCRIPTION
### ☑️ Resolves

- Regression from: https://github.com/nextcloud/talk-desktop/pull/1743
- A typo preventing build without TALK_PATH
