### PR TITLE
build(macos): fix packaging `.dmg` on macOS on Node,js 24+ by manually updating `nan` from 2.22.0 to 2.28.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13910,10 +13910,11 @@
       }
     },
     "node_modules/nan": {
-      "version": "2.22.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.22.0.tgz",
-      "integrity": "sha512-nbajikzWTMwsW+eSsNm3QwlOs7het9gGJU5dDZzRTQGk03vyBOauxgI4VakDzE0PtsGTmXPsXTbbjVhRwR5mpw==",
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.28.0.tgz",
+      "integrity": "sha512-fTsDz99OTq2sVePhGdp4qQhggZFtKr64ZNVyVajRKtMOkJxYekplBh577PiJB12v/D3s2E5cGtOI45LWp6rnLQ==",
       "dev": true,
+      "license": "MIT",
       "optional": true
     },
     "node_modules/nanoid": {
@@ -28483,9 +28484,9 @@
       "dev": true
     },
     "nan": {
-      "version": "2.22.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.22.0.tgz",
-      "integrity": "sha512-nbajikzWTMwsW+eSsNm3QwlOs7het9gGJU5dDZzRTQGk03vyBOauxgI4VakDzE0PtsGTmXPsXTbbjVhRwR5mpw==",
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.28.0.tgz",
+      "integrity": "sha512-fTsDz99OTq2sVePhGdp4qQhggZFtKr64ZNVyVajRKtMOkJxYekplBh577PiJB12v/D3s2E5cGtOI45LWp6rnLQ==",
       "dev": true,
       "optional": true
     },


### PR DESCRIPTION
### ☑️ Resolves

- `build(deps-dev): update nan 2.22.0 -> 2.28.0 in the lock file`
- `nan` is a transitive dependency used during macOS `.dmg` packaging
  - `nan -> macos-alias -> appdmg -> electron-installed-dmg -> @electron-forge/maker-dmg`
- v2.22.0 is not compatible with Node.js 23+
  - We are using Node 24
- It crashes during the build if it was installed on 22 but used on 24
- It is not installed on 24 at all (because this is an optional macOS-only dependency, it's just skipped)
- Bumping `nan` in the lock file allows installing and build from source these dependencies on Node 24
