### PR TITLE
build(prepare-release-package): regression preventing run without npm ci

### DIFF
--- a/scripts/prepare-release-packages.mjs
+++ b/scripts/prepare-release-packages.mjs
@@ -6,7 +6,6 @@
 /// <reference types="zx" />
 
 const packageJson = require('../package.json')
-import { overrideNextcloudStyles } from './overrideNextcloudStyles.commands.mjs'
 
 const TALK_PATH = './out/.temp/spreed/'
 const talkDotGit = `${TALK_PATH}.git`
@@ -121,6 +120,7 @@ async function prepareRelease() {
 
 	// Styles override
 	await spinner('[4.3/5] Overriding Nextcloud styles', async () => {
+		const { overrideNextcloudStyles } = await import('./overrideNextcloudStyles.commands.mjs')
 		await overrideNextcloudStyles({ verbose: true })
 	})
 


### PR DESCRIPTION
### ☑️ Resolves

- A small regression from: https://github.com/nextcloud/talk-desktop/pull/1799
- With static import the script doesn't work anymore even via `zx` without `npm ci`
- With dynamic import we can run the function after the script has installed dependencies
