### PR TITLE
build(deps): bump electron from ~43.2.0 to 44.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,7 @@
         "cheerio": "^1.2.0",
         "css-loader": "^7.1.4",
         "dotenv": "^17.4.2",
-        "electron": "~43.2.0",
+        "electron": "^44.2.0",
         "esbuild-loader": "^4.5.0",
         "eslint": "^10.9.0",
         "globals": "^17.11.0",
@@ -7207,9 +7207,9 @@
       "dev": true
     },
     "node_modules/electron": {
-      "version": "43.2.0",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-43.2.0.tgz",
-      "integrity": "sha512-80zvrgG7ZRXD+tD0IyLvrnN9n+veSxadMRsMaC9wKKP3iUbtC7rGM8+dVuCmOb0Rrwwv8ESW4awnUZh9Hbp1fA==",
+      "version": "44.2.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-44.2.0.tgz",
+      "integrity": "sha512-oK1icjhapp3xsUZycO9WZaLmd3hJnA7ieobC4mpdtO1pEN+PPGWpA3m1Mgzzuc1wzSD2Wai4zcH4yfpGJqxFMA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "cheerio": "^1.2.0",
     "css-loader": "^7.1.4",
     "dotenv": "^17.4.2",
-    "electron": "~43.2.0",
+    "electron": "^44.2.0",
     "esbuild-loader": "^4.5.0",
     "eslint": "^10.9.0",
     "globals": "^17.11.0",


### PR DESCRIPTION
### ☑️ Resolves

- The Electron issue preventing updates has been fixed
  - https://github.com/electron/electron/issues/52674
- New feature allows a simple implementation for
  - https://github.com/nextcloud/talk-desktop/pull/1857
- Breaking changes are not relevant
- Also closes: https://github.com/nextcloud/talk-desktop/pull/1878

Tested on Windows and Linux