### PR TITLE
fix(authentication): login fails with UTF-8 characters in username from an external identity provider

### DIFF
--- a/src/app/webRequestInterceptor.js
+++ b/src/app/webRequestInterceptor.js
@@ -27,7 +27,9 @@ function enableWebRequestInterceptor(serverUrl, { credentials } = {}) {
 				requestHeaders: {
 					...details.requestHeaders,
 					Origin: new URL(serverUrl).origin,
-					Authorization: `Basic ${btoa(`${credentials.user}:${credentials.password}`)}`,
+					// btoa() only handles Latin-1: it throws on characters like ş or ı and encodes ü/ö as Latin-1,
+					// while the server decodes the header as UTF-8 - see #1360
+					Authorization: `Basic ${Buffer.from(`${credentials.user}:${credentials.password}`, 'utf8').toString('base64')}`,
 					'OCS-APIRequest': 'true',
 				},
 			})


### PR DESCRIPTION
### ☑️ Resolves

- Fix: #1360

`webRequestInterceptor.js` builds the `Authorization: Basic …` header with `btoa()`, which only handles Latin-1. For a login name with characters outside of Latin-1 (Turkish `ş`, `ı`, `ç`, Cyrillic, …) it throws `InvalidCharacterError`, and for Latin-1 characters such as `ü`/`ö` it produces Latin-1 bytes while the server decodes the header as UTF-8. Either way the first authenticated request after the login flow fails with 401, which is exactly the "Login successful, but something went wrong" reported in #1360 (LDAP login names with umlauts).

This encodes the credentials with `Buffer.from(..., 'utf8')` instead. Quick check in Node:

```
btoa('müller:pw')            -> "bfxsbGVyOnB3"  (decodes to "m\xFCller", not UTF-8)
btoa('şükrü:pw')             -> InvalidCharacterError
Buffer.from('şükrü:pw', 'utf8').toString('base64') -> works, server reads "şükrü"
```

No behaviour change for ASCII user names (same output as before).

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
Login with `müller` / `şükrü` ends in 401 after the login flow | Login works
