### PR TITLE
feat(config): add managed configuration for Windows with `serverUrl` and `accounts` configs

### DIFF
--- a/forge.config.js
+++ b/forge.config.js
@@ -196,6 +196,11 @@ module.exports = {
 		},
 	},
 
+	rebuildConfig: {
+		// Do not rebuild any modules until explicitly specified
+		onlyModules: [],
+	},
+
 	// https://electron.github.io/packager/main/interfaces/Options.html
 	packagerConfig: {
 		// Common

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@nextcloud/notify_push": "^1.4.0",
         "@nextcloud/router": "^3.1.0",
         "@nextcloud/vue": "^9.8.2",
+        "@vscode/windows-registry": "github:nextcloud-deps/vscode-windows-registry#v1.2.0-prebuild",
         "@vueuse/core": "^14.3.0",
         "core-js": "^3.49.0",
         "electron-squirrel-startup": "^1.0.1",
@@ -5274,6 +5275,12 @@
       "resolved": "https://registry.npmjs.org/@vscode/sudo-prompt/-/sudo-prompt-9.3.2.tgz",
       "integrity": "sha512-gcXoCN00METUNFeQOFJ+C9xUI0DKB+0EGMVg7wbVYRHBw2Eq3fKisDZOkRdOz3kqXRKOENMfShPOmypw1/8nOw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vscode/windows-registry": {
+      "version": "1.2.0",
+      "resolved": "git+ssh://git@github.com/nextcloud-deps/vscode-windows-registry.git#9a7e835c937777ae55ccffe0b4af345d78d33914",
+      "hasInstallScript": true,
       "license": "MIT"
     },
     "node_modules/@vue-macros/common": {
@@ -22652,6 +22659,10 @@
       "resolved": "https://registry.npmjs.org/@vscode/sudo-prompt/-/sudo-prompt-9.3.2.tgz",
       "integrity": "sha512-gcXoCN00METUNFeQOFJ+C9xUI0DKB+0EGMVg7wbVYRHBw2Eq3fKisDZOkRdOz3kqXRKOENMfShPOmypw1/8nOw==",
       "dev": true
+    },
+    "@vscode/windows-registry": {
+      "version": "git+ssh://git@github.com/nextcloud-deps/vscode-windows-registry.git#9a7e835c937777ae55ccffe0b4af345d78d33914",
+      "from": "@vscode/windows-registry@github:nextcloud-deps/vscode-windows-registry#v1.2.0-prebuild"
     },
     "@vue-macros/common": {
       "version": "3.1.2",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "@nextcloud/notify_push": "^1.4.0",
     "@nextcloud/router": "^3.1.0",
     "@nextcloud/vue": "^9.8.2",
+    "@vscode/windows-registry": "github:nextcloud-deps/vscode-windows-registry#v1.2.0-prebuild",
     "@vueuse/core": "^14.3.0",
     "core-js": "^3.49.0",
     "electron-squirrel-startup": "^1.0.1",

--- a/src/app/AppConfig.ts
+++ b/src/app/AppConfig.ts
@@ -6,6 +6,7 @@
 import { app, webContents } from 'electron'
 import { readFile, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
+import { readManagedConfig } from './managedConfig.service.ts'
 import { isMac, isWayland } from './system.utils.ts'
 
 const APP_CONFIG_FILE_NAME = 'config.json'
@@ -139,7 +140,7 @@ export type AppConfig = {
 export type AppConfigKey = keyof AppConfig
 
 /**
- * Get the default config
+ * Default App Config
  */
 const defaultAppConfig: AppConfig = {
 	accounts: [],
@@ -158,7 +159,14 @@ const defaultAppConfig: AppConfig = {
 }
 
 /**
- * Forced App Config
+ * Admin-managed App Config.
+ * Overrides the default config if set.
+ */
+const managedAppConfig = readManagedConfig()
+
+/**
+ * Forced App Config.
+ * Overrides any config value if set, including user defined.
  */
 const forcedAppConfig: Partial<AppConfig> = Object.fromEntries(Object.entries({
 	// See: https://github.com/electron/electron/issues/49244
@@ -228,7 +236,19 @@ export function getAppConfig<T extends AppConfigKey>(key?: T): AppConfig | AppCo
 		throw new Error('The application config is not initialized yet')
 	}
 
-	const config = { ...defaultAppConfig, ...appConfig, ...forcedAppConfig }
+	const config = {
+		...defaultAppConfig,
+		...managedAppConfig,
+		...appConfig,
+		// Merge accounts arrays
+		// TODO: add config merge utility when there are more mergeable config values
+		accounts: [
+			...defaultAppConfig.accounts ?? [],
+			...managedAppConfig.accounts ?? [],
+			...appConfig.accounts ?? [],
+		],
+		...forcedAppConfig,
+	}
 
 	if (key) {
 		return config[key]

--- a/src/app/managedConfig.service.ts
+++ b/src/app/managedConfig.service.ts
@@ -1,0 +1,67 @@
+/*!
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { normalizeServerUrl, parseAccountId } from '../shared/accounts.utils.ts'
+import { BUILD_CONFIG } from '../shared/build.config.ts'
+import { isWindows } from './system.utils.ts'
+import { getWindowsRegistryItem } from './windows.utils.ts'
+
+type ManagedConfigKey = 'accounts' | 'serverUrl'
+
+/**
+ * Read managed application configuration:
+ * - Windows Registry Policies
+ * - macOS Managed Preferences (not implemented)
+ */
+export function readManagedConfig() {
+	const accounts = readManagedConfigValue('accounts')?.split(',')
+		// Parse to get normalized accountId
+		.map((account) => parseAccountId(account))
+		// Filter out invalid/empty value
+		.filter(Boolean)
+		// Keep only the accountId string
+		.map((account) => account.accountId) ?? []
+
+	// Fallback to simple serverUrl setting if accounts is not set
+	if (!accounts.length) {
+		const serverUrl = normalizeServerUrl(readManagedConfigValue('serverUrl'))
+		if (serverUrl) {
+			accounts.push(serverUrl)
+		}
+	}
+
+	return {
+		accounts,
+	}
+}
+
+/**
+ * Read environment managed configuration for the application:
+ * - Windows Registry Policies
+ * - macOS Managed Preferences (not implemented)
+ *
+ * @param key - Configuration key
+ */
+function readManagedConfigValue(key: ManagedConfigKey): string | undefined {
+	if (isWindows) {
+		return readWindowsManagedConfigValue(key)
+	}
+	// TODO: add macOS support
+	return undefined
+}
+
+/**
+ * Read managed configuration (policy) from Windows Registry in the following order:
+ * 1. HKEY_CURRENT_USER\Software\Policies\{vendor}\{applicationName}\{key}
+ * 2. HKEY_LOCAL_MACHINE\Software\Policies\{vendor}\{applicationName}\{key}
+ *
+ * @see https://learn.microsoft.com/en-us/previous-versions/windows/desktop/policy/implementing-registry-based-policy
+ * @see https://learn.microsoft.com/en-us/windows/client-management/understanding-admx-backed-policies
+ * @param key - Configuration key
+ */
+function readWindowsManagedConfigValue(key: ManagedConfigKey): string | undefined {
+	return getWindowsRegistryItem('HKEY_CURRENT_USER', `Software\\Policies\\${BUILD_CONFIG.companyName}\\${BUILD_CONFIG.applicationName}`, key)
+		?? getWindowsRegistryItem('HKEY_LOCAL_MACHINE', `Software\\Policies\\${BUILD_CONFIG.companyName}\\${BUILD_CONFIG.applicationName}`, key)
+}

--- a/src/app/windows.utils.ts
+++ b/src/app/windows.utils.ts
@@ -1,0 +1,38 @@
+/*!
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { createRequire } from 'node:module'
+
+export type HKEY = 'HKEY_CURRENT_USER' | 'HKEY_LOCAL_MACHINE' | 'HKEY_CLASSES_ROOT' | 'HKEY_USERS' | 'HKEY_CURRENT_CONFIG'
+
+/**
+ * Read Windows Registry item (only string values are supported)
+ *
+ * @param hive - Registry hive (e.g., HKEY_CURRENT_USER, HKEY_LOCAL_MACHINE)
+ * @param path - Registry path (e.g., Software\Policies\Nextcloud\Talk)
+ * @param name - Registry value name (e.g., accounts)
+ */
+export function getWindowsRegistryItem(hive: HKEY, path: string, name: string): string | undefined {
+	if (process.platform !== 'win32') {
+		throw new Error('getWindowsRegistryItem is only available on Windows')
+	}
+
+	if (process.arch !== 'x64') {
+		throw new Error('getWindowsRegistryItem is only available on x64')
+	}
+
+	try {
+		const require = createRequire(import.meta.url)
+		const windowRegistry = require('@vscode/windows-registry/prebuilds/win32-x64/@vscode+windows-registry.node')
+
+		return windowRegistry.GetStringRegKey(hive, path, name)
+	} catch (error) {
+		// 'Unable to open registry key' is expected when the registry key does not exist
+		if ((error as Error).message !== 'Unable to open registry key') {
+			console.error('Error getting Windows Registry item:', (error as Error).message)
+		}
+		return undefined
+	}
+}

--- a/src/authentication/renderer/AuthenticationApp.vue
+++ b/src/authentication/renderer/AuthenticationApp.vue
@@ -14,6 +14,7 @@ import AppWindow from '../../shared/components/AppWindow.vue'
 import { appData } from '../../app/AppData.js'
 import { refetchAppData } from '../../app/appData.service.js'
 import { MIN_REQUIRED_NEXTCLOUD_VERSION, MIN_REQUIRED_TALK_VERSION } from '../../constants.js'
+import { parseAccountId } from '../../shared/accounts.utils.ts'
 import { getAppConfigValue, setAppConfigValue } from '../../shared/appConfig.service.ts'
 import { BUILD_CONFIG } from '../../shared/build.config.ts'
 import { getCapabilities } from '../../shared/ocs.service.js'
@@ -21,9 +22,8 @@ import { getCapabilities } from '../../shared/ocs.service.js'
 const channel = __CHANNEL__
 const version = __VERSION_TAG__
 
-// Pre-fill server url and the user with the last used one
-const prefilledAccount = getAppConfigValue('accounts')?.[0] ?? ''
-let prefilledServer = prefilledAccount.slice(prefilledAccount.lastIndexOf('@') + 1)
+// Pre-fill server url with the last used one or set in the config
+const prefilledServer = parseAccountId(getAppConfigValue('accounts')?.[0])?.serverUrl
 
 const rawServerUrl = ref(BUILD_CONFIG.domain ?? prefilledServer)
 const enforceDomain = Boolean(BUILD_CONFIG.domain && BUILD_CONFIG.enforceDomain)

--- a/src/shared/accounts.utils.ts
+++ b/src/shared/accounts.utils.ts
@@ -1,0 +1,94 @@
+/*!
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { createUrl } from './utils.ts'
+
+export type AccountId = {
+	accountId: string
+	serverUrl: string
+	userId?: string
+}
+
+/**
+ * Normalize server URL by removing protocol, trailing slash and optional /index.php
+ *
+ * @param serverUrl - Server URL string, e.g. https://company.tld:4433/nextcloud/index.php?what
+ * @return Normalized server URL string, e.g. company.tld:4433/nextcloud or null if invalid or http://
+ */
+export function normalizeServerUrl(serverUrl?: string): string | null {
+	if (!serverUrl) {
+		return null
+	}
+
+	if (serverUrl.startsWith('http://')) {
+		return null
+	}
+
+	const url = createUrl(serverUrl.startsWith('https://') ? serverUrl : `https://${serverUrl}`)
+	if (!url) {
+		return null
+	}
+
+	const pathname = url.pathname
+		// Remove optional trailing /index.php
+		.replace(/\/index\.php$/, '')
+		// Remove trailing slash
+		.replace(/\/$/, '')
+
+	return url.host + pathname
+}
+
+/**
+ * Validate userid format according to OC\User\Manager::validateUserId
+ *
+ * @see https://github.com/nextcloud/server/blob/v34.0.0/lib/private/User/Manager.php#L717
+ * @param userId - User Id string
+ * @return Whether the userId is in a valid format
+ */
+export function isValidUserId(userId: string): boolean {
+	return /^[a-zA-Z0-9 _.@\-']{1,64}$/.test(userId)
+		&& userId === userId.trim()
+		&& userId !== '.'
+		&& userId !== '..'
+}
+
+/**
+ * Build accountId from serverUrl and optional userid
+ *
+ * @param serverUrl - Normalized server URL string
+ * @param userId - UserId
+ */
+export function buildAccountId(serverUrl: string, userId?: string): string {
+	return userId ? `${userId}@${serverUrl}` : serverUrl
+}
+
+/**
+ * Parse accountId into normalized serverUrl, optional userId
+ *
+ * @param accountId - Account Id string in the format of {user}@{server} or {server}
+ */
+export function parseAccountId(accountId?: string) {
+	if (!accountId) {
+		return null
+	}
+
+	const atIndex = accountId.lastIndexOf('@')
+	const serverUrl = normalizeServerUrl(accountId.slice(atIndex + 1))
+	const userId = atIndex !== -1 ? accountId.slice(0, atIndex) : undefined
+
+	if (!serverUrl) {
+		return null
+	}
+
+	if (userId !== undefined && !isValidUserId(userId)) {
+		return null
+	}
+
+	return {
+		accountId: buildAccountId(serverUrl, userId),
+		serverUrl,
+		userId,
+	}
+}

--- a/src/shared/utils.ts
+++ b/src/shared/utils.ts
@@ -26,3 +26,18 @@ export function once<F extends (() => any) | ((...args: any[]) => void)>(func: F
 }
 
 /* eslint-enable @typescript-eslint/no-explicit-any */
+
+/**
+ * Create a new URL object from a string but returning null instead of exception on invalid URL
+ *
+ * @param url - URL string
+ * @param base - Base URL string
+ * @return URL object or null if invalid
+ */
+export function createUrl(url: string, base?: string): URL | null {
+	try {
+		return new URL(url, base)
+	} catch {
+		return null
+	}
+}


### PR DESCRIPTION
## ☑️ Resolves

- Fix: https://github.com/nextcloud/talk-desktop/issues/1661
- https://github.com/nextcloud/talk-desktop/pull/1747
- Differences with the PR:
  - Using Windows API via prebuilt binary instead of `reg.exe` which might not be available in a strict corporate environment
  - Support `accounts` options as in CLI for future support of `userId` and multi-account
  - No `enforceServerUrl` since it reflects the build configuration rather than application config and not user-controlled
  - The value is used on the application config level, not on a UI request

### 1. Adding utils to read Windows Registry

- See https://github.com/nextcloud-deps/vscode-windows-registry/pull/1

### 2. Adding support for _managed configuration_

An admin-managed configuration overrides the default configuration and is defined by:

- Windows: Windows Registry Policy
- macOS: will be added later

### 3. Adding `accounts` and `serverUrl` managed configuration items

- `accounts`:
  - List in a format of `[userId@]serverUrl,[userId@]serverUrl`
  - Examples:
    - `nextcloud.local`
    - `user@nextcloud.local`
    - `alice@company.tld@company.tld/nextcloud,bob@home.tld@home.tld`
  - Used to predefine values during the login
  - `userId` will be supported when the server issue is fixed
    - https://github.com/nextcloud/talk-desktop/pull/1789
  - Multiple values will be supported when the multi-account feature is available
- `serverUrl`:
  - Simplified fallback for `accounts` with a single server URL

In both configs:
- Invalid items are ignored (invalid userId or serverURL)
- `http://` server URL is ignored
- values are normalized to have no protocol and trailing slash or `/index.php`

## How To test

1. Logout
2. Press <kbg>Win + R</kbd>
3. Run `regedit`
4. Create the following keys
   - `HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Nextcloud GmbH\Nextcloud Talk`
   - `HKEY_CURRENT_USER\SOFTWARE\Policies\Nextcloud GmbH\Nextcloud Talk` (overrides `HKEY_LOCAL_MACHINE`)
6. Create a new string value `accounts` or `serverUrl`
7. Start the app
8. Check prefilled URL in the login window

<img width="661" height="269" alt="image" src="https://github.com/user-attachments/assets/b0420cb6-f1f3-419f-b05f-6d1e81eabe4d" />
