### PR TITLE
chore(release): v2.3.0-beta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@
 
 # Changelog
 
+## v2.3.0-beta - 2026-08-26
+
+### Fixes
+
+- Linux: tray icon is missing [#1864](https://github.com/nextcloud/talk-desktop/pull/1864)
+
+### Changes
+
+- Built-in Talk in binaries is updated to v25.0.0-rc.1 in the beta release channel [#1873](https://github.com/nextcloud/talk-desktop/pull/1873)
+
 ## v2.2.4 - 2026-08-14
 
 ### Changes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "talk-desktop",
-  "version": "2.2.4",
+  "version": "2.3.0-beta",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "talk-desktop",
-      "version": "2.2.4",
+      "version": "2.3.0-beta",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@mdi/svg": "^7.4.47",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "talk-desktop",
-  "version": "2.2.4",
+  "version": "2.3.0-beta",
   "private": true,
   "bugs": {
     "url": "https://github.com/nextcloud/talk-desktop/issues",


### PR DESCRIPTION
## v2.3.0-beta - 2026-08-26

### Fixes

- Linux: tray icon is missing [#1864](https://github.com/nextcloud/talk-desktop/pull/1864)

### Changes

- Built-in Talk in binaries is updated to v25.0.0-rc.1 in the beta release channel [#1873](https://github.com/nextcloud/talk-desktop/pull/1873)