### PR TITLE
fix: partially invalid l10n init may crash app load on some languages

### DIFF
--- a/src/shared/setupWebPage.js
+++ b/src/shared/setupWebPage.js
@@ -4,7 +4,7 @@
  */
 
 import axios from '@nextcloud/axios'
-import { isRTL, register } from '@nextcloud/l10n'
+import { isRTL, register, setLanguage, setLocale } from '@nextcloud/l10n'
 import { appData } from '../app/AppData.js'
 import { refetchAppData } from '../app/appData.service.js'
 import { TITLE_BAR_HEIGHT } from '../constants.js'
@@ -61,8 +61,8 @@ async function applyL10n() {
 
 	const canonicalLanguage = language.replaceAll('_', '-')
 
-	document.documentElement.lang = canonicalLanguage
-	document.documentElement.dataset.locale = locale
+	setLanguage(canonicalLanguage)
+	setLocale(locale)
 
 	console.info(`Using locale "${locale}" for language "${language}"`)
 


### PR DESCRIPTION
### ☑️ Resolves

- Fix: https://github.com/nextcloud/talk-desktop/issues/1811

Setting lang via `document` at this point is too late.

The current `nextcloud-l10n` version caches the value on the module init.
During the init without the value in the `document`, it falls back to the system language.
Then `document` isn't used when the value is already cached.

As a result, translations are loaded correctly, but `nextcloud-l10n/getLanguage` returns another language. For plural translation it results in an error because the plural form has a different number of translations (for example, 1 for Japanese, 2 for English)

Init on the library side is already fixed but not released:
- https://github.com/nextcloud-libraries/nextcloud-l10n/pull/996

`set*` functions override the cached value together with the `document` set.

Alternative could be setting `document` properties before importing `@nextcloud/l10n`, but it is riskier for a so widely used library.

### 🖼️ Screenshots

<img width="1402" height="901" alt="image" src="https://github.com/user-attachments/assets/ee3a74db-1829-43c9-b546-2dd39cd429e7" />
