### PR TITLE
fix(windows): make Windows ARM64 build start and package correctly

### DIFF
--- a/src/app/windows.utils.ts
+++ b/src/app/windows.utils.ts
@@ -19,14 +19,20 @@ export function getWindowsRegistryItem(hive: HKEY, path: string, name: string): 
 		throw new Error('getWindowsRegistryItem is only available on Windows')
 	}
 
-	if (process.arch !== 'x64') {
-		throw new Error('getWindowsRegistryItem is only available on x64')
+	if (process.arch !== 'x64' && process.arch !== 'arm64') {
+		throw new Error('getWindowsRegistryItem is only available on x64 and arm64')
+	}
+
+	let windowRegistry
+	try {
+		const require = createRequire(import.meta.url)
+		windowRegistry = require(`@vscode/windows-registry/prebuilds/win32-${process.arch}/@vscode+windows-registry.node`)
+	} catch {
+		console.error('Error loading @vscode/windows-registry')
+		return undefined
 	}
 
 	try {
-		const require = createRequire(import.meta.url)
-		const windowRegistry = require('@vscode/windows-registry/prebuilds/win32-x64/@vscode+windows-registry.node')
-
 		return windowRegistry.GetStringRegKey(hive, path, name)
 	} catch (error) {
 		// 'Unable to open registry key' is expected when the registry key does not exist


### PR DESCRIPTION
## Summary

One fixes needed for a working win32-arm64 build/release, on top of the packaging groundwork
from #1725:

1. **App crashes immediately on launch on arm64.** `getWindowsRegistryItem()`
   (`src/app/windows.utils.ts`) threw unconditionally on any non-x64 architecture, before ever
   attempting to load the native `@vscode/windows-registry` module. Since
   `readManagedConfig()` (`src/app/managedConfig.service.ts`) is called at module scope in
   `AppConfig.ts`, i.e. on every app start, this throw is never caught: Error: getWindowsRegistryItem is only available on x64


## Changes

- Resolve the native Registry module path per `process.arch` instead of a hardcoded
  `win32-x64` path; treat a missing prebuild for the current architecture as a recoverable
  error (return `undefined`) instead of throwing.


## Testing

- Applied and verified both patches against a fresh clone of `main` (`git am`, no conflicts).
- Verified `windows.utils.ts` change with esbuild (syntax/bundle check).

## Related

- #1725 (Windows ARM64 packaging support)