### PR TITLE
chore(release): v2.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@
 
 # Changelog
 
+## v2.2.3 - 2026-07-30
+
+### Fixes
+
+- Reply quotes and file previews are visually broken [#1837](https://github.com/nextcloud/talk-desktop/pull/1837)
+
 ## v2.2.2 - 2026-07-29
 
 ### Fixes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "talk-desktop",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "talk-desktop",
-      "version": "2.2.2",
+      "version": "2.2.3",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@mdi/svg": "^7.4.47",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "talk-desktop",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "private": true,
   "bugs": {
     "url": "https://github.com/nextcloud/talk-desktop/issues",


### PR DESCRIPTION
## v2.2.3 - 2026-07-30

### Fixes

- Reply quotes and file previews are visually broken [#1837](https://github.com/nextcloud/talk-desktop/pull/1837)