### PR TITLE
build: update built-in Talk versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -127,8 +127,8 @@
   "desktopName": "com.nextcloud.talk.desktop",
   "productName": "Nextcloud Talk",
   "talk": {
-    "stable": "v24.0.3",
-    "beta": "v24.0.3",
+    "stable": "v24.0.4",
+    "beta": "v25.0.0-alpha.1",
     "dev": "main"
   }
 }


### PR DESCRIPTION
## Update Built-in Talk Version

Stable:
- Current: v24.0.3
- Latest: v24.0.4

Beta:
- Current: v24.0.3
- Latest: v25.0.0-alpha.1

Updating stable from v24.0.3 to v24.0.4
Updating beta from v24.0.3 to v25.0.0-alpha.1