### PR TITLE
fix(build): no audio/video on e2ee call

### DIFF
--- a/webpack.renderer.config.js
+++ b/webpack.renderer.config.js
@@ -173,17 +173,6 @@ const webpackRendererConfig = {
 				},
 			},
 			{
-				test: /\.worker\.js$/,
-				use: {
-					loader: 'worker-loader',
-					options: {
-						// Some workers load .wasm resources by relative path, ignoring the bundler
-						// So workers and wasm must be in the same directory
-						filename: 'talk_desktop__dist/assets/[name].js?v=[contenthash]',
-					},
-				},
-			},
-			{
 				test: /\.ogg$/,
 				type: 'asset/resource',
 			},


### PR DESCRIPTION
### ☑️ Resolves

- Fix: #1850
	- Should be a regression from RSPack migration
	- E2EE worker is now loaded with native webpack5 syntax: `new Worker(<path>, import.meta.url)) - but it expects worker to sit on a path relative to E2EE js module
	- Webpack rule `(test: /\.worker\.js$/)` matched this file and put it through worker-loader, so output path is `talk_desktop__dist/assets/[name].js?v=[contenthash]`
	- At runtime, webpack native resolution looked for the file at relative path, not in assets, and couldn't find it there.
	- Result: e2ee worker never starts.

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
B | A
<img width="883" height="601" alt="2026-08-07_12h35_01" src="https://github.com/user-attachments/assets/6e24e1e7-a076-482f-b2f1-91c8ad826e98" /> | <img width="908" height="605" alt="2026-08-07_12h34_15" src="https://github.com/user-attachments/assets/cb5165e4-9aaa-40b3-aa03-7f75a0e90a36" />