### PR TITLE
chore(package): prepare for npm@12

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+# We need "root" for github:nextcloud-deps/vscode-windows-registry
+# Current @electron-forge/* 7 uses old @electron/rebuild@7 which requires node
+# Allowing git only for a specific package is not supported
+# electron/node-gyp#06b29aafb7708acef8b3669835c8a7857ebc92d2 added to package.json explicitly to be in the root
+allow-git=root

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,7 @@
         "@electron-forge/maker-wix": "^7.11.1",
         "@electron-forge/maker-zip": "^7.11.1",
         "@electron-forge/plugin-webpack": "^7.11.1",
+        "@electron/node-gyp": "github:electron/node-gyp#06b29aafb7708acef8b3669835c8a7857ebc92d2",
         "@nextcloud/eslint-config": "^9.0.0",
         "@total-typescript/ts-reset": "^0.6.1",
         "@types/howler": "^2.2.13",
@@ -19981,7 +19982,7 @@
       "version": "git+ssh://git@github.com/electron/node-gyp.git#06b29aafb7708acef8b3669835c8a7857ebc92d2",
       "integrity": "sha512-4MSBTT8y07YUDqf69/vSh80Hh791epYqGtWHO3zSKhYFwQg+gx9wi1PqbqP6YqC4WMsNxZ5l9oDmnWdK5pfCKQ==",
       "dev": true,
-      "from": "@electron/node-gyp@git+https://github.com/electron/node-gyp.git#06b29aafb7708acef8b3669835c8a7857ebc92d2",
+      "from": "@electron/node-gyp@github:electron/node-gyp#06b29aafb7708acef8b3669835c8a7857ebc92d2",
       "requires": {
         "env-paths": "^2.2.0",
         "exponential-backoff": "^3.1.1",

--- a/package.json
+++ b/package.json
@@ -108,6 +108,14 @@
     "node": "^24.0.0",
     "npm": "^11.3.0"
   },
+  "allowScripts": {
+    "github:nextcloud-deps/vscode-windows-registry": true,
+    "core-js": true,
+    "electron": true,
+    "electron-winstaller": true,
+    "esbuild": true,
+    "sharp": true
+  },
   "desktopName": "com.nextcloud.talk.desktop",
   "productName": "Nextcloud Talk",
   "talk": {

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "@electron-forge/maker-wix": "^7.11.1",
     "@electron-forge/maker-zip": "^7.11.1",
     "@electron-forge/plugin-webpack": "^7.11.1",
+    "@electron/node-gyp": "github:electron/node-gyp#06b29aafb7708acef8b3669835c8a7857ebc92d2",
     "@nextcloud/eslint-config": "^9.0.0",
     "@total-typescript/ts-reset": "^0.6.1",
     "@types/howler": "^2.2.13",


### PR DESCRIPTION
### ☑️ Resolves

- See also: https://github.blog/changelog/2026-06-09-upcoming-breaking-changes-for-npm-v12/
- Added via `npm approve-scripts <pkg> <pkg>`
  - All the dependencies are well-known and widely used => added without version pinning
  - If they weren't well known, they should have been pinned with a specific version
- Added `.npmrc` with `allow-git=root`
  - This is tricky – it has only `none`, `all` and `root` values
  - We use `github:nextcloud-deps/vscode-windows-registry` - expected
  - `@electron-forge/*` use outdated `@electron/rebuild@7` which uses a specific `@electron/node-gyp` commit
    - Temporary adding it as a root dependency
    - To be removed after migrating to `@electron-forge/*@8` or removing electron forge

