### PR TITLE
refactor: remove `@nextcloud/initial-state@2` usage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,6 @@
         "@nextcloud/browser-storage": "^0.5.0",
         "@nextcloud/event-bus": "^3.3.2",
         "@nextcloud/files": "^4.0.0",
-        "@nextcloud/initial-state": "^2.2.0",
         "@nextcloud/l10n": "^3.4.1",
         "@nextcloud/notify_push": "^1.4.0",
         "@nextcloud/router": "^3.1.0",
@@ -3729,15 +3728,6 @@
       },
       "engines": {
         "node": "^24.0.0"
-      }
-    },
-    "node_modules/@nextcloud/initial-state": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@nextcloud/initial-state/-/initial-state-2.2.0.tgz",
-      "integrity": "sha512-cDW98L5KGGgpS8pzd+05304/p80cyu8U2xSDQGa+kGPTpUFmCbv2qnO5WrwwGTauyjYijCal2bmw82VddSH+Pg==",
-      "engines": {
-        "node": "^20.0.0",
-        "npm": "^10.0.0"
       }
     },
     "node_modules/@nextcloud/l10n": {
@@ -21508,11 +21498,6 @@
         "typescript-event-target": "^1.1.2",
         "webdav": "^5.9.0"
       }
-    },
-    "@nextcloud/initial-state": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@nextcloud/initial-state/-/initial-state-2.2.0.tgz",
-      "integrity": "sha512-cDW98L5KGGgpS8pzd+05304/p80cyu8U2xSDQGa+kGPTpUFmCbv2qnO5WrwwGTauyjYijCal2bmw82VddSH+Pg=="
     },
     "@nextcloud/l10n": {
       "version": "3.4.1",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
     "@nextcloud/browser-storage": "^0.5.0",
     "@nextcloud/event-bus": "^3.3.2",
     "@nextcloud/files": "^4.0.0",
-    "@nextcloud/initial-state": "^2.2.0",
     "@nextcloud/l10n": "^3.4.1",
     "@nextcloud/notify_push": "^1.4.0",
     "@nextcloud/router": "^3.1.0",

--- a/src/callbox/renderer/callbox.utils.ts
+++ b/src/callbox/renderer/callbox.utils.ts
@@ -4,11 +4,12 @@
  */
 
 import type { HowlOptions } from 'howler'
+import type { UserStatusPrivate } from '../../talk/renderer/UserStatus/userStatus.types.ts'
 
-import { loadState } from '@nextcloud/initial-state'
 import { generateFilePath } from '@nextcloud/router'
 import { Howl } from 'howler'
 import { getAppConfigValue } from '../../shared/appConfig.service.ts'
+import { browserStorage } from '../../shared/browserStorage.service.ts'
 
 /**
  * Play ringtone
@@ -16,8 +17,14 @@ import { getAppConfigValue } from '../../shared/appConfig.service.ts'
  * @return function to stop ringing
  */
 export function playRingtone() {
-	if (!loadState('notifications', 'sound_talk')) {
-		return
+	const playSoundCall = getAppConfigValue('playSoundCall')
+	const userStatus = JSON.parse(browserStorage.getItem('userStatus') ?? 'null') as UserStatusPrivate | null
+	const shouldPlaySoundCall = playSoundCall === 'respect-dnd'
+		? userStatus?.status !== 'dnd'
+		: playSoundCall === 'always'
+
+	if (!shouldPlaySoundCall) {
+		return () => {}
 	}
 
 	const howlPayload: HowlOptions = {

--- a/src/shared/globals/globals.js
+++ b/src/shared/globals/globals.js
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import { loadState } from '@nextcloud/initial-state'
 import { translate, translatePlural } from '@nextcloud/l10n'
 import { appData } from '../../app/AppData.js'
 import { getDesktopMediaSource } from '../../talk/renderer/screensharing/screensharing.module.ts'
@@ -65,8 +64,9 @@ const OC = {
 	dialogs,
 
 	theme: {
+		// TODO: use Capabilities on spreed side
 		get productName() {
-			return loadState('theming', 'data').name
+			return appData.capabilities?.theming?.name
 		},
 	},
 

--- a/src/shared/setupWebPage.js
+++ b/src/shared/setupWebPage.js
@@ -218,7 +218,6 @@ function getInitialStateFromCapabilities(capabilities, userMetadata) {
 			shortcutsDisabled: false, // MISSED
 		},
 		notifications: {
-			throttled_push_notifications: false, // MISSED
 			sound_talk: true, // MISSED
 			sound_notification: true, // MISSED
 		},

--- a/src/shared/setupWebPage.js
+++ b/src/shared/setupWebPage.js
@@ -217,10 +217,6 @@ function getInitialStateFromCapabilities(capabilities, userMetadata) {
 			},
 			shortcutsDisabled: false, // MISSED
 		},
-		notifications: {
-			sound_talk: true, // MISSED
-			sound_notification: true, // MISSED
-		},
 		// user_status: {} - MISSED
 	}
 }

--- a/src/talk/renderer/Settings/appConfig.store.ts
+++ b/src/talk/renderer/Settings/appConfig.store.ts
@@ -7,10 +7,8 @@ import type { Ref } from 'vue'
 import type { AppConfig, AppConfigKey } from '../../../app/AppConfig.ts'
 
 import { defineStore } from 'pinia'
-import { readonly, ref, watch, watchEffect } from 'vue'
+import { readonly, ref, watch } from 'vue'
 import { getAppConfig } from '../../../shared/appConfig.service.ts'
-import { setInitialState } from '../../../shared/initialState.service.js'
-import { useUserStatusStore } from '../UserStatus/userStatus.store.ts'
 
 export const useAppConfigStore = defineStore('appConfig', () => {
 	const appConfig: Ref<AppConfig> = ref(getAppConfig())
@@ -28,18 +26,6 @@ export const useAppConfigStore = defineStore('appConfig', () => {
 			unwatchRelaunch()
 		},
 	)
-
-	const userStatusStore = useUserStatusStore()
-	watchEffect(() => {
-		const playSoundChat = appConfig.value.playSoundChat === 'respect-dnd'
-			? userStatusStore.userStatus?.status !== 'dnd'
-			: appConfig.value.playSoundChat === 'always'
-		const playSoundCall = appConfig.value.playSoundCall === 'respect-dnd'
-			? userStatusStore.userStatus?.status !== 'dnd'
-			: appConfig.value.playSoundCall === 'always'
-		setInitialState('notifications', 'sound_notification', playSoundChat)
-		setInitialState('notifications', 'sound_talk', playSoundCall)
-	})
 
 	/**
 	 * Get an application config value

--- a/src/talk/renderer/notifications/notifications.store.js
+++ b/src/talk/renderer/notifications/notifications.store.js
@@ -11,15 +11,16 @@
  */
 
 import { emit } from '@nextcloud/event-bus'
-import { loadState } from '@nextcloud/initial-state'
 import { t } from '@nextcloud/l10n'
 import { listen } from '@nextcloud/notify_push'
 import { generateFilePath } from '@nextcloud/router'
 import { Howl } from 'howler'
+import { computed } from 'vue'
 import { appData } from '../../../app/AppData.js'
 import { checkCurrentUserHasPendingCall } from '../../../callbox/renderer/callbox.service.ts'
 import { getAppConfigValue } from '../../../shared/appConfig.service.ts'
 import { subscribeBroadcast } from '../../../shared/broadcast.service.ts'
+import { useAppConfigValue } from '../Settings/useAppConfigValue.ts'
 import { openConversation } from '../TalkWrapper/talk.service.ts'
 import { useUserStatusStore } from '../UserStatus/userStatus.store.ts'
 import { getNotificationsData } from './notifications.service.js'
@@ -31,6 +32,10 @@ const isTestNotificationApp = (notificationApp) => ['admin_notification_talk', '
  */
 export function createNotificationStore() {
 	const userStatusStore = useUserStatusStore()
+	const playSoundChat = useAppConfigValue('playSoundChat')
+	const shouldPlaySoundChat = computed(() => playSoundChat.value === 'respect-dnd'
+		? userStatusStore.userStatus?.status !== 'dnd'
+		: playSoundChat.value === 'always')
 
 	let _oldcount = 0
 	let notificationsSet = new Set()
@@ -135,7 +140,7 @@ export function createNotificationStore() {
 	 *
 	 */
 	function playSound() {
-		if (!loadState('notifications', 'sound_notification')) {
+		if (!shouldPlaySoundChat.value) {
 			return
 		}
 

--- a/src/talk/renderer/notifications/notifications.store.js
+++ b/src/talk/renderer/notifications/notifications.store.js
@@ -40,7 +40,7 @@ export function createNotificationStore() {
 		backgroundFetching: false,
 		hasNotifyPush: false,
 		shutdown: false,
-		hasThrottledPushNotifications: loadState('notifications', 'throttled_push_notifications'),
+		hasThrottledPushNotifications: false, // TODO: Add notifications/throttled_push_notifications to Capabilities
 		notifications: [],
 		lastETag: null,
 		lastTabId: null,


### PR DESCRIPTION
### ☑️ Resolves

- Currently, the initial state is used only for `notifications` app settings (like in the original app)
- App **mutates** initial state on settings and user status change
- Mutating the initial state is not compatible with the latest `@nextcloud/initial-state` 
- Instead of sharing the state via initial state, computing it on the only place it is actually needed.

For testing:
1. Enable dev mode
2. Open any conversation
3. Use Show Call Popup and listen for the sound depending on settings and user status

<img width="403" height="352" alt="image" src="https://github.com/user-attachments/assets/ebf36073-2b9b-4fa4-bd81-079e81674366" />