### PR TITLE
fix: include webp as 'asset/inline' for webpack

### DIFF
--- a/webpack.renderer.config.js
+++ b/webpack.renderer.config.js
@@ -115,7 +115,7 @@ const webpackRendererConfig = {
 				loader: 'vue-loader',
 			},
 			{
-				test: /\.(png|jpe?g|gif|svg|woff2?|eot|ttf)$/,
+				test: /\.(png|jpe?g|gif|webp|svg|woff2?|eot|ttf)$/,
 				type: 'asset/inline',
 			},
 			// Talk specific rules


### PR DESCRIPTION
### ☑️ Resolves

- images were added as a new asset type with dashboard redesign

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
<img width="502" height="166" alt="image" src="https://github.com/user-attachments/assets/c7c1d460-b34b-4956-a0af-404294de385c" /> | <img width="1139" height="426" alt="image" src="https://github.com/user-attachments/assets/8ef03469-50a3-413b-aa38-e81f9fa7bae2" />
