### PR TITLE
fix(login): remove user prefilling due to critical login flow backend bug

### DIFF
--- a/src/authentication/login.window.js
+++ b/src/authentication/login.window.js
@@ -20,10 +20,9 @@ const genId = () => Math.random().toString(36).slice(2, 9)
  *
  * @param {import('electron').BrowserWindow} parentWindow - Parent window
  * @param {string} serverUrl - Server URL
- * @param {string} [user] - Preset User ID
  * @return {Promise<import('./login.service.js').Credentials|Error>}
  */
-function openLoginWebView(parentWindow, serverUrl, user) {
+function openLoginWebView(parentWindow, serverUrl) {
 	return new Promise((resolve) => {
 		const WIDTH = 750
 		const HEIGHT = 750
@@ -56,9 +55,7 @@ function openLoginWebView(parentWindow, serverUrl, user) {
 		})
 		window.removeMenu()
 
-		// Undocumented but widely used feature
-		const presetUserQuery = user ? `?user=${encodeURIComponent(user)}` : ''
-		window.loadURL(`${serverUrl}/index.php/login/flow${presetUserQuery}`, {
+		window.loadURL(`${serverUrl}/index.php/login/flow`, {
 			// User-Agent header is used as the app name, device and session
 			// On the login flow page and then on the Personal settings / Security / Devices & Sessions
 			// Format used by all the clients: {HostUsername} ({ApplicationName} - {OS})

--- a/src/authentication/renderer/AuthenticationApp.vue
+++ b/src/authentication/renderer/AuthenticationApp.vue
@@ -23,10 +23,7 @@ const version = __VERSION_TAG__
 
 // Pre-fill server url and the user with the last used one
 const prefilledAccount = getAppConfigValue('accounts')?.[0] ?? ''
-const atIndex = prefilledAccount.lastIndexOf('@')
-let [prefilledServer, prefilledUser] = atIndex === -1
-	? [prefilledAccount, '']
-	: [prefilledAccount.slice(atIndex + 1), prefilledAccount.slice(0, atIndex)]
+let prefilledServer = prefilledAccount.slice(prefilledAccount.lastIndexOf('@') + 1)
 
 const rawServerUrl = ref(BUILD_CONFIG.domain ?? prefilledServer)
 const enforceDomain = Boolean(BUILD_CONFIG.domain && BUILD_CONFIG.enforceDomain)
@@ -148,7 +145,7 @@ async function login() {
 	// Login with web view
 	let credentials
 	try {
-		const maybeCredentials = await window.TALK_DESKTOP.openLoginWebView(serverUrl.value, prefilledUser)
+		const maybeCredentials = await window.TALK_DESKTOP.openLoginWebView(serverUrl.value)
 		if (maybeCredentials instanceof Error) {
 			return setError(maybeCredentials.message)
 		}


### PR DESCRIPTION
### ☑️ Resolves

- Fix: https://github.com/nextcloud/talk-desktop/issues/1786
- Fix: https://github.com/nextcloud/talk-desktop/issues/1776
- Fix: https://github.com/nextcloud/talk-desktop/issues/1721
- Ref: https://github.com/nextcloud/server/issues/59874
- Presetting userid during the login flow completely brakes the flow if the userid contains `@`
- Fixing it from the client side isn't possible
- Removing the feature until the server bug is fixed and we can determine if using the feature is safe
