### PR TITLE
release: v2.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@
 
 # Changelog
 
+## v2.2.2 - 2026-07-29
+
+### Fixes
+
+- App crashes on some languages [#1813](https://github.com/nextcloud/talk-desktop/pull/1813)
+- Linux/Wayland: allow switching back to the native title bar via app settings [#1773](https://github.com/nextcloud/talk-desktop/pull/1773)
+
+### Changes
+
+- Built-in Talk in binaries is updated to v24.0.3 in both beta and stable release channels [#1834](https://github.com/nextcloud/talk-desktop/pull/1834)
+
+
 ## v2.2.1 - 2026-07-09
 
 ### Features

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "talk-desktop",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "talk-desktop",
-      "version": "2.2.1",
+      "version": "2.2.2",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@mdi/svg": "^7.4.47",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "talk-desktop",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "private": true,
   "bugs": {
     "url": "https://github.com/nextcloud/talk-desktop/issues",


### PR DESCRIPTION
## v2.2.2 - 2026-07-29

### Fixes

- App crashes on some languages [#1813](https://github.com/nextcloud/talk-desktop/pull/1813)
- Linux/Wayland: allow switching back to the native title bar via app settings [#1773](https://github.com/nextcloud/talk-desktop/pull/1773)

### Changes

- Built-in Talk in binaries is updated to v24.0.3 in both beta and stable release channels [#1834](https://github.com/nextcloud/talk-desktop/pull/1834)