### PR TITLE
build: update built-in Talk versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
   "productName": "Nextcloud Talk",
   "talk": {
     "stable": "v24.0.4",
-    "beta": "v25.0.0-rc.1",
+    "beta": "v25.0.0-rc.2",
     "dev": "main"
   }
 }


### PR DESCRIPTION
## Update Built-in Talk Version

Stable:
- Current: v24.0.4
- Latest: v24.0.4

Beta:
- Current: v25.0.0-rc.1
- Latest: v25.0.0-rc.2

Updating beta from v25.0.0-rc.1 to v25.0.0-rc.2