### PR TITLE
chore(deps): make vscode-windows-registry an optional dependency (win32)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@nextcloud/notify_push": "^1.4.0",
         "@nextcloud/router": "^3.1.0",
         "@nextcloud/vue": "^9.8.2",
-        "@vscode/windows-registry": "github:nextcloud-deps/vscode-windows-registry#v1.2.0-prebuild",
+        "@vscode/windows-registry": "github:nextcloud-deps/vscode-windows-registry#v1.2.0-prebuild.2",
         "@vueuse/core": "^14.3.0",
         "core-js": "^3.49.0",
         "electron-squirrel-startup": "^1.0.1",
@@ -71,6 +71,9 @@
       "engines": {
         "node": "^24.0.0",
         "npm": "^11.3.0"
+      },
+      "optionalDependencies": {
+        "@vscode/windows-registry": "github:nextcloud-deps/vscode-windows-registry#v1.2.0-prebuild.2"
       }
     },
     "node_modules/@babel/generator": {
@@ -5280,9 +5283,13 @@
     },
     "node_modules/@vscode/windows-registry": {
       "version": "1.2.0",
-      "resolved": "git+ssh://git@github.com/nextcloud-deps/vscode-windows-registry.git#9a7e835c937777ae55ccffe0b4af345d78d33914",
+      "resolved": "git+ssh://git@github.com/nextcloud-deps/vscode-windows-registry.git#b9f30116590cabd4caeb7e86801afea172dc04b5",
       "hasInstallScript": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@vue-macros/common": {
       "version": "3.1.2",
@@ -22663,8 +22670,9 @@
       "dev": true
     },
     "@vscode/windows-registry": {
-      "version": "git+ssh://git@github.com/nextcloud-deps/vscode-windows-registry.git#9a7e835c937777ae55ccffe0b4af345d78d33914",
-      "from": "@vscode/windows-registry@github:nextcloud-deps/vscode-windows-registry#v1.2.0-prebuild"
+      "version": "git+ssh://git@github.com/nextcloud-deps/vscode-windows-registry.git#b9f30116590cabd4caeb7e86801afea172dc04b5",
+      "from": "@vscode/windows-registry@github:nextcloud-deps/vscode-windows-registry#v1.2.0-prebuild.2",
+      "optional": true
     },
     "@vue-macros/common": {
       "version": "3.1.2",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
     "@nextcloud/notify_push": "^1.4.0",
     "@nextcloud/router": "^3.1.0",
     "@nextcloud/vue": "^9.8.2",
-    "@vscode/windows-registry": "github:nextcloud-deps/vscode-windows-registry#v1.2.0-prebuild",
     "@vueuse/core": "^14.3.0",
     "core-js": "^3.49.0",
     "electron-squirrel-startup": "^1.0.1",
@@ -104,6 +103,9 @@
     "webpack-merge": "^6.0.1",
     "worker-loader": "^3.0.8",
     "zx": "^8.8.5"
+  },
+  "optionalDependencies": {
+    "@vscode/windows-registry": "github:nextcloud-deps/vscode-windows-registry#v1.2.0-prebuild.2"
   },
   "engines": {
     "node": "^24.0.0",


### PR DESCRIPTION
### ☑️ Resolves

- Using changes from: https://github.com/nextcloud-deps/vscode-windows-registry/pull/2
- Now the package will only be installed on Windows
  - No more trying to rebuild Windows Registry binary on macOS and Linux