### PR TITLE
fix(window): apply the ready-to-show fallback on all platforms

### DIFF
--- a/src/app/utils.ts
+++ b/src/app/utils.ts
@@ -10,7 +10,6 @@ import { APP_ORIGIN } from '../constants.js'
 import { BUILD_CONFIG } from '../shared/build.config.ts'
 import { getAppConfig } from './AppConfig.ts'
 import { appData } from './AppData.js'
-import { isWayland } from './system.utils.ts'
 
 /**
  * Get the scaled window size based on the current zoom factor
@@ -179,16 +178,29 @@ export function getTitleBarSymbolColor(backgroundColor: string = BUILD_CONFIG.ba
  * @param callback - Callback
  */
 export function onReadyToShow(window: BrowserWindow, callback: () => void) {
-	if (!isWayland) {
-		window.once('ready-to-show', callback)
-		return
-	}
-
-	// 'ready-to-show' may not be triggered on Wayland due to GPU sync issues in Chromium on some GPUs and VMware
-	// A workaround: wait for the page load and then for a tick
+	// 'ready-to-show' may never be emitted when the GPU process fails to initialize
+	// (seen with some GPUs and VMware on Wayland, but not tied to the platform as such),
+	// which would leave the window hidden forever.
+	// Race it against "page loaded + a tick", which is late enough not to show a blank window.
 	// See: https://github.com/electron/electron/issues/48859
-	window.webContents.once('did-finish-load', async () => {
-		await window.webContents.executeJavaScript('new Promise((resolve) => setTimeout(resolve, 0))')
+	const readyToShow = new Promise<string>((resolve) => {
+		window.once('ready-to-show', () => resolve('ready-to-show'))
+	})
+	const pageLoaded = new Promise<string>((resolve) => {
+		window.webContents.once('did-finish-load', () => {
+			window.webContents.executeJavaScript('new Promise((resolve) => setTimeout(resolve, 0))')
+				.catch(() => {}) // The window may be gone already
+				.then(() => resolve('did-finish-load'))
+		})
+	})
+
+	Promise.race([readyToShow, pageLoaded]).then((winner) => {
+		if (window.isDestroyed()) {
+			return
+		}
+		if (winner !== 'ready-to-show') {
+			console.warn('[window] "ready-to-show" was not emitted, showing the window after the page load')
+		}
 		callback()
 	})
 }


### PR DESCRIPTION
### ☑️ Resolves

- Fix: #1882
- Possibly related: #1156

`ready-to-show` is not only unreliable on Wayland. We hit exactly the same symptom on Windows after moving our branded build from v2.1.1 to v2.2.4: the splash screen stays forever because the main window never gets `ready-to-show`. v2.2.4 comes with Electron 43; under Wine, where the GPU process exits right after start, the same thing happens and the added log line confirms `ready-to-show` never fires, which points to the same GPU-related cause as electron/electron#48859.

This applies the existing `did-finish-load` fallback on all platforms instead of Wayland only, and adds a 15 s hard timeout so a window can never stay hidden forever. On platforms where `ready-to-show` works nothing changes: it still wins the race, the timers are cleared. On Wayland the behaviour is the same as before (fallback runs right after `did-finish-load`); elsewhere the fallback waits 1.5 s after load to avoid showing an unpainted window in the normal case.

`did-fail-load` is treated as "show now" as well, so a failed load ends up visible instead of an invisible window.

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
Splash screen stays forever on affected Windows machines | Main window is shown ~1.5 s after the page has loaded
