### PR TITLE
build(scripts): only override styles on release if missing or outdated

### DIFF
--- a/build/resolveBuildConfig.js
+++ b/build/resolveBuildConfig.js
@@ -87,34 +87,77 @@ function getNextcloudVersionForTalk() {
 }
 
 /**
- * Get the path to Nextcloud styles with overrides
+ * Try to get the Nextcloud styles from a given directory
+ *
+ * @param {string} directory - Path to the styles directory, e.g. "resources/server-global-styles"
+ * @param {string} version - Nextcloud major version (e.g. 34)
+ * @return {{ path: string, meta: Record<string, unknown> } | null} - Styles path and meta data or null if not found
  */
-function resolveNextcloudStylesPath() {
+function tryGetNextcloudStyles(directory, version) {
+	try {
+		const stylesPath = join(directory, version.toString())
+		return {
+			path: stylesPath,
+			meta: JSON.parse(readFileSync(join(stylesPath, 'meta.json'), 'utf-8')),
+		}
+	} catch {
+		return null
+	}
+}
+
+/**
+ * Get available Nextcloud styles
+ *
+ * @param {string} version - Nextcloud major version (e.g. 34)
+ */
+function getNextcloudStyles(version = getNextcloudVersionForTalk()) {
 	const BUILD_CONFIG = resolveBuildConfig()
-	const version = getNextcloudVersionForTalk()
 
-	const nextcloudStylesOverridesPath = join(__dirname, `../.overrides/styles/${version}`)
-	const nextcloudStylesPath = join(__dirname, `../resources/server-global-styles/${version}`)
+	const base = tryGetNextcloudStyles(join(__dirname, '../resources/server-global-styles'), version)
+	const overrides = tryGetNextcloudStyles(join(__dirname, '../.overrides/styles'), version)
 
-	if (existsSync(nextcloudStylesOverridesPath)) {
-		return nextcloudStylesOverridesPath
+	if (!base) {
+		throw new Error(`Nextcloud ${version} is not supported: no styles found`)
 	}
 
-	if (BUILD_CONFIG.withThemingOverrides) {
-		throw new Error(`Build Config has custom theming, but no styles overrides found for Nextcloud ${version}.
-			If you are testing build locally, run "node scripts/override-nextcloud-styles.mjs --version ${version}".`)
+	return {
+		base,
+		overrides,
+		overridesRequired: BUILD_CONFIG.withThemingOverrides,
+		overridesUpToDate: overrides
+			// Same styles version
+			&& overrides.meta.versionCommitHash === base.meta.versionCommitHash
+			// On the same theming configuration
+			&& overrides.meta.themingConfigs[0].primaryColor === BUILD_CONFIG.primaryColor
+			&& overrides.meta.themingConfigs[0].backgroundColor === BUILD_CONFIG.backgroundColor,
+	}
+}
+
+/**
+ * Resolve path to the currently used Nextcloud styles
+ *
+ * @param {string} version - Nextcloud major version (e.g. 34)
+ */
+function resolveNextcloudStylesPath(version = getNextcloudVersionForTalk()) {
+	const styles = getNextcloudStyles(version)
+
+	if (!styles.overrides && styles.overridesRequired) {
+		throw new Error(`Nextcloud ${version} styles overrides are missing. `
+			+ `If you are testing the build locally, run "node scripts/override-nextcloud-styles.mjs --version ${version}".`)
 	}
 
-	if (existsSync(nextcloudStylesPath)) {
-		return nextcloudStylesPath
+	if (styles.overrides && !styles.overridesUpToDate) {
+		throw new Error(`Nextcloud ${version} styles overrides are not up-to-date with the current styles version or the build configuration. `
+			+ `If you are testing the build locally, run "node scripts/override-nextcloud-styles.mjs --version ${version}".`)
 	}
 
-	throw new Error(`No styles found for Nextcloud ${version}. This version is not supported.`)
+	return styles.overrides?.path ?? styles.base.path
 }
 
 module.exports = {
 	resolveBuildConfig,
 	resolveTalkPath,
 	getNextcloudVersionForTalk,
+	getNextcloudStyles,
 	resolveNextcloudStylesPath,
 }

--- a/scripts/override-nextcloud-styles.mjs
+++ b/scripts/override-nextcloud-styles.mjs
@@ -3,10 +3,8 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import { resolve } from 'node:path'
 import { argv, echo } from 'zx'
-import { getNextcloudVersionForTalk, resolveBuildConfig } from '../build/resolveBuildConfig.js'
-import { extractNextcloudStyles } from './nextcloud-app-host/extractNextcloudStyles.mjs'
+import { overrideNextcloudStyles } from './overrideNextcloudStyles.commands.mjs'
 
 if (argv.help) {
 	echo`Override Nextcloud styles with the current build config
@@ -17,7 +15,6 @@ if (argv.help) {
 	Arguments:
 		--version <nextcloud-version-major> - major version of Nextcloud to override styles for (e.g. "34"), default: the current built-in Talk's Nextcloud version
 		--help - show help
-		--port <number> - port to expose the Nextcloud server on, default: 6123
 		--keep - keep the Docker container after styles extraction (useful for debugging and multiple runs)
 		--verbose - show verbose output
 
@@ -28,28 +25,8 @@ if (argv.help) {
 	process.exit(0)
 }
 
-const BUILD_CONFIG = resolveBuildConfig()
-
-if (!BUILD_CONFIG.withThemingOverrides) {
-	echo('Theming override is not needed for the current build config')
-	process.exit(0)
-}
-
-const version = argv.version || getNextcloudVersionForTalk()
-
-const meta = await import(`../resources/server-global-styles/${version}/meta.js`)
-
-await extractNextcloudStyles({
-	dest: resolve(import.meta.dirname, '../.overrides/styles'),
-	[meta.versionRefType]: meta.versionRef,
-	themingConfigs: [
-		{
-			name: '',
-			primaryColor: BUILD_CONFIG.primaryColor,
-			backgroundColor: BUILD_CONFIG.backgroundColor,
-		},
-	],
-	port: argv.port,
-	keep: !!argv.keep,
-	verbose: !!argv.verbose,
+await overrideNextcloudStyles({
+	version: argv.version,
+	keep: argv.keep,
+	verbose: argv.verbose,
 })

--- a/scripts/overrideNextcloudStyles.commands.mjs
+++ b/scripts/overrideNextcloudStyles.commands.mjs
@@ -4,8 +4,8 @@
  */
 
 import { resolve } from 'node:path'
-import { echo } from 'zx'
-import { getNextcloudVersionForTalk, resolveBuildConfig } from '../build/resolveBuildConfig.js'
+import { chalk, echo } from 'zx'
+import { getNextcloudStyles, getNextcloudVersionForTalk, resolveBuildConfig } from '../build/resolveBuildConfig.js'
 import { extractNextcloudStyles } from './nextcloud-app-host/extractNextcloudStyles.mjs'
 
 /**
@@ -18,17 +18,21 @@ import { extractNextcloudStyles } from './nextcloud-app-host/extractNextcloudSty
  */
 export async function overrideNextcloudStyles({ version = getNextcloudVersionForTalk(), keep = false, verbose = false } = {}) {
 	const BUILD_CONFIG = resolveBuildConfig()
+	const styles = getNextcloudStyles(version)
 
-	if (!BUILD_CONFIG.withThemingOverrides) {
-		echo('Theming override is not needed for the current build config')
-		process.exit(0)
+	if (!styles.overridesRequired) {
+		echo(chalk.gray('No styles overrides required: build config does not modify the default theming configurations'))
+		return
 	}
 
-	const meta = await import(`../resources/server-global-styles/${version}/meta.js`)
+	if (styles.overridesUpToDate) {
+		echo(chalk.gray('No styles overrides required: already up-to-date'))
+		return
+	}
 
 	await extractNextcloudStyles({
 		dest: resolve(import.meta.dirname, '../.overrides/styles'),
-		[meta.versionRefType]: meta.versionRef,
+		[styles.base.meta.versionRefType]: styles.base.meta.versionRef,
 		themingConfigs: [
 			{
 				name: '',

--- a/scripts/overrideNextcloudStyles.commands.mjs
+++ b/scripts/overrideNextcloudStyles.commands.mjs
@@ -1,0 +1,42 @@
+/*!
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { resolve } from 'node:path'
+import { echo } from 'zx'
+import { getNextcloudVersionForTalk, resolveBuildConfig } from '../build/resolveBuildConfig.js'
+import { extractNextcloudStyles } from './nextcloud-app-host/extractNextcloudStyles.mjs'
+
+/**
+ * Override Nextcloud styles with the current build config, if needed
+ *
+ * @param {object} options - Options
+ * @param {string} options.version - Nextcloud major version (e.g. "34")
+ * @param {boolean} options.keep - Whether to keep the Docker container after styles extraction
+ * @param {boolean} options.verbose - Whether to show verbose output
+ */
+export async function overrideNextcloudStyles({ version = getNextcloudVersionForTalk(), keep = false, verbose = false } = {}) {
+	const BUILD_CONFIG = resolveBuildConfig()
+
+	if (!BUILD_CONFIG.withThemingOverrides) {
+		echo('Theming override is not needed for the current build config')
+		process.exit(0)
+	}
+
+	const meta = await import(`../resources/server-global-styles/${version}/meta.js`)
+
+	await extractNextcloudStyles({
+		dest: resolve(import.meta.dirname, '../.overrides/styles'),
+		[meta.versionRefType]: meta.versionRef,
+		themingConfigs: [
+			{
+				name: '',
+				primaryColor: BUILD_CONFIG.primaryColor,
+				backgroundColor: BUILD_CONFIG.backgroundColor,
+			},
+		],
+		keep,
+		verbose,
+	})
+}

--- a/scripts/prepare-release-packages.mjs
+++ b/scripts/prepare-release-packages.mjs
@@ -7,6 +7,7 @@
 
 import { resolveBuildConfig } from '../build/resolveBuildConfig.js'
 const packageJson = require('../package.json')
+import { overrideNextcloudStyles } from './overrideNextcloudStyles.commands.mjs'
 
 const TALK_PATH = './out/.temp/spreed/'
 const talkDotGit = `${TALK_PATH}.git`
@@ -123,7 +124,7 @@ async function prepareRelease() {
 	const BUILD_CONFIG = resolveBuildConfig()
 	if (BUILD_CONFIG.withThemingOverrides) {
 		await spinner('[4.3/5] Overriding Nextcloud theming', async () => {
-			await $`node ./scripts/override-nextcloud-styles.mjs`
+			await overrideNextcloudStyles({ verbose: true })
 		})
 	}
 

--- a/scripts/prepare-release-packages.mjs
+++ b/scripts/prepare-release-packages.mjs
@@ -5,7 +5,6 @@
 
 /// <reference types="zx" />
 
-import { resolveBuildConfig } from '../build/resolveBuildConfig.js'
 const packageJson = require('../package.json')
 import { overrideNextcloudStyles } from './overrideNextcloudStyles.commands.mjs'
 
@@ -120,13 +119,10 @@ async function prepareRelease() {
 	$.env.TALK_PATH = TALK_PATH
 	$.env.CHANNEL = CHANNEL
 
-	// Theming overrides
-	const BUILD_CONFIG = resolveBuildConfig()
-	if (BUILD_CONFIG.withThemingOverrides) {
-		await spinner('[4.3/5] Overriding Nextcloud theming', async () => {
-			await overrideNextcloudStyles({ verbose: true })
-		})
-	}
+	// Styles override
+	await spinner('[4.3/5] Overriding Nextcloud styles', async () => {
+		await overrideNextcloudStyles({ verbose: true })
+	})
 
 	// Build and package
 	echo`[5/5] Packaging...`


### PR DESCRIPTION
### ☑️ Resolves

- `build(server-styles): check if overrides are up-to-date`
  - When overrides are required, they must be on the same styles version and on the current build config's theming
- `refactor(scripts): split override-nextcloud-styles into CLI and function`
  - To call a function from CLI instead of one CLI from another CLI
- `build(override-nextcloud-styles): only override if missing or outdated`
  - If overridden styles are up-to-date, no need to extract them again, including on release
